### PR TITLE
feat: add stripPrefix route option for dynamic path rewriting

### DIFF
--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -243,15 +243,18 @@ No database. No Redis. No Docker. Just a single binary.
 
 The example config (`examples/gateway.yaml`) sets up:
 
-| Route | Path | Policy | Description |
-|-------|------|--------|-------------|
-| health | `/health` | Built-in | Always available |
-| public-demo | `/public/*` | `public` | No auth required |
-| protected-demo | `/protected/*` | `capability` | Requires valid Macaroon |
-| api-micro | `/api/micro` | `l402` (1 sat) | Lightning micropayment |
-| api-basic | `/api/basic` | `l402` (10 sats) | Lightning payment |
-| api-standard | `/api/standard` | `l402` (100 sats) | Lightning payment |
-| api-premium | `/api/premium` | `l402` (1000 sats) | Lightning payment |
+| Route | Path | Policy | Strip Prefix | Description |
+|-------|------|--------|:---:|-------------|
+| health | `/health` | Built-in | — | Always available |
+| public-demo | `/public/*` | `public` | ✓ | No auth required |
+| protected-demo | `/protected/*` | `capability` | ✓ | Requires valid Macaroon |
+| premium-demo | `/premium/*` | `l402` (100 sats) | ✓ | Lightning payment |
+| api-micro | `/api/micro` | `l402` (1 sat) | — | Lightning micropayment |
+| api-basic | `/api/basic` | `l402` (10 sats) | — | Lightning payment |
+| api-standard | `/api/standard` | `l402` (100 sats) | — | Lightning payment |
+| api-premium | `/api/premium` | `l402` (1000 sats) | — | Lightning payment |
+
+> **Tip:** `stripPrefix: true` removes the matched path prefix before proxying. So `/public/get` → upstream receives `/get`. Use `rewrite` for static path replacement instead.
 
 ---
 

--- a/examples/gateway.yaml
+++ b/examples/gateway.yaml
@@ -95,10 +95,12 @@ routes:
   # =====================================================
 
   # Public route - no authentication required
+  # stripPrefix removes /public before proxying, so /public/get → httpbin.org/get
   - name: public-demo
     match:
       pathPrefix: /public
     upstream: httpbin
+    stripPrefix: true
     policy:
       kind: public
 
@@ -107,6 +109,7 @@ routes:
     match:
       pathPrefix: /protected
     upstream: httpbin
+    stripPrefix: true
     policy:
       kind: capability
       scope: "api:read"
@@ -116,6 +119,7 @@ routes:
     match:
       pathPrefix: /premium
     upstream: httpbin
+    stripPrefix: true
     policy:
       kind: l402
       priceSats: 100

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -502,13 +502,14 @@ type CircuitBreaker struct {
 
 // Route defines how requests are matched and handled
 type Route struct {
-	Name      string      `yaml:"name"`
-	Match     RouteMatch  `yaml:"match"`
-	Upstream  string      `yaml:"upstream"`
-	Rewrite   string      `yaml:"rewrite,omitempty"` // Rewrite path before proxying
-	Policy    RoutePolicy `yaml:"policy"`
-	Transform *Transform  `yaml:"transform,omitempty"`
-	RateLimit *RateLimit  `yaml:"rateLimit,omitempty"`
+	Name        string      `yaml:"name"`
+	Match       RouteMatch  `yaml:"match"`
+	Upstream    string      `yaml:"upstream"`
+	Rewrite     string      `yaml:"rewrite,omitempty"`     // Rewrite path before proxying (static)
+	StripPrefix bool        `yaml:"stripPrefix,omitempty"` // Strip the matched pathPrefix before proxying
+	Policy      RoutePolicy `yaml:"policy"`
+	Transform   *Transform  `yaml:"transform,omitempty"`
+	RateLimit   *RateLimit  `yaml:"rateLimit,omitempty"`
 }
 
 // RouteMatch defines matching criteria

--- a/pkg/proxy/proxy_oss.go
+++ b/pkg/proxy/proxy_oss.go
@@ -497,10 +497,22 @@ func (g *Gateway) proxyRequest(w http.ResponseWriter, r *http.Request, route *co
 		return
 	}
 
-	// Apply path rewrite if configured
+	// Apply path rewrite if configured (static rewrite takes precedence)
 	if route.Rewrite != "" {
 		r.URL.Path = route.Rewrite
 		r.URL.RawPath = route.Rewrite
+	} else if route.StripPrefix && route.Match.PathPrefix != "" {
+		// Strip the matched prefix from the path before proxying
+		prefix := route.Match.PathPrefix
+		if strings.HasSuffix(prefix, "*") {
+			prefix = strings.TrimSuffix(prefix, "*")
+		}
+		newPath := strings.TrimPrefix(r.URL.Path, prefix)
+		if !strings.HasPrefix(newPath, "/") {
+			newPath = "/" + newPath
+		}
+		r.URL.Path = newPath
+		r.URL.RawPath = newPath
 	}
 
 	// Forward request


### PR DESCRIPTION
## Problem

Routes with `pathPrefix` matching forward the **full request path** to the upstream. For example:

```
/public/get → httpbin.org/public/get → 404 ❌
/protected/headers → httpbin.org/protected/headers → 404 ❌
```

The existing `rewrite` field only supports static replacement (good for single endpoints like `/api/micro → /anything/micro`), but doesn't work for wildcard prefix routes where the suffix varies.

The enterprise onboarding wizard has the same issue — user-configured routes with `pathPrefix` would forward the full path to their upstream APIs.

## Solution

New `stripPrefix: true` option on routes. When enabled, the matched `pathPrefix` is removed before proxying:

```yaml
- name: public-demo
  match:
    pathPrefix: /public
  upstream: httpbin
  stripPrefix: true    # /public/get → upstream receives /get ✅
  policy:
    kind: public
```

### Precedence
- `rewrite` (static) takes precedence over `stripPrefix` if both are set
- `stripPrefix` only applies when a `pathPrefix` match is configured
- Stripped paths always start with `/` (no bare paths)

## Changes

| File | Change |
|---|---|
| `pkg/config/config.go` | Added `StripPrefix bool` field to Route struct |
| `pkg/proxy/proxy_oss.go` | Prefix stripping logic in `proxyRequest` |
| `examples/gateway.yaml` | Updated public/protected/premium routes |
| `docs/getting-started/quickstart.md` | Added stripPrefix column + tip |

## Testing

Verified end-to-end with httpbin.org:
- `/public/get` → httpbin receives `/get` ✅
- `/public/headers` → httpbin receives `/headers` ✅
- `/protected/get` (with token) → httpbin receives `/get` ✅
- `/protected/headers` (with token) → httpbin receives `/headers` ✅
- Existing `rewrite` routes (L402 demos) unaffected ✅
- All unit tests pass ✅