### PR TITLE
feat: /govern and /design-partners pages for enterprise GTM

### DIFF
--- a/satgate-landing/app/design-partners/page.tsx
+++ b/satgate-landing/app/design-partners/page.tsx
@@ -1,0 +1,490 @@
+'use client';
+
+import React, { useState } from 'react';
+import {
+  ArrowRight, CheckCircle, Clock, Eye, MessageSquare, Headphones,
+  Server, Calendar, BarChart3, Shield, ChevronDown, ChevronUp,
+  Zap, Users, Code, Menu, X, Send, Building2, UserCheck
+} from 'lucide-react';
+import Link from 'next/link';
+import Image from 'next/image';
+
+export default function DesignPartnersPage() {
+  const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
+  const [openFaq, setOpenFaq] = useState<number | null>(null);
+  const [formData, setFormData] = useState({
+    name: '',
+    email: '',
+    company: '',
+    role: '',
+    agentCount: '',
+    apis: [] as string[],
+    challenge: '',
+  });
+
+  const toggleFaq = (idx: number) => {
+    setOpenFaq(openFaq === idx ? null : idx);
+  };
+
+  const handleApiToggle = (api: string) => {
+    setFormData(prev => ({
+      ...prev,
+      apis: prev.apis.includes(api) ? prev.apis.filter(a => a !== api) : [...prev.apis, api],
+    }));
+  };
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    const subject = encodeURIComponent('Design Partner Application');
+    const body = encodeURIComponent(
+      `Name: ${formData.name}\nEmail: ${formData.email}\nCompany: ${formData.company}\nRole: ${formData.role}\nAI Agents: ${formData.agentCount}\nAPIs: ${formData.apis.join(', ')}\n\nBiggest Challenge:\n${formData.challenge}`
+    );
+    window.location.href = `mailto:contact@satgate.io?subject=${subject}&body=${body}`;
+  };
+
+  const faqs = [
+    { q: 'How long is the program?', a: '90 days. After that, you keep everything you built and get priority access to GA pricing.' },
+    { q: 'Is it really free?', a: 'Yes. Observe mode is completely free—no credit card, no commitment. You get full visibility into your AI agent traffic at zero cost.' },
+    { q: 'Do I need to change my code?', a: 'No. One DNS change points your AI agent traffic through SatGate. Zero code modifications. Takes about 5 minutes.' },
+    { q: 'Where does my data go?', a: 'Your infrastructure in hybrid mode. The SatGate gateway runs in your VPC. We never see your API payloads or sensitive data.' },
+    { q: 'Is this production-ready?', a: 'Yes. 60+ dashboard pages, full deployment options (Docker, K8s, Terraform, SaaS), and a battle-tested Go binary with zero dependencies.' },
+  ];
+
+  return (
+    <div className="min-h-screen bg-black text-gray-100 font-sans selection:bg-purple-500 selection:text-white">
+
+      {/* Navigation */}
+      <nav className="border-b border-gray-800 backdrop-blur-md fixed w-full z-50 bg-black/50">
+        <div className="max-w-6xl mx-auto px-4 sm:px-6 h-16 flex items-center justify-between">
+          <Link href="/" className="flex items-center gap-2 shrink-0">
+            <Image src="/logo_white_transparent.png" alt="SatGate" width={32} height={32} className="w-7 h-7 sm:w-8 sm:h-8" />
+            <span className="text-lg sm:text-xl font-bold text-white whitespace-nowrap">SatGate<sup className="text-xs font-normal">™</sup></span>
+          </Link>
+
+          <div className="hidden md:flex gap-6 text-sm font-medium text-gray-400">
+            <Link href="/protect" className="hover:text-white transition">Protect Demo</Link>
+            <Link href="/pay" className="hover:text-white transition">Pay Demo</Link>
+            <Link href="/govern" className="hover:text-white transition">Govern</Link>
+            <Link href="#" className="hover:text-white transition">Pricing</Link>
+            <a href="https://github.com/SatGate-io/satgate" target="_blank" rel="noopener noreferrer" className="hover:text-white transition">Docs</a>
+            <a href="https://cloud.satgate.io" target="_blank" rel="noopener noreferrer" className="hover:text-white transition">Cloud</a>
+          </div>
+
+          <button
+            onClick={() => setMobileMenuOpen(!mobileMenuOpen)}
+            className="flex md:hidden items-center justify-center w-10 h-10 rounded-lg bg-gray-800/50 hover:bg-gray-700/50 text-gray-400 hover:text-white transition"
+            aria-label="Toggle menu"
+            aria-expanded={mobileMenuOpen}
+          >
+            {mobileMenuOpen ? <X size={20} /> : <Menu size={20} />}
+          </button>
+        </div>
+
+        <div className={`md:hidden overflow-hidden transition-all duration-300 ease-in-out ${mobileMenuOpen ? 'max-h-96 opacity-100' : 'max-h-0 opacity-0'}`}>
+          <div className="bg-black/95 backdrop-blur-xl border-t border-gray-800 px-4 py-4 space-y-1">
+            {[
+              { href: '/protect', label: 'Protect Demo' },
+              { href: '/pay', label: 'Pay Demo' },
+              { href: '/govern', label: 'Govern' },
+              { href: '#', label: 'Pricing' },
+            ].map(item => (
+              <Link key={item.href} href={item.href} onClick={() => setMobileMenuOpen(false)} className="block text-gray-400 hover:text-white hover:bg-gray-800/50 transition py-3 px-4 rounded-lg">
+                {item.label}
+              </Link>
+            ))}
+            <a href="https://github.com/SatGate-io/satgate" target="_blank" rel="noopener noreferrer" onClick={() => setMobileMenuOpen(false)} className="block text-gray-400 hover:text-white hover:bg-gray-800/50 transition py-3 px-4 rounded-lg">
+              Docs
+            </a>
+            <a href="https://cloud.satgate.io" target="_blank" rel="noopener noreferrer" onClick={() => setMobileMenuOpen(false)} className="block text-gray-400 hover:text-white hover:bg-gray-800/50 transition py-3 px-4 rounded-lg">
+              Cloud
+            </a>
+          </div>
+        </div>
+      </nav>
+
+      {/* Hero Section */}
+      <header className="pt-32 pb-20 px-6">
+        <div className="max-w-4xl mx-auto text-center">
+          <div className="inline-flex items-center gap-2 px-3 py-1 rounded-full bg-cyan-900/30 border border-cyan-500/30 text-cyan-300 text-xs font-mono mb-6">
+            <Users size={12} /> Limited to 10 Companies
+          </div>
+          <h1 className="text-5xl md:text-6xl font-extrabold tracking-tight mb-6">
+            Shape the Future of{' '}
+            <span className="text-transparent bg-clip-text bg-gradient-to-r from-cyan-400 via-purple-400 to-pink-400">
+              AI Agent Governance
+            </span>
+          </h1>
+          <p className="text-xl text-gray-400 mb-10 max-w-2xl mx-auto leading-relaxed">
+            We're working with <strong className="text-white">10 enterprises</strong> to build the economic firewall
+            for the agent economy. Get free access, direct engineering support, and a product shaped by your needs.
+          </p>
+          <a href="#apply" className="inline-flex items-center gap-2 bg-white text-black px-8 py-3 rounded-lg font-bold hover:bg-gray-200 transition">
+            Apply Now <ArrowRight size={18} />
+          </a>
+        </div>
+      </header>
+
+      {/* What You Get */}
+      <section className="py-20 px-6 border-t border-gray-800">
+        <div className="max-w-5xl mx-auto">
+          <h2 className="text-3xl font-bold text-center mb-4">What You Get</h2>
+          <p className="text-gray-500 text-center mb-12">Everything you need to evaluate SatGate. No strings attached.</p>
+
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+            <div className="p-6 rounded-xl bg-gradient-to-br from-purple-950/30 to-purple-900/10 border border-purple-800/30 hover:border-purple-600/50 transition group">
+              <div className="flex items-center gap-3 mb-4">
+                <div className="p-2.5 bg-purple-900/50 rounded-lg group-hover:bg-purple-900/70 transition">
+                  <Eye className="text-purple-400" size={22} />
+                </div>
+                <h3 className="font-bold text-lg">Free Observe Mode</h3>
+              </div>
+              <p className="text-gray-400 text-sm leading-relaxed">
+                Full visibility into your AI agent traffic on your staging environment. See every API call, every token, every cost—completely free.
+              </p>
+            </div>
+
+            <div className="p-6 rounded-xl bg-gradient-to-br from-cyan-950/30 to-cyan-900/10 border border-cyan-800/30 hover:border-cyan-600/50 transition group">
+              <div className="flex items-center gap-3 mb-4">
+                <div className="p-2.5 bg-cyan-900/50 rounded-lg group-hover:bg-cyan-900/70 transition">
+                  <Headphones className="text-cyan-400" size={22} />
+                </div>
+                <h3 className="font-bold text-lg">Direct Engineering Access</h3>
+              </div>
+              <p className="text-gray-400 text-sm leading-relaxed">
+                Shared Slack channel with our engineering team. Priority bug fixes, feature requests, and architecture guidance tailored to your stack.
+              </p>
+            </div>
+
+            <div className="p-6 rounded-xl bg-gradient-to-br from-green-950/30 to-green-900/10 border border-green-800/30 hover:border-green-600/50 transition group">
+              <div className="flex items-center gap-3 mb-4">
+                <div className="p-2.5 bg-green-900/50 rounded-lg group-hover:bg-green-900/70 transition">
+                  <MessageSquare className="text-green-400" size={22} />
+                </div>
+                <h3 className="font-bold text-lg">Your Feedback Shapes Product</h3>
+              </div>
+              <p className="text-gray-400 text-sm leading-relaxed">
+                Design partners get direct influence on the roadmap. The dashboards, alerts, and governance features you need—built with your input.
+              </p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* What We Need */}
+      <section className="py-20 px-6 border-t border-gray-800 bg-gradient-to-b from-gray-900/30 to-black">
+        <div className="max-w-5xl mx-auto">
+          <h2 className="text-3xl font-bold text-center mb-4">What We Need</h2>
+          <p className="text-gray-500 text-center mb-12">A small commitment. A big impact.</p>
+
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+            <div className="p-6 rounded-xl bg-gray-900 border border-gray-800 hover:border-gray-600 transition">
+              <div className="flex items-center gap-3 mb-4">
+                <div className="p-2.5 bg-gray-800 rounded-lg">
+                  <Server className="text-gray-300" size={22} />
+                </div>
+                <h3 className="font-bold text-lg">A Staging Endpoint</h3>
+              </div>
+              <p className="text-gray-400 text-sm leading-relaxed">
+                Point one staging API endpoint through SatGate. One DNS change, no code modifications.
+              </p>
+            </div>
+
+            <div className="p-6 rounded-xl bg-gray-900 border border-gray-800 hover:border-gray-600 transition">
+              <div className="flex items-center gap-3 mb-4">
+                <div className="p-2.5 bg-gray-800 rounded-lg">
+                  <Clock className="text-gray-300" size={22} />
+                </div>
+                <h3 className="font-bold text-lg">15 Minutes / Week</h3>
+              </div>
+              <p className="text-gray-400 text-sm leading-relaxed">
+                A quick sync call or async feedback. Tell us what works, what doesn't, and what you need next.
+              </p>
+            </div>
+
+            <div className="p-6 rounded-xl bg-gray-900 border border-gray-800 hover:border-gray-600 transition">
+              <div className="flex items-center gap-3 mb-4">
+                <div className="p-2.5 bg-gray-800 rounded-lg">
+                  <UserCheck className="text-gray-300" size={22} />
+                </div>
+                <h3 className="font-bold text-lg">Honest Feedback</h3>
+              </div>
+              <p className="text-gray-400 text-sm leading-relaxed">
+                We want the truth. If something's broken, tell us. If a feature is missing, we need to know. Your candor makes the product better.
+              </p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* How It Works - Timeline */}
+      <section className="py-20 px-6 border-t border-gray-800">
+        <div className="max-w-4xl mx-auto">
+          <h2 className="text-3xl font-bold text-center mb-4">How It Works</h2>
+          <p className="text-gray-500 text-center mb-12">From application to insights in under 3 weeks.</p>
+
+          <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
+            {[
+              {
+                step: '1',
+                title: 'Sign Up',
+                time: '5 minutes',
+                desc: 'Fill out the form below. We review and respond within 24 hours.',
+                color: 'purple',
+                icon: <Send size={20} />,
+              },
+              {
+                step: '2',
+                title: 'Setup Call',
+                time: '30 minutes',
+                desc: 'We walk through your architecture and configure SatGate for your environment.',
+                color: 'cyan',
+                icon: <Calendar size={20} />,
+              },
+              {
+                step: '3',
+                title: 'Traffic Flows',
+                time: 'Week 1–2',
+                desc: 'Route staging traffic through SatGate. Observe mode starts collecting data immediately.',
+                color: 'green',
+                icon: <Zap size={20} />,
+              },
+              {
+                step: '4',
+                title: 'Your Reports',
+                time: 'Week 3+',
+                desc: 'Your data, your dashboards. Cost attribution, security insights, governance reports—all yours.',
+                color: 'yellow',
+                icon: <BarChart3 size={20} />,
+              },
+            ].map((item) => (
+              <div key={item.step} className="relative p-5 rounded-xl bg-gray-900 border border-gray-800 text-center">
+                <div className={`inline-flex items-center justify-center w-10 h-10 rounded-full bg-${item.color}-900/50 border-2 border-${item.color}-500/60 mb-4`}>
+                  <span className={`text-${item.color}-400`}>{item.icon}</span>
+                </div>
+                <h4 className="font-semibold text-white mb-1">{item.title}</h4>
+                <p className={`text-${item.color}-400 text-xs font-mono mb-2`}>{item.time}</p>
+                <p className="text-gray-500 text-sm">{item.desc}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* Application Form */}
+      <section id="apply" className="py-20 px-6 border-t border-gray-800 bg-gradient-to-b from-purple-950/10 to-black">
+        <div className="max-w-2xl mx-auto">
+          <h2 className="text-3xl font-bold text-center mb-4">Apply to the Design Partner Program</h2>
+          <p className="text-gray-500 text-center mb-10">Takes about 2 minutes. We'll respond within 24 hours.</p>
+
+          <form onSubmit={handleSubmit} className="space-y-6">
+            {/* Name */}
+            <div>
+              <label className="block text-sm font-medium text-gray-300 mb-2">Name *</label>
+              <input
+                type="text"
+                required
+                value={formData.name}
+                onChange={(e) => setFormData(prev => ({ ...prev, name: e.target.value }))}
+                className="w-full px-4 py-3 bg-gray-900 border border-gray-800 rounded-lg text-white placeholder-gray-500 focus:border-purple-500 focus:outline-none focus:ring-1 focus:ring-purple-500/50 transition"
+                placeholder="Jane Smith"
+              />
+            </div>
+
+            {/* Email */}
+            <div>
+              <label className="block text-sm font-medium text-gray-300 mb-2">Work Email *</label>
+              <input
+                type="email"
+                required
+                value={formData.email}
+                onChange={(e) => setFormData(prev => ({ ...prev, email: e.target.value }))}
+                className="w-full px-4 py-3 bg-gray-900 border border-gray-800 rounded-lg text-white placeholder-gray-500 focus:border-purple-500 focus:outline-none focus:ring-1 focus:ring-purple-500/50 transition"
+                placeholder="jane@company.com"
+              />
+            </div>
+
+            {/* Company */}
+            <div>
+              <label className="block text-sm font-medium text-gray-300 mb-2">Company *</label>
+              <input
+                type="text"
+                required
+                value={formData.company}
+                onChange={(e) => setFormData(prev => ({ ...prev, company: e.target.value }))}
+                className="w-full px-4 py-3 bg-gray-900 border border-gray-800 rounded-lg text-white placeholder-gray-500 focus:border-purple-500 focus:outline-none focus:ring-1 focus:ring-purple-500/50 transition"
+                placeholder="Acme Corp"
+              />
+            </div>
+
+            {/* Role */}
+            <div>
+              <label className="block text-sm font-medium text-gray-300 mb-2">Role / Title *</label>
+              <input
+                type="text"
+                required
+                value={formData.role}
+                onChange={(e) => setFormData(prev => ({ ...prev, role: e.target.value }))}
+                className="w-full px-4 py-3 bg-gray-900 border border-gray-800 rounded-lg text-white placeholder-gray-500 focus:border-purple-500 focus:outline-none focus:ring-1 focus:ring-purple-500/50 transition"
+                placeholder="VP Engineering"
+              />
+            </div>
+
+            {/* Number of AI Agents */}
+            <div>
+              <label className="block text-sm font-medium text-gray-300 mb-2">Number of AI Agents *</label>
+              <select
+                required
+                value={formData.agentCount}
+                onChange={(e) => setFormData(prev => ({ ...prev, agentCount: e.target.value }))}
+                className="w-full px-4 py-3 bg-gray-900 border border-gray-800 rounded-lg text-white focus:border-purple-500 focus:outline-none focus:ring-1 focus:ring-purple-500/50 transition appearance-none"
+              >
+                <option value="" className="text-gray-500">Select range...</option>
+                <option value="1-10">1–10</option>
+                <option value="10-50">10–50</option>
+                <option value="50-100">50–100</option>
+                <option value="100+">100+</option>
+              </select>
+            </div>
+
+            {/* Primary APIs */}
+            <div>
+              <label className="block text-sm font-medium text-gray-300 mb-3">Primary APIs Used</label>
+              <div className="grid grid-cols-2 gap-3">
+                {['OpenAI', 'Anthropic', 'Internal APIs', 'Other'].map(api => (
+                  <label key={api} className="flex items-center gap-3 p-3 bg-gray-900 border border-gray-800 rounded-lg cursor-pointer hover:border-gray-600 transition has-[:checked]:border-purple-500/60 has-[:checked]:bg-purple-950/20">
+                    <input
+                      type="checkbox"
+                      checked={formData.apis.includes(api)}
+                      onChange={() => handleApiToggle(api)}
+                      className="w-4 h-4 rounded border-gray-700 bg-gray-800 text-purple-500 focus:ring-purple-500/50 focus:ring-offset-0"
+                    />
+                    <span className="text-sm text-gray-300">{api}</span>
+                  </label>
+                ))}
+              </div>
+            </div>
+
+            {/* Challenge */}
+            <div>
+              <label className="block text-sm font-medium text-gray-300 mb-2">
+                What's your biggest challenge with AI agent management?
+              </label>
+              <textarea
+                value={formData.challenge}
+                onChange={(e) => setFormData(prev => ({ ...prev, challenge: e.target.value }))}
+                rows={4}
+                className="w-full px-4 py-3 bg-gray-900 border border-gray-800 rounded-lg text-white placeholder-gray-500 focus:border-purple-500 focus:outline-none focus:ring-1 focus:ring-purple-500/50 transition resize-none"
+                placeholder="e.g., We can't track which team is responsible for our $50k/month OpenAI bill..."
+              />
+            </div>
+
+            {/* Submit */}
+            <button
+              type="submit"
+              className="w-full py-4 bg-gradient-to-r from-purple-600 to-cyan-600 text-white rounded-xl font-bold text-lg hover:opacity-90 transition shadow-lg shadow-purple-500/20 flex items-center justify-center gap-2"
+            >
+              Submit Application <Send size={18} />
+            </button>
+
+            <p className="text-center text-gray-600 text-xs">
+              By submitting, you agree to our{' '}
+              <Link href="/terms" className="text-gray-500 underline hover:text-white transition">Terms</Link>{' '}
+              and{' '}
+              <Link href="/privacy" className="text-gray-500 underline hover:text-white transition">Privacy Policy</Link>.
+            </p>
+          </form>
+        </div>
+      </section>
+
+      {/* FAQ */}
+      <section className="py-20 px-6 border-t border-gray-800">
+        <div className="max-w-2xl mx-auto">
+          <h2 className="text-3xl font-bold text-center mb-4">Frequently Asked Questions</h2>
+          <p className="text-gray-500 text-center mb-12">Quick answers to common questions.</p>
+
+          <div className="space-y-3">
+            {faqs.map((faq, idx) => (
+              <div key={idx} className="rounded-xl border border-gray-800 overflow-hidden">
+                <button
+                  onClick={() => toggleFaq(idx)}
+                  className="w-full flex items-center justify-between p-5 text-left hover:bg-gray-900/50 transition"
+                >
+                  <span className="font-medium text-white pr-4">{faq.q}</span>
+                  {openFaq === idx ? (
+                    <ChevronUp size={18} className="text-gray-400 flex-shrink-0" />
+                  ) : (
+                    <ChevronDown size={18} className="text-gray-400 flex-shrink-0" />
+                  )}
+                </button>
+                <div className={`overflow-hidden transition-all duration-300 ease-in-out ${openFaq === idx ? 'max-h-40 opacity-100' : 'max-h-0 opacity-0'}`}>
+                  <div className="px-5 pb-5 text-gray-400 text-sm leading-relaxed">
+                    {faq.a}
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* Final CTA */}
+      <section className="py-20 px-6 border-t border-gray-800 bg-gradient-to-b from-cyan-950/10 to-black">
+        <div className="max-w-3xl mx-auto text-center">
+          <h2 className="text-3xl font-bold mb-4">Still have questions?</h2>
+          <p className="text-gray-400 mb-8">
+            Reach out directly. We'd love to chat about your use case.
+          </p>
+          <div className="flex flex-col sm:flex-row gap-4 justify-center">
+            <a href="mailto:contact@satgate.io" className="border border-gray-700 px-8 py-3 rounded-lg font-bold hover:border-gray-500 transition flex items-center justify-center gap-2">
+              Email Us <ArrowRight size={18} />
+            </a>
+            <a href="#apply" className="bg-white text-black px-8 py-3 rounded-lg font-bold hover:bg-gray-200 transition flex items-center justify-center gap-2">
+              Apply Now <ArrowRight size={18} />
+            </a>
+          </div>
+        </div>
+      </section>
+
+      {/* Footer */}
+      <footer className="py-12 border-t border-gray-800">
+        <div className="max-w-6xl mx-auto px-6">
+          <div className="grid grid-cols-1 md:grid-cols-4 gap-8 py-8">
+            <div>
+              <div className="flex items-center gap-2 mb-4">
+                <Image src="/logo_white_transparent.png" alt="SatGate" width={24} height={24} className="w-6 h-6" />
+                <h4 className="font-bold text-white">SatGate</h4>
+              </div>
+              <p className="text-gray-500 text-sm">The governance layer for AI agents.</p>
+            </div>
+            <div>
+              <h4 className="font-bold text-white mb-4">Product</h4>
+              <ul className="space-y-2 text-sm text-gray-500">
+                <li><Link href="/protect" className="hover:text-white transition">Protect</Link></li>
+                <li><Link href="/pay" className="hover:text-white transition">Pay</Link></li>
+                <li><Link href="/govern" className="hover:text-white transition">Govern</Link></li>
+              </ul>
+            </div>
+            <div>
+              <h4 className="font-bold text-white mb-4">Resources</h4>
+              <ul className="space-y-2 text-sm text-gray-500">
+                <li><a href="https://github.com/SatGate-io/satgate" target="_blank" rel="noopener noreferrer" className="hover:text-white transition">GitHub</a></li>
+                <li><a href="https://cloud.satgate.io" target="_blank" rel="noopener noreferrer" className="hover:text-white transition">Cloud Dashboard</a></li>
+              </ul>
+            </div>
+            <div>
+              <h4 className="font-bold text-white mb-4">Company</h4>
+              <ul className="space-y-2 text-sm text-gray-500">
+                <li><a href="mailto:contact@satgate.io" className="hover:text-white transition">contact@satgate.io</a></li>
+                <li><Link href="/terms" className="hover:text-white transition">Terms</Link></li>
+                <li><Link href="/privacy" className="hover:text-white transition">Privacy</Link></li>
+              </ul>
+            </div>
+          </div>
+          <div className="pt-8 border-t border-gray-800 text-center text-gray-600 text-sm">
+            © 2025 SatGate Inc. All rights reserved. SatGate™ is a trademark of SatGate Inc. Patent Pending.
+          </div>
+        </div>
+      </footer>
+    </div>
+  );
+}

--- a/satgate-landing/app/govern/page.tsx
+++ b/satgate-landing/app/govern/page.tsx
@@ -1,0 +1,622 @@
+'use client';
+
+import React, { useState } from 'react';
+import {
+  Eye, Sliders, CreditCard, Shield, AlertTriangle, Users, Building2,
+  ArrowRight, CheckCircle, Clock, DollarSign, Lock, Key, Bot,
+  GitBranch, Activity, Server, Cloud, Container, FileCode, Menu, X,
+  ChevronRight, Zap, UserCheck, FileSearch, BarChart3, ShieldCheck,
+  Network, Timer, Coins, Layers
+} from 'lucide-react';
+import Link from 'next/link';
+import Image from 'next/image';
+
+export default function GovernPage() {
+  const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
+
+  return (
+    <div className="min-h-screen bg-black text-gray-100 font-sans selection:bg-purple-500 selection:text-white">
+
+      {/* Navigation */}
+      <nav className="border-b border-gray-800 backdrop-blur-md fixed w-full z-50 bg-black/50">
+        <div className="max-w-6xl mx-auto px-4 sm:px-6 h-16 flex items-center justify-between">
+          <Link href="/" className="flex items-center gap-2 shrink-0">
+            <Image src="/logo_white_transparent.png" alt="SatGate" width={32} height={32} className="w-7 h-7 sm:w-8 sm:h-8" />
+            <span className="text-lg sm:text-xl font-bold text-white whitespace-nowrap">SatGate<sup className="text-xs font-normal">™</sup></span>
+          </Link>
+
+          <div className="hidden md:flex gap-6 text-sm font-medium text-gray-400">
+            <Link href="/protect" className="hover:text-white transition">Protect Demo</Link>
+            <Link href="/pay" className="hover:text-white transition">Pay Demo</Link>
+            <Link href="/govern" className="text-white transition">Govern</Link>
+            <Link href="#" className="hover:text-white transition">Pricing</Link>
+            <a href="https://github.com/SatGate-io/satgate" target="_blank" rel="noopener noreferrer" className="hover:text-white transition">Docs</a>
+            <a href="https://cloud.satgate.io" target="_blank" rel="noopener noreferrer" className="hover:text-white transition">Cloud</a>
+          </div>
+
+          <button
+            onClick={() => setMobileMenuOpen(!mobileMenuOpen)}
+            className="flex md:hidden items-center justify-center w-10 h-10 rounded-lg bg-gray-800/50 hover:bg-gray-700/50 text-gray-400 hover:text-white transition"
+            aria-label="Toggle menu"
+            aria-expanded={mobileMenuOpen}
+          >
+            {mobileMenuOpen ? <X size={20} /> : <Menu size={20} />}
+          </button>
+        </div>
+
+        <div className={`md:hidden overflow-hidden transition-all duration-300 ease-in-out ${mobileMenuOpen ? 'max-h-96 opacity-100' : 'max-h-0 opacity-0'}`}>
+          <div className="bg-black/95 backdrop-blur-xl border-t border-gray-800 px-4 py-4 space-y-1">
+            {[
+              { href: '/protect', label: 'Protect Demo' },
+              { href: '/pay', label: 'Pay Demo' },
+              { href: '/govern', label: 'Govern' },
+              { href: '#', label: 'Pricing' },
+            ].map(item => (
+              <Link key={item.href} href={item.href} onClick={() => setMobileMenuOpen(false)} className="block text-gray-400 hover:text-white hover:bg-gray-800/50 transition py-3 px-4 rounded-lg">
+                {item.label}
+              </Link>
+            ))}
+            <a href="https://github.com/SatGate-io/satgate" target="_blank" rel="noopener noreferrer" onClick={() => setMobileMenuOpen(false)} className="block text-gray-400 hover:text-white hover:bg-gray-800/50 transition py-3 px-4 rounded-lg">
+              Docs
+            </a>
+            <a href="https://cloud.satgate.io" target="_blank" rel="noopener noreferrer" onClick={() => setMobileMenuOpen(false)} className="block text-gray-400 hover:text-white hover:bg-gray-800/50 transition py-3 px-4 rounded-lg">
+              Cloud
+            </a>
+          </div>
+        </div>
+      </nav>
+
+      {/* Hero Section */}
+      <header className="pt-32 pb-20 px-6">
+        <div className="max-w-4xl mx-auto text-center">
+          <div className="inline-flex items-center gap-2 px-3 py-1 rounded-full bg-purple-900/30 border border-purple-500/30 text-purple-300 text-xs font-mono mb-6">
+            <Shield size={12} /> Enterprise AI Governance
+          </div>
+          <h1 className="text-5xl md:text-6xl font-extrabold tracking-tight mb-6">
+            See Everything.{' '}
+            <span className="text-transparent bg-clip-text bg-gradient-to-r from-purple-400 via-pink-400 to-cyan-400">
+              Control What Matters.
+            </span>
+          </h1>
+          <p className="text-xl text-gray-400 mb-10 max-w-2xl mx-auto leading-relaxed">
+            Your AI agents are spending money, calling APIs, and making decisions—with zero visibility.
+            SatGate gives you the governance layer: <strong className="text-white">observe</strong> every call,{' '}
+            <strong className="text-white">control</strong> every budget, and{' '}
+            <strong className="text-white">charge back</strong> every dollar to the right team.
+          </p>
+          <div className="flex flex-col sm:flex-row gap-4 justify-center">
+            <Link href="/design-partners" className="bg-white text-black px-8 py-3 rounded-lg font-bold hover:bg-gray-200 transition flex items-center justify-center gap-2">
+              Become a Design Partner <ArrowRight size={18} />
+            </Link>
+            <Link href="#observe" className="border border-gray-700 px-8 py-3 rounded-lg font-bold hover:border-gray-500 transition flex items-center justify-center gap-2">
+              Start Free <Eye size={18} />
+            </Link>
+          </div>
+        </div>
+      </header>
+
+      {/* Three Personas */}
+      <section className="py-20 px-6 border-t border-gray-800">
+        <div className="max-w-5xl mx-auto">
+          <h2 className="text-3xl font-bold text-center mb-4">Built for Every Stakeholder</h2>
+          <p className="text-gray-500 text-center mb-12">One platform, three perspectives. Everyone gets what they need.</p>
+
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+            {/* CFO */}
+            <div className="p-6 rounded-xl bg-gradient-to-br from-green-950/30 to-green-900/10 border border-green-800/30 hover:border-green-600/50 transition group">
+              <div className="flex items-center gap-3 mb-4">
+                <div className="p-2.5 bg-green-900/50 rounded-lg group-hover:bg-green-900/70 transition">
+                  <DollarSign className="text-green-400" size={22} />
+                </div>
+                <h3 className="font-bold text-lg">CFO</h3>
+              </div>
+              <p className="text-gray-400 text-sm leading-relaxed mb-4">
+                "Where is the money going?"
+              </p>
+              <ul className="space-y-2 text-sm text-gray-500">
+                <li className="flex items-center gap-2"><BarChart3 size={14} className="text-green-400 flex-shrink-0" /> Cost attribution by team & agent</li>
+                <li className="flex items-center gap-2"><CreditCard size={14} className="text-green-400 flex-shrink-0" /> Automated chargeback reports</li>
+                <li className="flex items-center gap-2"><Activity size={14} className="text-green-400 flex-shrink-0" /> Budget alerts before overruns</li>
+              </ul>
+            </div>
+
+            {/* CISO */}
+            <div className="p-6 rounded-xl bg-gradient-to-br from-red-950/30 to-red-900/10 border border-red-800/30 hover:border-red-600/50 transition group">
+              <div className="flex items-center gap-3 mb-4">
+                <div className="p-2.5 bg-red-900/50 rounded-lg group-hover:bg-red-900/70 transition">
+                  <Shield className="text-red-400" size={22} />
+                </div>
+                <h3 className="font-bold text-lg">CISO</h3>
+              </div>
+              <p className="text-gray-400 text-sm leading-relaxed mb-4">
+                "Are we secure and compliant?"
+              </p>
+              <ul className="space-y-2 text-sm text-gray-500">
+                <li className="flex items-center gap-2"><ShieldCheck size={14} className="text-red-400 flex-shrink-0" /> Security dashboard & threat detection</li>
+                <li className="flex items-center gap-2"><AlertTriangle size={14} className="text-red-400 flex-shrink-0" /> Anomalous usage alerts</li>
+                <li className="flex items-center gap-2"><FileSearch size={14} className="text-red-400 flex-shrink-0" /> SOC2/GDPR compliance exports</li>
+              </ul>
+            </div>
+
+            {/* CTO */}
+            <div className="p-6 rounded-xl bg-gradient-to-br from-purple-950/30 to-purple-900/10 border border-purple-800/30 hover:border-purple-600/50 transition group">
+              <div className="flex items-center gap-3 mb-4">
+                <div className="p-2.5 bg-purple-900/50 rounded-lg group-hover:bg-purple-900/70 transition">
+                  <Key className="text-purple-400" size={22} />
+                </div>
+                <h3 className="font-bold text-lg">CTO</h3>
+              </div>
+              <p className="text-gray-400 text-sm leading-relaxed mb-4">
+                "Who has access, and how do I control it?"
+              </p>
+              <ul className="space-y-2 text-sm text-gray-500">
+                <li className="flex items-center gap-2"><GitBranch size={14} className="text-purple-400 flex-shrink-0" /> Full audit trail of every token</li>
+                <li className="flex items-center gap-2"><Lock size={14} className="text-purple-400 flex-shrink-0" /> Token delegation & revocation</li>
+                <li className="flex items-center gap-2"><Sliders size={14} className="text-purple-400 flex-shrink-0" /> Governance policies as code</li>
+              </ul>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Observe → Control → Charge */}
+      <section id="observe" className="py-20 px-6 border-t border-gray-800 bg-gradient-to-b from-gray-900/30 to-black">
+        <div className="max-w-5xl mx-auto">
+          <h2 className="text-3xl font-bold text-center mb-4">Three Modes. One Gateway.</h2>
+          <p className="text-gray-500 text-center mb-12">Start with visibility. Add control when you're ready. Monetize when it makes sense.</p>
+
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+            {/* Observe */}
+            <div className="relative p-6 rounded-xl bg-gray-900 border-2 border-purple-500/60 hover:border-purple-400/80 transition">
+              <div className="absolute -top-3 left-4 px-3 py-0.5 bg-purple-600 text-white text-xs font-bold rounded-full">FREE</div>
+              <div className="flex items-center gap-3 mb-4 mt-2">
+                <div className="p-2.5 bg-purple-900/50 rounded-lg">
+                  <Eye className="text-purple-400" size={22} />
+                </div>
+                <h3 className="font-bold text-lg">Observe</h3>
+              </div>
+              <p className="text-gray-400 text-sm leading-relaxed mb-4">
+                See every API call, every token, every agent. Full visibility with zero enforcement.
+              </p>
+              <ul className="space-y-2 text-sm text-gray-500">
+                <li className="text-purple-400">✓ Real-time request logging</li>
+                <li className="text-purple-400">✓ Cost attribution dashboards</li>
+                <li className="text-purple-400">✓ Agent inventory</li>
+                <li className="text-purple-400">✓ Anomaly detection</li>
+              </ul>
+            </div>
+
+            {/* Control */}
+            <div className="p-6 rounded-xl bg-gray-900 border border-cyan-800/30 hover:border-cyan-600/50 transition">
+              <div className="flex items-center gap-3 mb-4">
+                <div className="p-2.5 bg-cyan-900/50 rounded-lg">
+                  <Sliders className="text-cyan-400" size={22} />
+                </div>
+                <h3 className="font-bold text-lg">Control</h3>
+              </div>
+              <p className="text-gray-400 text-sm leading-relaxed mb-4">
+                Set budgets, enforce policies, gate access. Observe + enforcement.
+              </p>
+              <ul className="space-y-2 text-sm text-gray-500">
+                <li className="text-cyan-400">✓ Per-agent budget limits</li>
+                <li className="text-cyan-400">✓ Token scope enforcement</li>
+                <li className="text-cyan-400">✓ Rate limiting by team</li>
+                <li className="text-cyan-400">✓ Automatic revocation</li>
+              </ul>
+            </div>
+
+            {/* Charge */}
+            <div className="p-6 rounded-xl bg-gray-900 border border-yellow-800/30 hover:border-yellow-600/50 transition">
+              <div className="flex items-center gap-3 mb-4">
+                <div className="p-2.5 bg-yellow-900/50 rounded-lg">
+                  <CreditCard className="text-yellow-400" size={22} />
+                </div>
+                <h3 className="font-bold text-lg">Charge</h3>
+              </div>
+              <p className="text-gray-400 text-sm leading-relaxed mb-4">
+                Meter usage, generate invoices, bill internal teams or external consumers.
+              </p>
+              <ul className="space-y-2 text-sm text-gray-500">
+                <li className="text-yellow-400">✓ Per-request metering</li>
+                <li className="text-yellow-400">✓ Internal chargeback automation</li>
+                <li className="text-yellow-400">✓ External billing integration</li>
+                <li className="text-yellow-400">✓ Lightning micropayments</li>
+              </ul>
+            </div>
+          </div>
+
+          <div className="text-center mt-8">
+            <div className="inline-flex items-center gap-2 px-4 py-2 bg-gray-900 border border-gray-800 rounded-full text-sm text-gray-400">
+              <Eye size={14} className="text-purple-400" />
+              <span>Observe</span>
+              <ChevronRight size={14} className="text-gray-600" />
+              <Sliders size={14} className="text-cyan-400" />
+              <span>Control</span>
+              <ChevronRight size={14} className="text-gray-600" />
+              <CreditCard size={14} className="text-yellow-400" />
+              <span>Charge</span>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* The Rogue Intern Story */}
+      <section className="py-20 px-6 border-t border-gray-800 bg-gradient-to-b from-red-950/10 to-black">
+        <div className="max-w-4xl mx-auto">
+          <div className="text-center mb-12">
+            <div className="inline-flex items-center gap-2 px-3 py-1 rounded-full bg-red-900/30 border border-red-500/30 text-red-300 text-xs font-mono mb-6">
+              <AlertTriangle size={12} /> Real-World Scenario
+            </div>
+            <h2 className="text-3xl font-bold mb-4">The Rogue Intern Story</h2>
+            <p className="text-gray-400 max-w-2xl mx-auto">
+              Friday afternoon. An intern creates an API token "to test something." By Monday, $47,000 in OpenAI charges. Here's how SatGate changes the ending.
+            </p>
+          </div>
+
+          <div className="relative">
+            {/* Timeline line */}
+            <div className="absolute left-6 md:left-1/2 top-0 bottom-0 w-px bg-gradient-to-b from-red-500/50 via-yellow-500/50 via-cyan-500/50 to-green-500/50 hidden sm:block"></div>
+
+            <div className="space-y-8">
+              {/* Step 1 */}
+              <div className="relative flex flex-col md:flex-row items-start gap-4 md:gap-8">
+                <div className="md:w-1/2 md:text-right md:pr-8">
+                  <div className="p-5 rounded-xl bg-gray-900 border border-red-800/30">
+                    <div className="flex items-center gap-2 mb-2 md:justify-end">
+                      <span className="text-red-400 font-mono text-xs">FRIDAY 4:47 PM</span>
+                    </div>
+                    <h4 className="font-semibold text-white mb-1 flex items-center gap-2 md:justify-end">
+                      <Bot size={16} className="text-red-400" /> Intern Creates Token
+                    </h4>
+                    <p className="text-gray-500 text-sm">
+                      "Just a quick test." Generates an API token with no budget limit, no scope restriction, no expiry.
+                    </p>
+                  </div>
+                </div>
+                <div className="hidden md:flex absolute left-1/2 -translate-x-1/2 w-10 h-10 bg-red-900/50 border-2 border-red-500 rounded-full items-center justify-center z-10">
+                  <span className="text-red-400 font-bold text-sm">1</span>
+                </div>
+                <div className="md:w-1/2 md:pl-8"></div>
+              </div>
+
+              {/* Step 2 */}
+              <div className="relative flex flex-col md:flex-row items-start gap-4 md:gap-8">
+                <div className="md:w-1/2 md:pr-8"></div>
+                <div className="hidden md:flex absolute left-1/2 -translate-x-1/2 w-10 h-10 bg-red-900/50 border-2 border-red-500 rounded-full items-center justify-center z-10">
+                  <span className="text-red-400 font-bold text-sm">2</span>
+                </div>
+                <div className="md:w-1/2 md:pl-8">
+                  <div className="p-5 rounded-xl bg-gray-900 border border-red-800/30">
+                    <div className="flex items-center gap-2 mb-2">
+                      <span className="text-red-400 font-mono text-xs">SATURDAY — SUNDAY</span>
+                    </div>
+                    <h4 className="font-semibold text-white mb-1 flex items-center gap-2">
+                      <Zap size={16} className="text-red-400" /> Agent Burns Budget
+                    </h4>
+                    <p className="text-gray-500 text-sm">
+                      The test script runs in a loop. 2.3 million API calls. $47,000 in compute. Nobody notices.
+                    </p>
+                  </div>
+                </div>
+              </div>
+
+              {/* Step 3 — SatGate catches it */}
+              <div className="relative flex flex-col md:flex-row items-start gap-4 md:gap-8">
+                <div className="md:w-1/2 md:text-right md:pr-8">
+                  <div className="p-5 rounded-xl bg-gray-900 border border-yellow-800/30">
+                    <div className="flex items-center gap-2 mb-2 md:justify-end">
+                      <span className="text-yellow-400 font-mono text-xs">WITH SATGATE: FRIDAY 4:48 PM</span>
+                    </div>
+                    <h4 className="font-semibold text-white mb-1 flex items-center gap-2 md:justify-end">
+                      <AlertTriangle size={16} className="text-yellow-400" /> CISO Gets Alert
+                    </h4>
+                    <p className="text-gray-500 text-sm">
+                      SatGate detects anomalous token creation. Budget threshold hit after $50. Alert fires in 60 seconds.
+                    </p>
+                  </div>
+                </div>
+                <div className="hidden md:flex absolute left-1/2 -translate-x-1/2 w-10 h-10 bg-yellow-900/50 border-2 border-yellow-500 rounded-full items-center justify-center z-10">
+                  <span className="text-yellow-400 font-bold text-sm">3</span>
+                </div>
+                <div className="md:w-1/2 md:pl-8"></div>
+              </div>
+
+              {/* Step 4 */}
+              <div className="relative flex flex-col md:flex-row items-start gap-4 md:gap-8">
+                <div className="md:w-1/2 md:pr-8"></div>
+                <div className="hidden md:flex absolute left-1/2 -translate-x-1/2 w-10 h-10 bg-cyan-900/50 border-2 border-cyan-500 rounded-full items-center justify-center z-10">
+                  <span className="text-cyan-400 font-bold text-sm">4</span>
+                </div>
+                <div className="md:w-1/2 md:pl-8">
+                  <div className="p-5 rounded-xl bg-gray-900 border border-cyan-800/30">
+                    <div className="flex items-center gap-2 mb-2">
+                      <span className="text-cyan-400 font-mono text-xs">FRIDAY 4:49 PM</span>
+                    </div>
+                    <h4 className="font-semibold text-white mb-1 flex items-center gap-2">
+                      <Lock size={16} className="text-cyan-400" /> CTO Revokes Token
+                    </h4>
+                    <p className="text-gray-500 text-sm">
+                      One click. Token revoked globally. All child tokens die instantly. Total cost: $50 instead of $47,000.
+                    </p>
+                  </div>
+                </div>
+              </div>
+
+              {/* Step 5 */}
+              <div className="relative flex flex-col md:flex-row items-start gap-4 md:gap-8">
+                <div className="md:w-1/2 md:text-right md:pr-8">
+                  <div className="p-5 rounded-xl bg-gray-900 border border-green-800/30">
+                    <div className="flex items-center gap-2 mb-2 md:justify-end">
+                      <span className="text-green-400 font-mono text-xs">AUTOMATIC</span>
+                    </div>
+                    <h4 className="font-semibold text-white mb-1 flex items-center gap-2 md:justify-end">
+                      <CheckCircle size={16} className="text-green-400" /> Audit Trail Complete
+                    </h4>
+                    <p className="text-gray-500 text-sm">
+                      Full timeline: who created the token, what it accessed, when it was revoked. Compliance-ready export.
+                    </p>
+                  </div>
+                </div>
+                <div className="hidden md:flex absolute left-1/2 -translate-x-1/2 w-10 h-10 bg-green-900/50 border-2 border-green-500 rounded-full items-center justify-center z-10">
+                  <span className="text-green-400 font-bold text-sm">5</span>
+                </div>
+                <div className="md:w-1/2 md:pl-8"></div>
+              </div>
+            </div>
+          </div>
+
+          <div className="text-center mt-12">
+            <div className="inline-block bg-gradient-to-r from-green-900/20 to-cyan-900/20 border border-green-800/30 rounded-xl px-6 py-4">
+              <p className="text-white font-semibold">$47,000 saved. 2 minutes to resolution. Zero code changes.</p>
+              <p className="text-gray-500 text-sm mt-1">SatGate Observe mode would have caught this for free.</p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Dashboard Screenshots */}
+      <section className="py-20 px-6 border-t border-gray-800">
+        <div className="max-w-5xl mx-auto">
+          <h2 className="text-3xl font-bold text-center mb-4">60+ Dashboard Pages. Day One.</h2>
+          <p className="text-gray-500 text-center mb-12">Real-time visibility into every agent, every API call, every dollar.</p>
+
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+            {[
+              {
+                title: 'Usage Dashboard',
+                description: 'Real-time API call volume, latency percentiles, error rates. Broken down by agent, team, and endpoint.',
+                gradient: 'from-purple-600 to-cyan-600',
+                icon: <Activity size={24} className="text-purple-400" />,
+              },
+              {
+                title: 'CFO Chargeback Report',
+                description: 'Automated cost attribution. See exactly which team spent what on which API. Export to CSV or push to your billing system.',
+                gradient: 'from-green-600 to-emerald-600',
+                icon: <DollarSign size={24} className="text-green-400" />,
+              },
+              {
+                title: 'Security Dashboard',
+                description: 'Active tokens, anomalous behavior, blocked requests, revocation history. CISO-ready at a glance.',
+                gradient: 'from-red-600 to-orange-600',
+                icon: <Shield size={24} className="text-red-400" />,
+              },
+              {
+                title: 'Compliance Export',
+                description: 'SOC2, GDPR, HIPAA audit trails. Every token lifecycle event, every access decision, timestamped and immutable.',
+                gradient: 'from-cyan-600 to-blue-600',
+                icon: <FileSearch size={24} className="text-cyan-400" />,
+              },
+            ].map((item) => (
+              <div key={item.title} className="relative group">
+                <div className={`absolute -inset-0.5 bg-gradient-to-r ${item.gradient} rounded-xl blur opacity-20 group-hover:opacity-40 transition duration-500 pointer-events-none`}></div>
+                <div className="relative bg-gray-900 rounded-xl border border-gray-800 overflow-hidden">
+                  <div className="flex items-center gap-2 px-4 py-3 border-b border-gray-800 bg-gray-900/80">
+                    <div className="w-3 h-3 rounded-full bg-red-500"></div>
+                    <div className="w-3 h-3 rounded-full bg-yellow-500"></div>
+                    <div className="w-3 h-3 rounded-full bg-green-500"></div>
+                    <div className="text-xs text-gray-500 ml-2 font-mono">{item.title}</div>
+                  </div>
+                  <div className="p-8 min-h-[200px] flex flex-col items-center justify-center text-center">
+                    <div className="mb-4">{item.icon}</div>
+                    <h4 className="font-semibold text-white mb-2">{item.title}</h4>
+                    <p className="text-gray-500 text-sm max-w-xs">{item.description}</p>
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* Token Delegation Hierarchy */}
+      <section className="py-20 px-6 border-t border-gray-800 bg-gradient-to-b from-gray-900/30 to-black">
+        <div className="max-w-5xl mx-auto">
+          <h2 className="text-3xl font-bold text-center mb-4">Hierarchical Token Delegation</h2>
+          <p className="text-gray-500 text-center mb-12">
+            Tokens flow down. Authority narrows. Every level is scoped, budgeted, and time-limited.
+          </p>
+
+          {/* Tree Visualization */}
+          <div className="max-w-3xl mx-auto">
+            {/* Root */}
+            <div className="flex justify-center mb-4">
+              <div className="p-4 rounded-xl bg-purple-900/30 border-2 border-purple-500/60 text-center min-w-[220px]">
+                <div className="flex items-center justify-center gap-2 mb-1">
+                  <Key size={18} className="text-purple-400" />
+                  <span className="font-bold text-purple-300">Root Token</span>
+                </div>
+                <p className="text-xs text-gray-400">CTO • All scopes • $∞ budget</p>
+              </div>
+            </div>
+
+            {/* Connector */}
+            <div className="flex justify-center mb-4">
+              <div className="w-px h-8 bg-gray-700"></div>
+            </div>
+
+            {/* Department Level */}
+            <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mb-4">
+              {[
+                { name: 'Engineering VP', scope: 'api:eng:*', budget: '$10k/mo', color: 'cyan' },
+                { name: 'Data Science VP', scope: 'api:data:*', budget: '$25k/mo', color: 'green' },
+                { name: 'Marketing VP', scope: 'api:mkt:*', budget: '$5k/mo', color: 'yellow' },
+              ].map((dept) => (
+                <div key={dept.name} className={`p-4 rounded-xl bg-gray-900 border border-${dept.color}-800/30 text-center`}>
+                  <div className="flex items-center justify-center gap-2 mb-1">
+                    <Users size={16} className={`text-${dept.color}-400`} />
+                    <span className={`font-semibold text-${dept.color}-300 text-sm`}>{dept.name}</span>
+                  </div>
+                  <p className="text-xs text-gray-500 font-mono">{dept.scope}</p>
+                  <p className="text-xs text-gray-500">{dept.budget}</p>
+                </div>
+              ))}
+            </div>
+
+            {/* Connector */}
+            <div className="flex justify-center mb-4">
+              <div className="w-px h-8 bg-gray-700"></div>
+            </div>
+
+            {/* Agent Level */}
+            <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
+              {[
+                { name: 'RAG Agent', scope: 'api:data:read', budget: '$500/day', ttl: '24h' },
+                { name: 'Code Agent', scope: 'api:eng:deploy', budget: '$200/day', ttl: '8h' },
+                { name: 'Support Bot', scope: 'api:mkt:chat', budget: '$50/day', ttl: '1h' },
+                { name: 'Analytics', scope: 'api:data:query', budget: '$1k/day', ttl: '12h' },
+              ].map((agent) => (
+                <div key={agent.name} className="p-3 rounded-lg bg-gray-900/80 border border-gray-800 text-center">
+                  <div className="flex items-center justify-center gap-1.5 mb-1">
+                    <Bot size={14} className="text-gray-400" />
+                    <span className="font-medium text-gray-300 text-xs">{agent.name}</span>
+                  </div>
+                  <p className="text-[10px] text-gray-500 font-mono">{agent.scope}</p>
+                  <div className="flex items-center justify-center gap-2 mt-1">
+                    <span className="text-[10px] text-green-400/70 flex items-center gap-0.5"><Coins size={10} />{agent.budget}</span>
+                    <span className="text-[10px] text-purple-400/70 flex items-center gap-0.5"><Timer size={10} />{agent.ttl}</span>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          {/* Properties */}
+          <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mt-12 max-w-3xl mx-auto">
+            {[
+              { label: 'Scoped', desc: 'Narrower than parent', icon: <Lock size={16} className="text-cyan-400" /> },
+              { label: 'Budgeted', desc: 'Hard spending limits', icon: <Coins size={16} className="text-green-400" /> },
+              { label: 'Time-Limited', desc: 'Auto-expire by policy', icon: <Timer size={16} className="text-purple-400" /> },
+              { label: 'Delegatable', desc: 'Agents can sub-delegate', icon: <GitBranch size={16} className="text-yellow-400" /> },
+            ].map((prop) => (
+              <div key={prop.label} className="p-4 rounded-xl bg-gray-900 border border-gray-800 text-center">
+                <div className="flex justify-center mb-2">{prop.icon}</div>
+                <h4 className="font-semibold text-white text-sm">{prop.label}</h4>
+                <p className="text-gray-500 text-xs mt-1">{prop.desc}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* Deployment Options */}
+      <section className="py-20 px-6 border-t border-gray-800">
+        <div className="max-w-4xl mx-auto">
+          <div className="text-center mb-12">
+            <h2 className="text-3xl font-bold mb-4">Single Go Binary. Zero Dependencies.</h2>
+            <p className="text-gray-400 max-w-2xl mx-auto">
+              Deploy anywhere in minutes. No JVM, no runtime, no dependency hell. One binary that runs on anything.
+            </p>
+          </div>
+
+          <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-8">
+            {[
+              { icon: <Container size={24} className="text-cyan-400" />, label: 'Docker', desc: 'docker pull satgate/satgate' },
+              { icon: <Layers size={24} className="text-purple-400" />, label: 'Kubernetes', desc: 'Helm chart included' },
+              { icon: <FileCode size={24} className="text-green-400" />, label: 'Terraform', desc: 'IaC modules ready' },
+              { icon: <Cloud size={24} className="text-yellow-400" />, label: 'SaaS', desc: 'cloud.satgate.io' },
+            ].map((opt) => (
+              <div key={opt.label} className="p-5 rounded-xl bg-gray-900 border border-gray-800 text-center hover:border-gray-600 transition">
+                <div className="flex justify-center mb-3">{opt.icon}</div>
+                <h4 className="font-semibold text-white text-sm mb-1">{opt.label}</h4>
+                <p className="text-gray-500 text-xs font-mono">{opt.desc}</p>
+              </div>
+            ))}
+          </div>
+
+          <div className="bg-gradient-to-r from-cyan-900/20 to-purple-900/20 border border-cyan-800/30 rounded-xl p-6 text-center">
+            <div className="flex items-center justify-center gap-2 mb-2">
+              <Network size={18} className="text-cyan-400" />
+              <h4 className="font-semibold text-white">Hybrid Mode</h4>
+            </div>
+            <p className="text-gray-400 text-sm max-w-lg mx-auto">
+              Gateway runs in your VPC. Dashboard in our cloud (or yours). Your data never leaves your infrastructure.
+              The best of both worlds: self-hosted security, managed convenience.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      {/* Final CTA */}
+      <section className="py-20 px-6 border-t border-gray-800 bg-gradient-to-b from-purple-950/20 to-black">
+        <div className="max-w-3xl mx-auto text-center">
+          <h2 className="text-3xl md:text-4xl font-bold mb-6">
+            Ready to govern your AI agents?
+          </h2>
+          <p className="text-gray-400 text-lg mb-8">
+            We're working with 10 enterprises to build the governance layer for the agent economy.
+            Start with free Observe mode—no risk, full visibility.
+          </p>
+          <div className="flex flex-col sm:flex-row gap-4 justify-center">
+            <Link href="/design-partners" className="bg-gradient-to-r from-purple-600 to-cyan-600 text-white px-10 py-4 rounded-full font-bold text-lg hover:opacity-90 transition shadow-lg shadow-purple-500/20 flex items-center justify-center gap-2">
+              Become a Design Partner <ArrowRight size={20} />
+            </Link>
+          </div>
+          <p className="text-gray-600 text-sm mt-6">
+            Free Observe mode • 5-minute setup • No credit card required
+          </p>
+        </div>
+      </section>
+
+      {/* Footer */}
+      <footer className="py-12 border-t border-gray-800">
+        <div className="max-w-6xl mx-auto px-6">
+          <div className="grid grid-cols-1 md:grid-cols-4 gap-8 py-8">
+            <div>
+              <div className="flex items-center gap-2 mb-4">
+                <Image src="/logo_white_transparent.png" alt="SatGate" width={24} height={24} className="w-6 h-6" />
+                <h4 className="font-bold text-white">SatGate</h4>
+              </div>
+              <p className="text-gray-500 text-sm">The governance layer for AI agents.</p>
+            </div>
+            <div>
+              <h4 className="font-bold text-white mb-4">Product</h4>
+              <ul className="space-y-2 text-sm text-gray-500">
+                <li><Link href="/protect" className="hover:text-white transition">Protect</Link></li>
+                <li><Link href="/pay" className="hover:text-white transition">Pay</Link></li>
+                <li><Link href="/govern" className="hover:text-white transition">Govern</Link></li>
+              </ul>
+            </div>
+            <div>
+              <h4 className="font-bold text-white mb-4">Resources</h4>
+              <ul className="space-y-2 text-sm text-gray-500">
+                <li><a href="https://github.com/SatGate-io/satgate" target="_blank" rel="noopener noreferrer" className="hover:text-white transition">GitHub</a></li>
+                <li><a href="https://cloud.satgate.io" target="_blank" rel="noopener noreferrer" className="hover:text-white transition">Cloud Dashboard</a></li>
+              </ul>
+            </div>
+            <div>
+              <h4 className="font-bold text-white mb-4">Company</h4>
+              <ul className="space-y-2 text-sm text-gray-500">
+                <li><a href="mailto:contact@satgate.io" className="hover:text-white transition">contact@satgate.io</a></li>
+                <li><Link href="/terms" className="hover:text-white transition">Terms</Link></li>
+                <li><Link href="/privacy" className="hover:text-white transition">Privacy</Link></li>
+              </ul>
+            </div>
+          </div>
+          <div className="pt-8 border-t border-gray-800 text-center text-gray-600 text-sm">
+            © 2025 SatGate Inc. All rights reserved. SatGate™ is a trademark of SatGate Inc. Patent Pending.
+          </div>
+        </div>
+      </footer>
+    </div>
+  );
+}

--- a/satgate-landing/app/page.tsx
+++ b/satgate-landing/app/page.tsx
@@ -28,11 +28,12 @@ const LandingPage = () => {
           
           {/* Desktop menu */}
           <div className="hidden md:flex gap-6 text-sm font-medium text-gray-400">
-            <Link href="#features" className="hover:text-white transition">Features</Link>
             <Link href="/protect" className="hover:text-white transition">Protect Demo</Link>
             <Link href="/pay" className="hover:text-white transition">Pay Demo</Link>
-            <Link href="/dashboard" className="hover:text-white transition">Dashboard</Link>
-            <a href="https://github.com/SatGate-io/satgate" target="_blank" rel="noopener noreferrer" className="hover:text-white transition">GitHub</a>
+            <Link href="/govern" className="hover:text-white transition">Govern</Link>
+            <Link href="#" className="hover:text-white transition">Pricing</Link>
+            <a href="https://github.com/SatGate-io/satgate" target="_blank" rel="noopener noreferrer" className="hover:text-white transition">Docs</a>
+            <a href="https://cloud.satgate.io" target="_blank" rel="noopener noreferrer" className="hover:text-white transition">Cloud</a>
           </div>
           
           {/* Mobile menu button */}
@@ -54,13 +55,6 @@ const LandingPage = () => {
         >
           <div className="bg-black/95 backdrop-blur-xl border-t border-gray-800 px-4 py-4 space-y-1">
             <Link 
-              href="#features" 
-              onClick={() => setMobileMenuOpen(false)} 
-              className="block text-gray-400 hover:text-white hover:bg-gray-800/50 transition py-3 px-4 rounded-lg"
-            >
-              Features
-            </Link>
-            <Link 
               href="/protect" 
               onClick={() => setMobileMenuOpen(false)} 
               className="block text-gray-400 hover:text-white hover:bg-gray-800/50 transition py-3 px-4 rounded-lg"
@@ -75,11 +69,18 @@ const LandingPage = () => {
               Pay Demo
             </Link>
             <Link 
-              href="/dashboard" 
+              href="/govern" 
               onClick={() => setMobileMenuOpen(false)} 
               className="block text-gray-400 hover:text-white hover:bg-gray-800/50 transition py-3 px-4 rounded-lg"
             >
-              Dashboard
+              Govern
+            </Link>
+            <Link 
+              href="#" 
+              onClick={() => setMobileMenuOpen(false)} 
+              className="block text-gray-400 hover:text-white hover:bg-gray-800/50 transition py-3 px-4 rounded-lg"
+            >
+              Pricing
             </Link>
             <a 
               href="https://github.com/SatGate-io/satgate" 
@@ -88,7 +89,16 @@ const LandingPage = () => {
               onClick={() => setMobileMenuOpen(false)} 
               className="block text-gray-400 hover:text-white hover:bg-gray-800/50 transition py-3 px-4 rounded-lg"
             >
-              GitHub
+              Docs
+            </a>
+            <a 
+              href="https://cloud.satgate.io" 
+              target="_blank" 
+              rel="noopener noreferrer"
+              onClick={() => setMobileMenuOpen(false)} 
+              className="block text-gray-400 hover:text-white hover:bg-gray-800/50 transition py-3 px-4 rounded-lg"
+            >
+              Cloud
             </a>
           </div>
         </div>


### PR DESCRIPTION
## New Pages

### /govern — Enterprise Governance Story
The page design partners land on from LinkedIn outreach. Covers all three buyer personas:

- **CFO**: Cost attribution, chargeback reports, budget enforcement
- **CISO**: Security dashboard, threats blocked, compliance exports
- **CTO**: Audit trail, token delegation, governance controls

Includes the 'Rogue Intern' incident narrative, Observe→Control→Charge progression, token delegation visual, and deployment options.

### /design-partners — Outreach Landing Page
Purpose-built for Wayne's LinkedIn DMs. Application form with:
- Company info + role
- Number of AI agents (dropdown)
- Primary APIs (checkboxes)
- Challenge description (textarea)
- FAQ section addressing common concerns

### Navigation Update
- Added: Govern, Pricing (placeholder), Docs, Cloud (→ cloud.satgate.io)
- Removed: Features anchor, Dashboard link

All pages match existing dark theme, are mobile responsive, and build passes clean.