### PR TITLE
test: add comprehensive tests for config and proxy packages

### DIFF
--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1,0 +1,1089 @@
+package config
+
+import (
+	"os"
+	"testing"
+	"time"
+)
+
+// --- ParseYAML / Load tests ---
+
+func TestParseYAML_MinimalValid(t *testing.T) {
+	yaml := []byte(`
+version: 1
+upstreams:
+  backend:
+    url: https://api.example.com
+routes:
+  - name: test-route
+    match:
+      pathPrefix: /api/
+    upstream: backend
+    policy:
+      kind: public
+`)
+	cfg, err := ParseYAML(yaml)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.Version != 1 {
+		t.Errorf("expected version 1, got %d", cfg.Version)
+	}
+	if len(cfg.Routes) != 1 {
+		t.Fatalf("expected 1 route, got %d", len(cfg.Routes))
+	}
+	if cfg.Routes[0].Name != "test-route" {
+		t.Errorf("expected route name 'test-route', got %q", cfg.Routes[0].Name)
+	}
+}
+
+func TestParseYAML_Defaults(t *testing.T) {
+	yaml := []byte(`
+upstreams:
+  backend:
+    url: https://api.example.com
+routes:
+  - name: r
+    match:
+      pathPrefix: /
+    upstream: backend
+    policy:
+      kind: public
+`)
+	cfg, err := ParseYAML(yaml)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.Server.Listen != ":8080" {
+		t.Errorf("expected default listen ':8080', got %q", cfg.Server.Listen)
+	}
+	if cfg.Server.ReadTimeout != 30*time.Second {
+		t.Errorf("expected default readTimeout 30s, got %v", cfg.Server.ReadTimeout)
+	}
+	if cfg.Server.WriteTimeout != 30*time.Second {
+		t.Errorf("expected default writeTimeout 30s, got %v", cfg.Server.WriteTimeout)
+	}
+}
+
+func TestParseYAML_CustomServerSettings(t *testing.T) {
+	yaml := []byte(`
+server:
+  listen: ":9090"
+  readTimeout: 10s
+  writeTimeout: 15s
+  maxRequestBody: 1048576
+upstreams:
+  backend:
+    url: https://api.example.com
+routes:
+  - name: r
+    match:
+      pathPrefix: /
+    upstream: backend
+    policy:
+      kind: public
+`)
+	cfg, err := ParseYAML(yaml)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.Server.Listen != ":9090" {
+		t.Errorf("expected listen ':9090', got %q", cfg.Server.Listen)
+	}
+	if cfg.Server.ReadTimeout != 10*time.Second {
+		t.Errorf("expected readTimeout 10s, got %v", cfg.Server.ReadTimeout)
+	}
+	if cfg.Server.WriteTimeout != 15*time.Second {
+		t.Errorf("expected writeTimeout 15s, got %v", cfg.Server.WriteTimeout)
+	}
+	if cfg.Server.MaxRequestBody != 1048576 {
+		t.Errorf("expected maxRequestBody 1048576, got %d", cfg.Server.MaxRequestBody)
+	}
+}
+
+func TestParseYAML_EnvVarExpansion(t *testing.T) {
+	os.Setenv("TEST_UPSTREAM_URL", "https://env-api.example.com")
+	defer os.Unsetenv("TEST_UPSTREAM_URL")
+
+	yaml := []byte(`
+upstreams:
+  backend:
+    url: $TEST_UPSTREAM_URL
+routes:
+  - name: r
+    match:
+      pathPrefix: /
+    upstream: backend
+    policy:
+      kind: public
+`)
+	cfg, err := ParseYAML(yaml)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	upstream, ok := cfg.Upstreams["backend"]
+	if !ok {
+		t.Fatal("expected 'backend' upstream")
+	}
+	if upstream.URL != "https://env-api.example.com" {
+		t.Errorf("expected env-expanded URL, got %q", upstream.URL)
+	}
+}
+
+func TestParseYAML_InvalidYAML(t *testing.T) {
+	yaml := []byte(`{{{invalid yaml`)
+	_, err := ParseYAML(yaml)
+	if err == nil {
+		t.Error("expected error for invalid YAML")
+	}
+}
+
+func TestLoad_MissingFile(t *testing.T) {
+	_, err := Load("/nonexistent/path/config.yaml")
+	if err == nil {
+		t.Error("expected error for missing file")
+	}
+}
+
+func TestLoad_ValidFile(t *testing.T) {
+	content := `
+upstreams:
+  backend:
+    url: https://api.example.com
+routes:
+  - name: r
+    match:
+      pathPrefix: /
+    upstream: backend
+    policy:
+      kind: public
+`
+	tmpFile, err := os.CreateTemp("", "satgate-config-*.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(tmpFile.Name())
+
+	if _, err := tmpFile.WriteString(content); err != nil {
+		t.Fatal(err)
+	}
+	tmpFile.Close()
+
+	cfg, err := Load(tmpFile.Name())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(cfg.Routes) != 1 {
+		t.Errorf("expected 1 route, got %d", len(cfg.Routes))
+	}
+}
+
+// --- Validation tests ---
+
+func TestValidate_NoRoutes(t *testing.T) {
+	yaml := []byte(`
+upstreams:
+  backend:
+    url: https://api.example.com
+routes: []
+`)
+	_, err := ParseYAML(yaml)
+	if err == nil {
+		t.Error("expected error for no routes")
+	}
+}
+
+func TestValidate_RouteNoName(t *testing.T) {
+	yaml := []byte(`
+upstreams:
+  backend:
+    url: https://api.example.com
+routes:
+  - match:
+      pathPrefix: /
+    upstream: backend
+    policy:
+      kind: public
+`)
+	_, err := ParseYAML(yaml)
+	if err == nil {
+		t.Error("expected error for route with no name")
+	}
+}
+
+func TestValidate_RouteNoPathMatcher(t *testing.T) {
+	yaml := []byte(`
+upstreams:
+  backend:
+    url: https://api.example.com
+routes:
+  - name: bad-route
+    upstream: backend
+    policy:
+      kind: public
+`)
+	_, err := ParseYAML(yaml)
+	if err == nil {
+		t.Error("expected error for route with no path matcher")
+	}
+}
+
+func TestValidate_RouteNoPolicyKind(t *testing.T) {
+	yaml := []byte(`
+upstreams:
+  backend:
+    url: https://api.example.com
+routes:
+  - name: no-policy
+    match:
+      pathPrefix: /
+    upstream: backend
+`)
+	_, err := ParseYAML(yaml)
+	if err == nil {
+		t.Error("expected error for route with no policy kind")
+	}
+}
+
+func TestValidate_RouteUnknownUpstream(t *testing.T) {
+	yaml := []byte(`
+upstreams:
+  backend:
+    url: https://api.example.com
+routes:
+  - name: bad-upstream
+    match:
+      pathPrefix: /
+    upstream: nonexistent
+    policy:
+      kind: public
+`)
+	_, err := ParseYAML(yaml)
+	if err == nil {
+		t.Error("expected error for unknown upstream reference")
+	}
+}
+
+func TestValidate_UpstreamNoURL(t *testing.T) {
+	yaml := []byte(`
+upstreams:
+  backend:
+    timeout: 10s
+routes:
+  - name: r
+    match:
+      pathPrefix: /
+    upstream: backend
+    policy:
+      kind: public
+`)
+	_, err := ParseYAML(yaml)
+	if err == nil {
+		t.Error("expected error for upstream with no URL")
+	}
+}
+
+func TestValidate_UpstreamBadScheme(t *testing.T) {
+	yaml := []byte(`
+upstreams:
+  backend:
+    url: ftp://api.example.com
+routes:
+  - name: r
+    match:
+      pathPrefix: /
+    upstream: backend
+    policy:
+      kind: public
+`)
+	_, err := ParseYAML(yaml)
+	if err == nil {
+		t.Error("expected error for non-http/https scheme")
+	}
+}
+
+func TestValidate_UpstreamCredentialsInURL(t *testing.T) {
+	yaml := []byte(`
+upstreams:
+  backend:
+    url: https://user:pass@api.example.com
+routes:
+  - name: r
+    match:
+      pathPrefix: /
+    upstream: backend
+    policy:
+      kind: public
+`)
+	_, err := ParseYAML(yaml)
+	if err == nil {
+		t.Error("expected error for credentials in upstream URL")
+	}
+}
+
+func TestValidate_UpstreamPrivateIP(t *testing.T) {
+	tests := []struct {
+		name string
+		url  string
+	}{
+		{"loopback", "http://127.0.0.1/api"},
+		{"private_10", "http://10.0.0.1/api"},
+		{"private_172", "http://172.16.0.1/api"},
+		{"private_192", "http://192.168.1.1/api"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			yaml := []byte(`
+upstreams:
+  backend:
+    url: ` + tt.url + `
+routes:
+  - name: r
+    match:
+      pathPrefix: /
+    upstream: backend
+    policy:
+      kind: public
+`)
+			_, err := ParseYAML(yaml)
+			if err == nil {
+				t.Errorf("expected error for private IP %s", tt.url)
+			}
+		})
+	}
+}
+
+func TestValidate_UpstreamPublicDNS_OK(t *testing.T) {
+	// DNS hostnames (not IPs) should pass the SSRF check
+	yaml := []byte(`
+upstreams:
+  backend:
+    url: https://api.example.com
+routes:
+  - name: r
+    match:
+      pathPrefix: /
+    upstream: backend
+    policy:
+      kind: public
+`)
+	_, err := ParseYAML(yaml)
+	if err != nil {
+		t.Fatalf("unexpected error for public DNS upstream: %v", err)
+	}
+}
+
+func TestValidate_L402NoPriceError(t *testing.T) {
+	yaml := []byte(`
+upstreams:
+  backend:
+    url: https://api.example.com
+routes:
+  - name: paid
+    match:
+      pathPrefix: /
+    upstream: backend
+    policy:
+      kind: l402
+`)
+	_, err := ParseYAML(yaml)
+	if err == nil {
+		t.Error("expected error for l402 route with no price")
+	}
+}
+
+func TestValidate_L402WithPriceSats(t *testing.T) {
+	yaml := []byte(`
+upstreams:
+  backend:
+    url: https://api.example.com
+routes:
+  - name: paid
+    match:
+      pathPrefix: /
+    upstream: backend
+    policy:
+      kind: l402
+      priceSats: 100
+`)
+	cfg, err := ParseYAML(yaml)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.Routes[0].Policy.Pay == nil {
+		t.Error("expected synthesized Pay policy for l402")
+	}
+	if cfg.Routes[0].Policy.Pay.Price != 100 {
+		t.Errorf("expected price 100, got %f", cfg.Routes[0].Policy.Pay.Price)
+	}
+}
+
+func TestValidate_Fiat402NoPay(t *testing.T) {
+	yaml := []byte(`
+upstreams:
+  backend:
+    url: https://api.example.com
+routes:
+  - name: budget
+    match:
+      pathPrefix: /
+    upstream: backend
+    policy:
+      kind: fiat402
+`)
+	_, err := ParseYAML(yaml)
+	if err == nil {
+		t.Error("expected error for fiat402 route with no pay config")
+	}
+}
+
+func TestValidate_InvalidPathRegex(t *testing.T) {
+	yaml := []byte(`
+upstreams:
+  backend:
+    url: https://api.example.com
+routes:
+  - name: regex-route
+    match:
+      pathRegex: "[invalid"
+    upstream: backend
+    policy:
+      kind: public
+`)
+	_, err := ParseYAML(yaml)
+	if err == nil {
+		t.Error("expected error for invalid path regex")
+	}
+}
+
+func TestValidate_ValidPathRegex(t *testing.T) {
+	yaml := []byte(`
+upstreams:
+  backend:
+    url: https://api.example.com
+routes:
+  - name: regex-route
+    match:
+      pathRegex: "^/api/v[0-9]+/"
+    upstream: backend
+    policy:
+      kind: public
+`)
+	_, err := ParseYAML(yaml)
+	if err != nil {
+		t.Fatalf("unexpected error for valid regex: %v", err)
+	}
+}
+
+// --- NormalizePolicyKind tests ---
+
+func TestNormalizePolicyKind(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"observe", "chargeback"},
+		{"audit", "chargeback"},
+		{"control", "fiat402"},
+		{"budget", "fiat402"},
+		{"charge", "l402"},
+		{"monetize", "l402"},
+		{"protected", "capability"},
+		{"protect", "capability"},
+		// Pass-through
+		{"public", "public"},
+		{"l402", "l402"},
+		{"capability", "capability"},
+		{"chargeback", "chargeback"},
+		{"fiat402", "fiat402"},
+		{"deny", "deny"},
+		{"unknown", "unknown"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := NormalizePolicyKind(tt.input)
+			if got != tt.expected {
+				t.Errorf("NormalizePolicyKind(%q) = %q, want %q", tt.input, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestNormalizePayMode(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"observe", "chargeback"},
+		{"audit", "chargeback"},
+		{"control", "fiat402"},
+		{"budget", "fiat402"},
+		{"charge", "l402"},
+		{"monetize", "l402"},
+		{"l402", "l402"},
+		{"fiat402", "fiat402"},
+		{"chargeback", "chargeback"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := NormalizePayMode(tt.input)
+			if got != tt.expected {
+				t.Errorf("NormalizePayMode(%q) = %q, want %q", tt.input, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestIsBillingMode(t *testing.T) {
+	tests := []struct {
+		kind     string
+		expected bool
+	}{
+		{"chargeback", true},
+		{"fiat402", true},
+		{"l402", true},
+		{"observe", true},  // normalized to chargeback
+		{"audit", true},    // normalized to chargeback
+		{"control", true},  // normalized to fiat402
+		{"budget", true},   // normalized to fiat402
+		{"charge", true},   // normalized to l402
+		{"monetize", true}, // normalized to l402
+		{"public", false},
+		{"capability", false},
+		{"deny", false},
+		{"protected", false}, // normalized to capability
+	}
+	for _, tt := range tests {
+		t.Run(tt.kind, func(t *testing.T) {
+			got := IsBillingMode(tt.kind)
+			if got != tt.expected {
+				t.Errorf("IsBillingMode(%q) = %v, want %v", tt.kind, got, tt.expected)
+			}
+		})
+	}
+}
+
+// --- Route matching tests ---
+
+func TestRouteMatches_PathPrefix(t *testing.T) {
+	route := Route{
+		Name:  "prefix",
+		Match: RouteMatch{PathPrefix: "/api/"},
+	}
+	tests := []struct {
+		path   string
+		method string
+		want   bool
+	}{
+		{"/api/users", "GET", true},
+		{"/api/", "POST", true},
+		{"/api/v1/data", "GET", true},
+		{"/other", "GET", false},
+		{"/", "GET", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.path, func(t *testing.T) {
+			got := route.Matches(tt.path, tt.method)
+			if got != tt.want {
+				t.Errorf("route.Matches(%q, %q) = %v, want %v", tt.path, tt.method, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRouteMatches_PathExact(t *testing.T) {
+	route := Route{
+		Name:  "exact",
+		Match: RouteMatch{PathExact: "/health"},
+	}
+	tests := []struct {
+		path string
+		want bool
+	}{
+		{"/health", true},
+		{"/health/", false},
+		{"/healthz", false},
+		{"/", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.path, func(t *testing.T) {
+			got := route.Matches(tt.path, "GET")
+			if got != tt.want {
+				t.Errorf("route.Matches(%q) = %v, want %v", tt.path, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRouteMatches_PathRegex(t *testing.T) {
+	route := Route{
+		Name: "regex",
+		Match: RouteMatch{
+			PathRegex: `^/api/v\d+/`,
+		},
+	}
+	if err := route.CompileRegex(); err != nil {
+		t.Fatal(err)
+	}
+	tests := []struct {
+		path string
+		want bool
+	}{
+		{"/api/v1/users", true},
+		{"/api/v2/data", true},
+		{"/api/v10/stuff", true},
+		{"/api/vX/nope", false},
+		{"/other", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.path, func(t *testing.T) {
+			got := route.Matches(tt.path, "GET")
+			if got != tt.want {
+				t.Errorf("route.Matches(%q) = %v, want %v", tt.path, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRouteMatches_Methods(t *testing.T) {
+	route := Route{
+		Name: "methods",
+		Match: RouteMatch{
+			PathPrefix: "/api/",
+			Methods:    []string{"GET", "POST"},
+		},
+	}
+	tests := []struct {
+		method string
+		want   bool
+	}{
+		{"GET", true},
+		{"POST", true},
+		{"get", true},   // case insensitive
+		{"post", true},  // case insensitive
+		{"PUT", false},
+		{"DELETE", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.method, func(t *testing.T) {
+			got := route.Matches("/api/test", tt.method)
+			if got != tt.want {
+				t.Errorf("route.Matches with method %q = %v, want %v", tt.method, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRouteMatchesWithHeaders_ExactMatch(t *testing.T) {
+	route := Route{
+		Name: "headers",
+		Match: RouteMatch{
+			PathPrefix: "/",
+			Headers: map[string]string{
+				"Content-Type": "application/json",
+			},
+		},
+	}
+	tests := []struct {
+		name    string
+		headers map[string]string
+		want    bool
+	}{
+		{"exact match", map[string]string{"Content-Type": "application/json"}, true},
+		{"wrong value", map[string]string{"Content-Type": "text/html"}, false},
+		{"missing header", map[string]string{}, false},
+		{"nil headers (skips check)", nil, true},
+		{"case insensitive key", map[string]string{"content-type": "application/json"}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := route.MatchesWithHeaders("/test", "GET", tt.headers)
+			if got != tt.want {
+				t.Errorf("got %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRouteMatchesWithHeaders_RegexPattern(t *testing.T) {
+	route := Route{
+		Name: "regex-header",
+		Match: RouteMatch{
+			PathPrefix: "/",
+			Headers: map[string]string{
+				"Content-Type": "~application/(json|xml)",
+			},
+		},
+	}
+	tests := []struct {
+		name    string
+		headers map[string]string
+		want    bool
+	}{
+		{"json", map[string]string{"Content-Type": "application/json"}, true},
+		{"xml", map[string]string{"Content-Type": "application/xml"}, true},
+		{"text", map[string]string{"Content-Type": "text/plain"}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := route.MatchesWithHeaders("/test", "GET", tt.headers)
+			if got != tt.want {
+				t.Errorf("got %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGetRoute(t *testing.T) {
+	cfg := &Config{
+		Routes: []Route{
+			{Name: "exact", Match: RouteMatch{PathExact: "/health"}, Policy: RoutePolicy{Kind: "public"}},
+			{Name: "api", Match: RouteMatch{PathPrefix: "/api/"}, Policy: RoutePolicy{Kind: "capability"}},
+			{Name: "catch-all", Match: RouteMatch{PathPrefix: "/"}, Policy: RoutePolicy{Kind: "public"}},
+		},
+	}
+	tests := []struct {
+		path     string
+		method   string
+		wantName string
+		wantNil  bool
+	}{
+		{"/health", "GET", "exact", false},
+		{"/api/users", "GET", "api", false},
+		{"/other", "GET", "catch-all", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.path, func(t *testing.T) {
+			route := cfg.GetRoute(tt.path, tt.method)
+			if tt.wantNil {
+				if route != nil {
+					t.Errorf("expected nil route, got %v", route.Name)
+				}
+				return
+			}
+			if route == nil {
+				t.Fatal("expected route, got nil")
+			}
+			if route.Name != tt.wantName {
+				t.Errorf("expected route %q, got %q", tt.wantName, route.Name)
+			}
+		})
+	}
+}
+
+func TestGetRouteWithHeaders(t *testing.T) {
+	cfg := &Config{
+		Routes: []Route{
+			{
+				Name: "json-api",
+				Match: RouteMatch{
+					PathPrefix: "/api/",
+					Headers:    map[string]string{"Accept": "application/json"},
+				},
+				Policy: RoutePolicy{Kind: "public"},
+			},
+			{
+				Name:   "api-fallback",
+				Match:  RouteMatch{PathPrefix: "/api/"},
+				Policy: RoutePolicy{Kind: "public"},
+			},
+		},
+	}
+
+	// With matching header → first route
+	route := cfg.GetRouteWithHeaders("/api/test", "GET", map[string]string{"Accept": "application/json"})
+	if route == nil || route.Name != "json-api" {
+		t.Errorf("expected 'json-api', got %v", route)
+	}
+
+	// Without header → fallback
+	route = cfg.GetRouteWithHeaders("/api/test", "GET", map[string]string{})
+	if route == nil || route.Name != "api-fallback" {
+		t.Errorf("expected 'api-fallback', got %v", route)
+	}
+}
+
+// --- Policy normalization during validation ---
+
+func TestValidate_PolicyNormalization(t *testing.T) {
+	tests := []struct {
+		inputKind    string
+		expectedKind string
+	}{
+		{"protect", "capability"},
+		{"protected", "capability"},
+		{"audit", "chargeback"},
+		{"observe", "chargeback"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.inputKind, func(t *testing.T) {
+			yaml := []byte(`
+upstreams:
+  backend:
+    url: https://api.example.com
+routes:
+  - name: normalized
+    match:
+      pathPrefix: /
+    upstream: backend
+    policy:
+      kind: ` + tt.inputKind + `
+`)
+			cfg, err := ParseYAML(yaml)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if cfg.Routes[0].Policy.Kind != tt.expectedKind {
+				t.Errorf("expected normalized kind %q, got %q", tt.expectedKind, cfg.Routes[0].Policy.Kind)
+			}
+		})
+	}
+}
+
+func TestValidate_ChargebackSynthesizesPay(t *testing.T) {
+	yaml := []byte(`
+upstreams:
+  backend:
+    url: https://api.example.com
+routes:
+  - name: audit-route
+    match:
+      pathPrefix: /
+    upstream: backend
+    policy:
+      kind: audit
+`)
+	cfg, err := ParseYAML(yaml)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.Routes[0].Policy.Pay == nil {
+		t.Error("expected synthesized Pay policy for chargeback")
+	}
+	if cfg.Routes[0].Policy.Pay.Mode != "chargeback" {
+		t.Errorf("expected mode 'chargeback', got %q", cfg.Routes[0].Policy.Pay.Mode)
+	}
+}
+
+// --- isPrivateIP tests ---
+
+func TestIsPrivateIP(t *testing.T) {
+	tests := []struct {
+		host    string
+		private bool
+	}{
+		{"127.0.0.1", true},
+		{"10.0.0.1", true},
+		{"172.16.0.1", true},
+		{"192.168.1.1", true},
+		{"169.254.1.1", true},   // link-local
+		{"8.8.8.8", false},      // public
+		{"1.1.1.1", false},      // public
+		{"example.com", false},  // DNS name, not IP
+	}
+	for _, tt := range tests {
+		t.Run(tt.host, func(t *testing.T) {
+			got := isPrivateIP(tt.host)
+			if got != tt.private {
+				t.Errorf("isPrivateIP(%q) = %v, want %v", tt.host, got, tt.private)
+			}
+		})
+	}
+}
+
+// --- parseURL tests ---
+
+func TestParseURL(t *testing.T) {
+	tests := []struct {
+		url       string
+		scheme    string
+		host      string
+		hasUser   bool
+		wantErr   bool
+	}{
+		{"https://api.example.com", "https", "api.example.com", false, false},
+		{"http://api.example.com:8080/path", "http", "api.example.com:8080", false, false},
+		{"https://user:pass@api.example.com", "https", "api.example.com", true, false},
+		{"noscheme", "", "", false, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.url, func(t *testing.T) {
+			parsed, err := parseURL(tt.url)
+			if tt.wantErr {
+				if err == nil {
+					t.Error("expected error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if parsed.Scheme != tt.scheme {
+				t.Errorf("expected scheme %q, got %q", tt.scheme, parsed.Scheme)
+			}
+			if parsed.Host != tt.host {
+				t.Errorf("expected host %q, got %q", tt.host, parsed.Host)
+			}
+			if tt.hasUser && parsed.User == nil {
+				t.Error("expected user info")
+			}
+			if !tt.hasUser && parsed.User != nil {
+				t.Error("did not expect user info")
+			}
+		})
+	}
+}
+
+// --- Multiple upstreams and routes ---
+
+func TestParseYAML_MultipleUpstreamsAndRoutes(t *testing.T) {
+	yaml := []byte(`
+upstreams:
+  openai:
+    url: https://api.openai.com
+    timeout: 30s
+    headers:
+      Authorization: "Bearer sk-test"
+  anthropic:
+    url: https://api.anthropic.com
+    timeout: 60s
+routes:
+  - name: openai-route
+    match:
+      pathPrefix: /openai/
+    upstream: openai
+    stripPrefix: true
+    policy:
+      kind: capability
+  - name: anthropic-route
+    match:
+      pathPrefix: /anthropic/
+    upstream: anthropic
+    policy:
+      kind: l402
+      priceSats: 50
+`)
+	cfg, err := ParseYAML(yaml)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(cfg.Upstreams) != 2 {
+		t.Errorf("expected 2 upstreams, got %d", len(cfg.Upstreams))
+	}
+	if len(cfg.Routes) != 2 {
+		t.Errorf("expected 2 routes, got %d", len(cfg.Routes))
+	}
+	if cfg.Routes[0].StripPrefix != true {
+		t.Error("expected stripPrefix true on first route")
+	}
+	openai := cfg.Upstreams["openai"]
+	if openai.Timeout != 30*time.Second {
+		t.Errorf("expected openai timeout 30s, got %v", openai.Timeout)
+	}
+	if openai.Headers["Authorization"] != "Bearer sk-test" {
+		t.Errorf("expected Authorization header, got %q", openai.Headers["Authorization"])
+	}
+}
+
+// --- CompileRegex ---
+
+func TestCompileRegex_EmptyIsNoop(t *testing.T) {
+	route := &Route{Name: "no-regex", Match: RouteMatch{PathPrefix: "/"}}
+	if err := route.CompileRegex(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestCompileRegex_Invalid(t *testing.T) {
+	route := &Route{Name: "bad-regex", Match: RouteMatch{PathRegex: "[invalid"}}
+	if err := route.CompileRegex(); err == nil {
+		t.Error("expected error for invalid regex")
+	}
+}
+
+// --- Upstream with optional fields ---
+
+func TestParseYAML_UpstreamWithHealthCheck(t *testing.T) {
+	yaml := []byte(`
+upstreams:
+  backend:
+    url: https://api.example.com
+    healthCheck:
+      path: /health
+      interval: 10s
+      timeout: 5s
+    circuitBreaker:
+      maxFailures: 5
+      resetTimeout: 30s
+      halfOpenMaxReqs: 2
+routes:
+  - name: r
+    match:
+      pathPrefix: /
+    upstream: backend
+    policy:
+      kind: public
+`)
+	cfg, err := ParseYAML(yaml)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	backend := cfg.Upstreams["backend"]
+	if backend.HealthCheck == nil {
+		t.Fatal("expected health check config")
+	}
+	if backend.HealthCheck.Path != "/health" {
+		t.Errorf("expected health check path '/health', got %q", backend.HealthCheck.Path)
+	}
+	if backend.CircuitBreaker == nil {
+		t.Fatal("expected circuit breaker config")
+	}
+	if backend.CircuitBreaker.MaxFailures != 5 {
+		t.Errorf("expected maxFailures 5, got %d", backend.CircuitBreaker.MaxFailures)
+	}
+}
+
+// --- Route with transform and rate limit ---
+
+func TestParseYAML_RouteTransformAndRateLimit(t *testing.T) {
+	yaml := []byte(`
+upstreams:
+  backend:
+    url: https://api.example.com
+routes:
+  - name: transformed
+    match:
+      pathPrefix: /api/
+    upstream: backend
+    policy:
+      kind: public
+    transform:
+      stripPrefix: /api
+      addHeaders:
+        X-Gateway: satgate
+    rateLimit:
+      requestsPerMinute: 100
+      burstSize: 10
+      key: ip
+`)
+	cfg, err := ParseYAML(yaml)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	route := cfg.Routes[0]
+	if route.Transform == nil {
+		t.Fatal("expected transform config")
+	}
+	if route.Transform.StripPrefix != "/api" {
+		t.Errorf("expected stripPrefix '/api', got %q", route.Transform.StripPrefix)
+	}
+	if route.Transform.AddHeaders["X-Gateway"] != "satgate" {
+		t.Errorf("expected X-Gateway header 'satgate'")
+	}
+	if route.RateLimit == nil {
+		t.Fatal("expected rate limit config")
+	}
+	if route.RateLimit.RequestsPerMinute != 100 {
+		t.Errorf("expected 100 rpm, got %d", route.RateLimit.RequestsPerMinute)
+	}
+}

--- a/pkg/proxy/proxy_oss_test.go
+++ b/pkg/proxy/proxy_oss_test.go
@@ -1,0 +1,1069 @@
+package proxy
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/satgate-io/satgate/pkg/config"
+	"github.com/satgate-io/satgate/pkg/governance"
+	"github.com/satgate-io/satgate/pkg/lightning"
+	"github.com/satgate-io/satgate/pkg/macaroon"
+)
+
+// --- helpers ---
+
+func newTestMacaroonService(t *testing.T) *macaroon.Service {
+	t.Helper()
+	svc, err := macaroon.NewService("test-secret-key-for-tests")
+	if err != nil {
+		t.Fatalf("failed to create macaroon service: %v", err)
+	}
+	return svc
+}
+
+func newTestGateway(t *testing.T, cfg *config.Config) *Gateway {
+	t.Helper()
+	macSvc := newTestMacaroonService(t)
+	govSvc := governance.NewService(nil)
+	mockLN := lightning.NewMockProvider()
+
+	gw, err := New(Options{
+		Config:     cfg,
+		Macaroon:   macSvc,
+		Governance: govSvc,
+		Lightning:  mockLN,
+	})
+	if err != nil {
+		t.Fatalf("failed to create gateway: %v", err)
+	}
+	return gw
+}
+
+func newTestGatewayWithUpstream(t *testing.T, upstream *httptest.Server, policyKind string) (*Gateway, *config.Config) {
+	t.Helper()
+	cfg := &config.Config{
+		Server: config.ServerConfig{Listen: ":8080"},
+		Admin:  config.AdminConfig{Token: "admin-secret"},
+		Upstreams: map[string]config.Upstream{
+			"backend": {URL: upstream.URL, Timeout: 10 * time.Second},
+		},
+		Routes: []config.Route{
+			{
+				Name:     "test-route",
+				Match:    config.RouteMatch{PathPrefix: "/api/"},
+				Upstream: "backend",
+				Policy:   config.RoutePolicy{Kind: policyKind},
+			},
+		},
+	}
+	gw := newTestGateway(t, cfg)
+	return gw, cfg
+}
+
+// --- New() constructor tests ---
+
+func TestNew_RequiresConfig(t *testing.T) {
+	macSvc := newTestMacaroonService(t)
+	_, err := New(Options{Macaroon: macSvc})
+	if err == nil {
+		t.Error("expected error when config is nil")
+	}
+}
+
+func TestNew_RequiresMacaroon(t *testing.T) {
+	cfg := &config.Config{
+		Upstreams: map[string]config.Upstream{},
+		Routes:    []config.Route{},
+	}
+	_, err := New(Options{Config: cfg})
+	if err == nil {
+		t.Error("expected error when macaroon service is nil")
+	}
+}
+
+func TestNew_CreatesProxies(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	cfg := &config.Config{
+		Upstreams: map[string]config.Upstream{
+			"backend": {URL: upstream.URL},
+		},
+		Routes: []config.Route{},
+	}
+	macSvc := newTestMacaroonService(t)
+	gw, err := New(Options{Config: cfg, Macaroon: macSvc})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, ok := gw.proxies["backend"]; !ok {
+		t.Error("expected proxy for 'backend' upstream")
+	}
+}
+
+// --- Health endpoint tests ---
+
+func TestHealthEndpoint(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	defer upstream.Close()
+
+	gw, _ := newTestGatewayWithUpstream(t, upstream, "public")
+
+	for _, path := range []string{"/health", "/healthz"} {
+		t.Run(path, func(t *testing.T) {
+			req := httptest.NewRequest("GET", path, nil)
+			w := httptest.NewRecorder()
+			gw.ServeHTTP(w, req)
+
+			if w.Code != http.StatusOK {
+				t.Errorf("expected 200, got %d", w.Code)
+			}
+			var body map[string]interface{}
+			if err := json.NewDecoder(w.Body).Decode(&body); err != nil {
+				t.Fatalf("failed to decode response: %v", err)
+			}
+			if body["status"] != "healthy" {
+				t.Errorf("expected status 'healthy', got %v", body["status"])
+			}
+		})
+	}
+}
+
+// --- CORS tests ---
+
+func TestCORSHeaders(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	defer upstream.Close()
+
+	gw, _ := newTestGatewayWithUpstream(t, upstream, "public")
+
+	req := httptest.NewRequest("GET", "/api/test", nil)
+	req.Header.Set("Origin", "https://example.com")
+	w := httptest.NewRecorder()
+	gw.ServeHTTP(w, req)
+
+	if w.Header().Get("Access-Control-Allow-Origin") != "https://example.com" {
+		t.Error("expected Access-Control-Allow-Origin to match origin")
+	}
+}
+
+func TestCORSPreflight(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	defer upstream.Close()
+
+	gw, _ := newTestGatewayWithUpstream(t, upstream, "public")
+
+	req := httptest.NewRequest("OPTIONS", "/api/test", nil)
+	req.Header.Set("Origin", "https://example.com")
+	w := httptest.NewRecorder()
+	gw.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNoContent {
+		t.Errorf("expected 204 for OPTIONS, got %d", w.Code)
+	}
+}
+
+// --- Route matching ---
+
+func TestNoMatchingRoute_Returns404(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	defer upstream.Close()
+
+	gw, _ := newTestGatewayWithUpstream(t, upstream, "public")
+
+	req := httptest.NewRequest("GET", "/no-match", nil)
+	w := httptest.NewRecorder()
+	gw.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Errorf("expected 404, got %d", w.Code)
+	}
+}
+
+// --- Public policy proxying ---
+
+func TestPublicPolicy_ProxiesRequest(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(map[string]string{"proxied": "true", "path": r.URL.Path})
+	}))
+	defer upstream.Close()
+
+	gw, _ := newTestGatewayWithUpstream(t, upstream, "public")
+
+	req := httptest.NewRequest("GET", "/api/data", nil)
+	w := httptest.NewRecorder()
+	gw.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	var body map[string]string
+	json.NewDecoder(w.Body).Decode(&body)
+	if body["proxied"] != "true" {
+		t.Error("expected proxied response")
+	}
+}
+
+// --- Capability policy tests ---
+
+func TestCapabilityPolicy_NoToken_Returns401(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	gw, _ := newTestGatewayWithUpstream(t, upstream, "capability")
+
+	req := httptest.NewRequest("GET", "/api/test", nil)
+	w := httptest.NewRecorder()
+	gw.ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("expected 401, got %d", w.Code)
+	}
+	if w.Header().Get("WWW-Authenticate") == "" {
+		t.Error("expected WWW-Authenticate header")
+	}
+}
+
+func TestCapabilityPolicy_InvalidToken_Returns401(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	gw, _ := newTestGatewayWithUpstream(t, upstream, "capability")
+
+	req := httptest.NewRequest("GET", "/api/test", nil)
+	req.Header.Set("Authorization", "Bearer invalid-token-garbage")
+	w := httptest.NewRecorder()
+	gw.ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("expected 401, got %d", w.Code)
+	}
+}
+
+func TestCapabilityPolicy_ValidToken_Proxies(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"ok":true}`))
+	}))
+	defer upstream.Close()
+
+	gw, _ := newTestGatewayWithUpstream(t, upstream, "capability")
+	macSvc := gw.macaroonSvc
+
+	// Mint a valid token
+	mac, err := macSvc.Mint("api:read", time.Now().Add(1*time.Hour))
+	if err != nil {
+		t.Fatal(err)
+	}
+	token := macSvc.Encode(mac)
+
+	req := httptest.NewRequest("GET", "/api/test", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	w := httptest.NewRecorder()
+	gw.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d; body: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestCapabilityPolicy_BannedToken_Returns401(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	gw, _ := newTestGatewayWithUpstream(t, upstream, "capability")
+	macSvc := gw.macaroonSvc
+
+	mac, err := macSvc.Mint("api:read", time.Now().Add(1*time.Hour))
+	if err != nil {
+		t.Fatal(err)
+	}
+	token := macSvc.Encode(mac)
+
+	// Ban the token
+	gw.governance.Ban(mac.Signature, "test ban", "admin")
+
+	req := httptest.NewRequest("GET", "/api/test", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	w := httptest.NewRecorder()
+	gw.ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("expected 401 for banned token, got %d", w.Code)
+	}
+}
+
+func TestCapabilityPolicy_ScopeEnforcement(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	cfg := &config.Config{
+		Server: config.ServerConfig{Listen: ":8080"},
+		Admin:  config.AdminConfig{Token: "admin-secret"},
+		Upstreams: map[string]config.Upstream{
+			"backend": {URL: upstream.URL},
+		},
+		Routes: []config.Route{
+			{
+				Name:     "scoped",
+				Match:    config.RouteMatch{PathPrefix: "/api/"},
+				Upstream: "backend",
+				Policy: config.RoutePolicy{
+					Kind:  "capability",
+					Scope: "api:admin",
+				},
+			},
+		},
+	}
+	gw := newTestGateway(t, cfg)
+	macSvc := gw.macaroonSvc
+
+	// Token with wrong scope
+	mac, _ := macSvc.Mint("api:read", time.Now().Add(1*time.Hour))
+	token := macSvc.Encode(mac)
+
+	req := httptest.NewRequest("GET", "/api/test", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	w := httptest.NewRecorder()
+	gw.ServeHTTP(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Errorf("expected 403 for wrong scope, got %d", w.Code)
+	}
+}
+
+// --- L402 policy tests ---
+
+func TestL402Policy_NoToken_Returns402(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	cfg := &config.Config{
+		Server: config.ServerConfig{Listen: ":8080"},
+		Admin:  config.AdminConfig{Token: "admin-secret"},
+		Upstreams: map[string]config.Upstream{
+			"backend": {URL: upstream.URL},
+		},
+		Routes: []config.Route{
+			{
+				Name:     "paid",
+				Match:    config.RouteMatch{PathPrefix: "/api/"},
+				Upstream: "backend",
+				Policy: config.RoutePolicy{
+					Kind:      "l402",
+					PriceSats: 100,
+				},
+			},
+		},
+	}
+	gw := newTestGateway(t, cfg)
+
+	req := httptest.NewRequest("GET", "/api/test", nil)
+	w := httptest.NewRecorder()
+	gw.ServeHTTP(w, req)
+
+	if w.Code != http.StatusPaymentRequired {
+		t.Errorf("expected 402, got %d", w.Code)
+	}
+	authHeader := w.Header().Get("WWW-Authenticate")
+	if !strings.Contains(authHeader, "L402") {
+		t.Error("expected L402 challenge in WWW-Authenticate")
+	}
+	if !strings.Contains(authHeader, "macaroon=") {
+		t.Error("expected macaroon in L402 challenge")
+	}
+	if !strings.Contains(authHeader, "invoice=") {
+		t.Error("expected invoice in L402 challenge")
+	}
+}
+
+// --- StripPrefix tests ---
+
+func TestStripPrefix_RemovesPrefixBeforeProxying(t *testing.T) {
+	var receivedPath string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedPath = r.URL.Path
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	cfg := &config.Config{
+		Server: config.ServerConfig{Listen: ":8080"},
+		Upstreams: map[string]config.Upstream{
+			"backend": {URL: upstream.URL},
+		},
+		Routes: []config.Route{
+			{
+				Name:        "stripped",
+				Match:       config.RouteMatch{PathPrefix: "/gateway/api/"},
+				Upstream:    "backend",
+				StripPrefix: true,
+				Policy:      config.RoutePolicy{Kind: "public"},
+			},
+		},
+	}
+	gw := newTestGateway(t, cfg)
+
+	req := httptest.NewRequest("GET", "/gateway/api/v1/users", nil)
+	w := httptest.NewRecorder()
+	gw.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	if receivedPath != "/v1/users" {
+		t.Errorf("expected upstream path '/v1/users', got %q", receivedPath)
+	}
+}
+
+func TestStripPrefix_WithWildcard(t *testing.T) {
+	var receivedPath string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedPath = r.URL.Path
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	cfg := &config.Config{
+		Server: config.ServerConfig{Listen: ":8080"},
+		Upstreams: map[string]config.Upstream{
+			"backend": {URL: upstream.URL},
+		},
+		Routes: []config.Route{
+			{
+				Name:        "wildcard-strip",
+				Match:       config.RouteMatch{PathPrefix: "/gw/*"},
+				Upstream:    "backend",
+				StripPrefix: true,
+				Policy:      config.RoutePolicy{Kind: "public"},
+			},
+		},
+	}
+	gw := newTestGateway(t, cfg)
+
+	req := httptest.NewRequest("GET", "/gw/hello/world", nil)
+	w := httptest.NewRecorder()
+	gw.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	if receivedPath != "/hello/world" {
+		t.Errorf("expected upstream path '/hello/world', got %q", receivedPath)
+	}
+}
+
+// --- Rewrite tests ---
+
+func TestRewrite_OverridesPath(t *testing.T) {
+	var receivedPath string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedPath = r.URL.Path
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	cfg := &config.Config{
+		Server: config.ServerConfig{Listen: ":8080"},
+		Upstreams: map[string]config.Upstream{
+			"backend": {URL: upstream.URL},
+		},
+		Routes: []config.Route{
+			{
+				Name:     "rewrite",
+				Match:    config.RouteMatch{PathPrefix: "/old-api/"},
+				Upstream: "backend",
+				Rewrite:  "/v2/new-endpoint",
+				Policy:   config.RoutePolicy{Kind: "public"},
+			},
+		},
+	}
+	gw := newTestGateway(t, cfg)
+
+	req := httptest.NewRequest("GET", "/old-api/anything", nil)
+	w := httptest.NewRecorder()
+	gw.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	if receivedPath != "/v2/new-endpoint" {
+		t.Errorf("expected rewrite path '/v2/new-endpoint', got %q", receivedPath)
+	}
+}
+
+// --- Upstream error handling ---
+
+func TestUpstreamDown_Returns502(t *testing.T) {
+	// Create a server and immediately close it so the upstream is unreachable
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	upstreamURL := upstream.URL
+	upstream.Close()
+
+	cfg := &config.Config{
+		Server: config.ServerConfig{Listen: ":8080"},
+		Upstreams: map[string]config.Upstream{
+			"backend": {URL: upstreamURL},
+		},
+		Routes: []config.Route{
+			{
+				Name:     "dead-upstream",
+				Match:    config.RouteMatch{PathPrefix: "/api/"},
+				Upstream: "backend",
+				Policy:   config.RoutePolicy{Kind: "public"},
+			},
+		},
+	}
+	gw := newTestGateway(t, cfg)
+
+	req := httptest.NewRequest("GET", "/api/test", nil)
+	w := httptest.NewRecorder()
+	gw.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadGateway {
+		t.Errorf("expected 502, got %d", w.Code)
+	}
+}
+
+func TestNoUpstreamConfigured_Returns502(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	defer upstream.Close()
+
+	cfg := &config.Config{
+		Server: config.ServerConfig{Listen: ":8080"},
+		Upstreams: map[string]config.Upstream{
+			"backend": {URL: upstream.URL},
+		},
+		Routes: []config.Route{
+			{
+				Name:     "no-upstream",
+				Match:    config.RouteMatch{PathPrefix: "/api/"},
+				Upstream: "", // no upstream set
+				Policy:   config.RoutePolicy{Kind: "public"},
+			},
+		},
+	}
+	gw := newTestGateway(t, cfg)
+
+	req := httptest.NewRequest("GET", "/api/test", nil)
+	w := httptest.NewRecorder()
+	gw.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadGateway {
+		t.Errorf("expected 502, got %d", w.Code)
+	}
+}
+
+// --- Unknown policy in OSS ---
+
+func TestUnknownPolicy_Returns501(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	defer upstream.Close()
+
+	cfg := &config.Config{
+		Server: config.ServerConfig{Listen: ":8080"},
+		Upstreams: map[string]config.Upstream{
+			"backend": {URL: upstream.URL},
+		},
+		Routes: []config.Route{
+			{
+				Name:     "enterprise",
+				Match:    config.RouteMatch{PathPrefix: "/api/"},
+				Upstream: "backend",
+				Policy:   config.RoutePolicy{Kind: "some-enterprise-feature"},
+			},
+		},
+	}
+	gw := newTestGateway(t, cfg)
+
+	req := httptest.NewRequest("GET", "/api/test", nil)
+	w := httptest.NewRecorder()
+	gw.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotImplemented {
+		t.Errorf("expected 501, got %d", w.Code)
+	}
+}
+
+// --- Check payment endpoint ---
+
+func TestCheckPayment_InvalidHash(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	defer upstream.Close()
+
+	gw, _ := newTestGatewayWithUpstream(t, upstream, "public")
+
+	req := httptest.NewRequest("GET", "/check-payment/tooshort", nil)
+	w := httptest.NewRecorder()
+	gw.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestCheckPayment_ValidHash_NotPaid(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	defer upstream.Close()
+
+	gw, _ := newTestGatewayWithUpstream(t, upstream, "public")
+
+	hash := "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2"
+	req := httptest.NewRequest("GET", "/check-payment/"+hash, nil)
+	w := httptest.NewRecorder()
+	gw.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d", w.Code)
+	}
+	var body map[string]interface{}
+	json.NewDecoder(w.Body).Decode(&body)
+	if body["paid"] != false {
+		t.Errorf("expected paid=false, got %v", body["paid"])
+	}
+}
+
+// --- Capability mint endpoint ---
+
+func TestCapabilityMint_NoAdminToken_Returns401(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	defer upstream.Close()
+
+	gw, _ := newTestGatewayWithUpstream(t, upstream, "public")
+
+	body := strings.NewReader(`{"scope":"api:read","duration":"1h"}`)
+	req := httptest.NewRequest("POST", "/api/capability/mint", body)
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	gw.ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("expected 401, got %d", w.Code)
+	}
+}
+
+func TestCapabilityMint_ValidAdmin_MintsToken(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	defer upstream.Close()
+
+	gw, _ := newTestGatewayWithUpstream(t, upstream, "public")
+
+	body := strings.NewReader(`{"scope":"api:read","duration":"1h"}`)
+	req := httptest.NewRequest("POST", "/api/capability/mint", body)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Admin-Token", "admin-secret")
+	w := httptest.NewRecorder()
+	gw.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d; body: %s", w.Code, w.Body.String())
+	}
+	var resp map[string]interface{}
+	json.NewDecoder(w.Body).Decode(&resp)
+	if _, ok := resp["token"]; !ok {
+		t.Error("expected 'token' in response")
+	}
+	if resp["scope"] != "api:read" {
+		t.Errorf("expected scope 'api:read', got %v", resp["scope"])
+	}
+}
+
+// --- Capability validate endpoint ---
+
+func TestCapabilityValidate_ValidToken(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	defer upstream.Close()
+
+	gw, _ := newTestGatewayWithUpstream(t, upstream, "public")
+	macSvc := gw.macaroonSvc
+
+	mac, _ := macSvc.Mint("api:read", time.Now().Add(1*time.Hour))
+	token := macSvc.Encode(mac)
+
+	body := strings.NewReader(`{"token":"` + token + `"}`)
+	req := httptest.NewRequest("POST", "/api/capability/validate", body)
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	gw.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d; body: %s", w.Code, w.Body.String())
+	}
+	var resp map[string]interface{}
+	json.NewDecoder(w.Body).Decode(&resp)
+	if resp["valid"] != true {
+		t.Errorf("expected valid=true, got %v", resp["valid"])
+	}
+}
+
+func TestCapabilityValidate_InvalidToken(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	defer upstream.Close()
+
+	gw, _ := newTestGatewayWithUpstream(t, upstream, "public")
+
+	body := strings.NewReader(`{"token":"garbage"}`)
+	req := httptest.NewRequest("POST", "/api/capability/validate", body)
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	gw.ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("expected 401, got %d", w.Code)
+	}
+}
+
+// --- Capability delegate endpoint ---
+
+func TestCapabilityDelegate_Success(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	defer upstream.Close()
+
+	gw, _ := newTestGatewayWithUpstream(t, upstream, "public")
+	macSvc := gw.macaroonSvc
+
+	parent, _ := macSvc.Mint("api:*", time.Now().Add(1*time.Hour))
+	parentToken := macSvc.Encode(parent)
+
+	body := strings.NewReader(`{"parentToken":"` + parentToken + `","caveats":["scope = api:read"]}`)
+	req := httptest.NewRequest("POST", "/api/capability/delegate", body)
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	gw.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d; body: %s", w.Code, w.Body.String())
+	}
+	var resp map[string]interface{}
+	json.NewDecoder(w.Body).Decode(&resp)
+	if _, ok := resp["token"]; !ok {
+		t.Error("expected 'token' in delegation response")
+	}
+}
+
+// --- Capability ping endpoint ---
+
+func TestCapabilityPing_NoAuth_Returns401(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	defer upstream.Close()
+
+	gw, _ := newTestGatewayWithUpstream(t, upstream, "public")
+
+	req := httptest.NewRequest("GET", "/api/capability/ping", nil)
+	w := httptest.NewRecorder()
+	gw.ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("expected 401, got %d", w.Code)
+	}
+}
+
+func TestCapabilityPing_ValidToken_ReturnsOK(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	defer upstream.Close()
+
+	gw, _ := newTestGatewayWithUpstream(t, upstream, "public")
+	macSvc := gw.macaroonSvc
+
+	mac, _ := macSvc.Mint("api:read", time.Now().Add(1*time.Hour))
+	token := macSvc.Encode(mac)
+
+	req := httptest.NewRequest("GET", "/api/capability/ping", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	w := httptest.NewRecorder()
+	gw.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d; body: %s", w.Code, w.Body.String())
+	}
+}
+
+// --- Governance ban endpoint ---
+
+func TestGovernanceBan_NoAdmin_Returns401(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	defer upstream.Close()
+
+	gw, _ := newTestGatewayWithUpstream(t, upstream, "public")
+
+	body := strings.NewReader(`{"tokenSignature":"abc123","reason":"test"}`)
+	req := httptest.NewRequest("POST", "/api/governance/ban", body)
+	w := httptest.NewRecorder()
+	gw.ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("expected 401, got %d", w.Code)
+	}
+}
+
+func TestGovernanceBan_Valid(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	defer upstream.Close()
+
+	gw, _ := newTestGatewayWithUpstream(t, upstream, "public")
+
+	body := strings.NewReader(`{"tokenSignature":"abc123def456","reason":"compromised"}`)
+	req := httptest.NewRequest("POST", "/api/governance/ban", body)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Admin-Token", "admin-secret")
+	w := httptest.NewRecorder()
+	gw.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d; body: %s", w.Code, w.Body.String())
+	}
+
+	// Verify the token is actually banned
+	if !gw.governance.IsBanned("abc123def456") {
+		t.Error("expected token to be banned")
+	}
+}
+
+// --- Governance graph endpoint ---
+
+func TestGovernanceGraph_ReturnsData(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	defer upstream.Close()
+
+	gw, _ := newTestGatewayWithUpstream(t, upstream, "public")
+
+	req := httptest.NewRequest("GET", "/api/governance/graph", nil)
+	w := httptest.NewRecorder()
+	gw.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d", w.Code)
+	}
+	var resp map[string]interface{}
+	json.NewDecoder(w.Body).Decode(&resp)
+	if _, ok := resp["nodes"]; !ok {
+		t.Error("expected 'nodes' in graph response")
+	}
+	if _, ok := resp["stats"]; !ok {
+		t.Error("expected 'stats' in graph response")
+	}
+}
+
+// --- Metrics ---
+
+func TestMetrics_Tracked(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	gw, _ := newTestGatewayWithUpstream(t, upstream, "public")
+
+	// Make a few requests
+	for i := 0; i < 3; i++ {
+		req := httptest.NewRequest("GET", "/api/test", nil)
+		w := httptest.NewRecorder()
+		gw.ServeHTTP(w, req)
+	}
+
+	metrics := gw.GetMetrics()
+	if metrics.TotalRequests < 3 {
+		t.Errorf("expected at least 3 total requests, got %d", metrics.TotalRequests)
+	}
+	if metrics.TotalPublic < 3 {
+		t.Errorf("expected at least 3 public requests, got %d", metrics.TotalPublic)
+	}
+}
+
+// --- Demo response tests ---
+
+func TestDemoRoutes_ReturnMockData(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Error("should not reach upstream for demo routes")
+	}))
+	defer upstream.Close()
+
+	demoNames := []string{"api-micro", "api-basic", "api-standard", "api-premium"}
+	for _, name := range demoNames {
+		t.Run(name, func(t *testing.T) {
+			cfg := &config.Config{
+				Server: config.ServerConfig{Listen: ":8080"},
+				Upstreams: map[string]config.Upstream{
+					"backend": {URL: upstream.URL},
+				},
+				Routes: []config.Route{
+					{
+						Name:     name,
+						Match:    config.RouteMatch{PathPrefix: "/api/"},
+						Upstream: "backend",
+						Policy:   config.RoutePolicy{Kind: "public"},
+					},
+				},
+			}
+			gw := newTestGateway(t, cfg)
+
+			req := httptest.NewRequest("GET", "/api/test", nil)
+			w := httptest.NewRecorder()
+			gw.ServeHTTP(w, req)
+
+			if w.Code != http.StatusOK {
+				t.Errorf("expected 200, got %d", w.Code)
+			}
+			var body map[string]interface{}
+			if err := json.NewDecoder(w.Body).Decode(&body); err != nil {
+				t.Fatalf("failed to decode: %v", err)
+			}
+			if body["tier"] == nil {
+				t.Error("expected 'tier' in demo response")
+			}
+		})
+	}
+}
+
+// --- extractBearerToken ---
+
+func TestExtractBearerToken(t *testing.T) {
+	tests := []struct {
+		name  string
+		auth  string
+		want  string
+	}{
+		{"bearer", "Bearer abc123", "abc123"},
+		{"no prefix", "raw-token", "raw-token"},
+		{"empty", "", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest("GET", "/", nil)
+			if tt.auth != "" {
+				req.Header.Set("Authorization", tt.auth)
+			}
+			got := extractBearerToken(req)
+			if got != tt.want {
+				t.Errorf("extractBearerToken() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// --- extractL402Token ---
+
+func TestExtractL402Token(t *testing.T) {
+	tests := []struct {
+		name string
+		auth string
+		want string
+	}{
+		{"L402 format", "L402 macaroon:preimage", "macaroon:preimage"},
+		{"LSAT format", "LSAT macaroon:preimage", "macaroon:preimage"},
+		{"bearer (not L402)", "Bearer token", ""},
+		{"empty", "", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest("GET", "/", nil)
+			if tt.auth != "" {
+				req.Header.Set("Authorization", tt.auth)
+			}
+			got := extractL402Token(req)
+			if got != tt.want {
+				t.Errorf("extractL402Token() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// --- matchRoute tests ---
+
+func TestMatchRoute_ExactBeforePrefix(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	defer upstream.Close()
+
+	cfg := &config.Config{
+		Server: config.ServerConfig{Listen: ":8080"},
+		Upstreams: map[string]config.Upstream{
+			"backend": {URL: upstream.URL},
+		},
+		Routes: []config.Route{
+			{Name: "exact", Match: config.RouteMatch{PathExact: "/api/special"}, Upstream: "backend", Policy: config.RoutePolicy{Kind: "public"}},
+			{Name: "prefix", Match: config.RouteMatch{PathPrefix: "/api/"}, Upstream: "backend", Policy: config.RoutePolicy{Kind: "public"}},
+		},
+	}
+	gw := newTestGateway(t, cfg)
+
+	req := httptest.NewRequest("GET", "/api/special", nil)
+	route := gw.matchRoute(req)
+	if route == nil {
+		t.Fatal("expected a match")
+	}
+	if route.Name != "exact" {
+		t.Errorf("expected 'exact' route, got %q", route.Name)
+	}
+}
+
+// --- statusWriter tests ---
+
+func TestStatusWriter_CapturesCode(t *testing.T) {
+	w := httptest.NewRecorder()
+	sw := &statusWriter{ResponseWriter: w, statusCode: http.StatusOK}
+
+	sw.WriteHeader(http.StatusCreated)
+	if sw.statusCode != http.StatusCreated {
+		t.Errorf("expected 201, got %d", sw.statusCode)
+	}
+}
+
+// --- min helper ---
+
+func TestMin(t *testing.T) {
+	if min(3, 5) != 3 {
+		t.Error("min(3,5) should be 3")
+	}
+	if min(5, 3) != 3 {
+		t.Error("min(5,3) should be 3")
+	}
+	if min(4, 4) != 4 {
+		t.Error("min(4,4) should be 4")
+	}
+}
+
+// --- Request forwarding with body ---
+
+func TestPublicPolicy_ForwardsRequestBody(t *testing.T) {
+	var receivedBody string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		bodyBytes, _ := io.ReadAll(r.Body)
+		receivedBody = string(bodyBytes)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	gw, _ := newTestGatewayWithUpstream(t, upstream, "public")
+
+	reqBody := `{"key":"value"}`
+	req := httptest.NewRequest("POST", "/api/data", strings.NewReader(reqBody))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	gw.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	if receivedBody != reqBody {
+		t.Errorf("expected body %q, got %q", reqBody, receivedBody)
+	}
+}


### PR DESCRIPTION
## Summary

Add test coverage for the `pkg/config/` and `pkg/proxy/` packages, which previously had **zero tests**. This is critical for a security product.

## Test Coverage

| Package | Coverage | Tests |
|---------|----------|-------|
| `pkg/config` | **94.7%** | 42 test functions |
| `pkg/proxy` | **64.4%** | 40 test functions |

## What's Tested

### Config Package
- YAML parsing, defaults, environment variable expansion
- Validation: missing routes/names/matchers/policies, unknown upstreams
- Upstream URL security: scheme validation, credential blocking, SSRF/private IP blocking
- Policy normalization (strategic aliases → canonical forms)
- L402/fiat402/chargeback policy synthesis
- Route matching: pathPrefix, pathExact, pathRegex, methods, headers (incl. regex patterns)

### Proxy Package
- Gateway constructor validation
- Health endpoint, CORS headers/preflight
- Public policy: request proxying, body forwarding
- Capability policy: auth required, invalid/valid/banned tokens, scope enforcement
- L402 policy: 402 challenge with macaroon + invoice
- StripPrefix and Rewrite path transformations
- Upstream error handling (unreachable, missing config)
- Admin endpoints: mint, validate, delegate, ping
- Governance endpoints: ban, graph
- Demo routes, metrics tracking
- Token extraction helpers (Bearer, L402, LSAT)

## Notes
- All tests use stdlib only (no testify dependency added)
- Table-driven tests used throughout
- Uses `httptest` for proxy integration tests
- No source code modifications — test files only
- `go test ./...` passes cleanly