### PR TITLE
feat(landing): add blog section with first post

### DIFF
--- a/satgate-landing/app/blog/page.tsx
+++ b/satgate-landing/app/blog/page.tsx
@@ -1,0 +1,101 @@
+import Link from 'next/link';
+import { ArrowLeft, ArrowRight, Calendar, Clock, User } from 'lucide-react';
+
+export const metadata = {
+  title: 'Blog - SatGate',
+  description: 'Insights on API economics, agent governance, and the future of machine-to-machine commerce.',
+};
+
+// Blog post data - in a real setup this would come from a CMS or markdown files
+const posts = [
+  {
+    slug: 'why-routing-isnt-governance',
+    title: 'Why Routing Isn\'t Governance',
+    description: 'AI gateways excel at routing LLM calls. But when agents control spend autonomously, routing isn\'t enough. You need economic governance.',
+    date: '2026-02-06',
+    readTime: '5 min read',
+    author: 'SatGate Team',
+    tags: ['MCP', 'Governance', 'Agent Economy'],
+  },
+];
+
+export default function BlogPage() {
+  return (
+    <div className="min-h-screen bg-black text-gray-100 font-sans">
+      <div className="max-w-4xl mx-auto px-6 py-16">
+        <Link href="/" className="text-gray-500 hover:text-white flex items-center gap-2 transition mb-8">
+          <ArrowLeft size={18} /> Back to Home
+        </Link>
+        
+        <div className="mb-12">
+          <h1 className="text-4xl font-bold mb-4">Blog</h1>
+          <p className="text-xl text-gray-400">
+            Insights on API economics, agent governance, and the future of machine-to-machine commerce.
+          </p>
+        </div>
+
+        <div className="space-y-6">
+          {posts.map((post) => (
+            <Link 
+              key={post.slug}
+              href={`/blog/${post.slug}`}
+              className="block bg-gray-900 border border-gray-800 rounded-xl p-6 hover:border-purple-600/50 transition group"
+            >
+              <div className="flex flex-wrap gap-2 mb-3">
+                {post.tags.map((tag) => (
+                  <span 
+                    key={tag}
+                    className="px-2 py-1 rounded-full bg-purple-900/30 border border-purple-500/30 text-purple-300 text-xs font-mono"
+                  >
+                    {tag}
+                  </span>
+                ))}
+              </div>
+              
+              <h2 className="text-xl font-bold mb-2 group-hover:text-purple-400 transition">
+                {post.title}
+              </h2>
+              
+              <p className="text-gray-400 mb-4">
+                {post.description}
+              </p>
+              
+              <div className="flex items-center gap-4 text-sm text-gray-500">
+                <span className="flex items-center gap-1">
+                  <Calendar size={14} />
+                  {new Date(post.date).toLocaleDateString('en-US', { 
+                    month: 'short', 
+                    day: 'numeric', 
+                    year: 'numeric' 
+                  })}
+                </span>
+                <span className="flex items-center gap-1">
+                  <Clock size={14} />
+                  {post.readTime}
+                </span>
+              </div>
+              
+              <div className="mt-4 flex items-center text-purple-400 text-sm font-medium group-hover:gap-2 transition-all">
+                Read more <ArrowRight size={16} className="ml-1" />
+              </div>
+            </Link>
+          ))}
+        </div>
+
+        {/* Newsletter CTA */}
+        <section className="mt-16 bg-gradient-to-r from-purple-900/20 to-cyan-900/20 border border-purple-800/30 rounded-xl p-8 text-center">
+          <h2 className="text-2xl font-bold mb-3">Stay Updated</h2>
+          <p className="text-gray-400 mb-6">
+            Get insights on API economics and agent governance delivered to your inbox.
+          </p>
+          <a 
+            href="mailto:contact@satgate.io?subject=Newsletter%20Subscription"
+            className="inline-flex items-center gap-2 bg-white text-black px-6 py-3 rounded-lg font-bold hover:bg-gray-200 transition"
+          >
+            Subscribe to Updates
+          </a>
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/satgate-landing/app/blog/why-routing-isnt-governance/page.tsx
+++ b/satgate-landing/app/blog/why-routing-isnt-governance/page.tsx
@@ -1,0 +1,262 @@
+import Link from 'next/link';
+import { ArrowLeft, Calendar, Clock, User } from 'lucide-react';
+
+export const metadata = {
+  title: 'Why Routing Isn\'t Governance - SatGate Blog',
+  description: 'AI gateways excel at routing LLM calls. But when agents control spend autonomously, routing isn\'t enough. You need economic governance.',
+};
+
+export default function WhyRoutingIsntGovernancePage() {
+  return (
+    <div className="min-h-screen bg-black text-gray-100 font-sans">
+      <div className="max-w-3xl mx-auto px-6 py-16">
+        <Link href="/blog" className="text-gray-500 hover:text-white flex items-center gap-2 transition mb-8">
+          <ArrowLeft size={18} /> Back to Blog
+        </Link>
+        
+        {/* Header */}
+        <header className="mb-12">
+          <div className="flex flex-wrap gap-2 mb-4">
+            <span className="px-2 py-1 rounded-full bg-purple-900/30 border border-purple-500/30 text-purple-300 text-xs font-mono">
+              MCP
+            </span>
+            <span className="px-2 py-1 rounded-full bg-cyan-900/30 border border-cyan-500/30 text-cyan-300 text-xs font-mono">
+              Governance
+            </span>
+            <span className="px-2 py-1 rounded-full bg-green-900/30 border border-green-500/30 text-green-300 text-xs font-mono">
+              Agent Economy
+            </span>
+          </div>
+          
+          <h1 className="text-4xl font-bold mb-4">Why Routing Isn't Governance</h1>
+          
+          <p className="text-xl text-gray-400 mb-6">
+            AI gateways excel at routing LLM calls. But when agents control spend autonomously, 
+            routing isn't enough. You need economic governance.
+          </p>
+          
+          <div className="flex items-center gap-4 text-sm text-gray-500">
+            <span className="flex items-center gap-1">
+              <Calendar size={14} />
+              February 6, 2026
+            </span>
+            <span className="flex items-center gap-1">
+              <Clock size={14} />
+              5 min read
+            </span>
+          </div>
+        </header>
+
+        {/* Article Content */}
+        <article className="prose prose-invert prose-gray max-w-none">
+          <div className="space-y-6 text-gray-300 leading-relaxed">
+            
+            <p className="text-lg">
+              The AI gateway market is booming. Bifrost, LiteLLM, Portkey, and others are racing to 
+              solve the same problem: <em>how do you efficiently route LLM calls across multiple providers?</em>
+            </p>
+
+            <p>
+              It's a real problem. When you're building AI applications, you don't want to be locked 
+              into a single provider. You want failover when OpenAI goes down. You want load balancing 
+              across API keys. You want semantic caching to reduce costs.
+            </p>
+
+            <p>
+              These gateways solve that beautifully. They're fast, reliable, and well-engineered.
+            </p>
+
+            <p className="text-xl font-medium text-white">
+              But they solve the wrong problem for the agent economy.
+            </p>
+
+            <h2 className="text-2xl font-bold text-white mt-12 mb-4">The Routing Mindset</h2>
+
+            <p>
+              Routing gateways think about the world in terms of <strong className="text-white">requests</strong>:
+            </p>
+
+            <ul className="list-disc list-inside space-y-2 text-gray-400">
+              <li>Which provider should handle this request?</li>
+              <li>How do we minimize latency?</li>
+              <li>How do we maximize uptime?</li>
+              <li>How do we cache similar requests?</li>
+            </ul>
+
+            <p>
+              These are infrastructure questions. They're about reliability and performance. 
+              And they assume a human is ultimately in control — making decisions about which 
+              applications to build, which APIs to call, and how much to spend.
+            </p>
+
+            <h2 className="text-2xl font-bold text-white mt-12 mb-4">The Agent Reality</h2>
+
+            <p>
+              Agents don't work that way.
+            </p>
+
+            <p>
+              An agent with access to an MCP tool server can decide — autonomously — to make 
+              thousands of API calls. It can spawn sub-agents, each with their own tool access. 
+              It can run overnight while you sleep.
+            </p>
+
+            <p>
+              The questions that matter in this world are different:
+            </p>
+
+            <ul className="list-disc list-inside space-y-2 text-gray-400">
+              <li><strong className="text-white">How much is this agent allowed to spend?</strong></li>
+              <li>Which tools can it use, and at what cost?</li>
+              <li>When should it stop — even if the task isn't complete?</li>
+              <li>Who pays when the bill arrives?</li>
+            </ul>
+
+            <p>
+              These aren't routing questions. They're <strong className="text-white">governance</strong> questions.
+            </p>
+
+            <h2 className="text-2xl font-bold text-white mt-12 mb-4">The Gap in the Stack</h2>
+
+            <p>
+              Here's the security stack most enterprises have today:
+            </p>
+
+            <div className="bg-gray-900 border border-gray-800 rounded-xl p-6 my-6 font-mono text-sm">
+              <div className="space-y-2">
+                <div className="flex items-center gap-3">
+                  <span className="text-green-400">✓</span>
+                  <span>Network Firewall</span>
+                  <span className="text-gray-500 ml-auto">"Can this packet enter?"</span>
+                </div>
+                <div className="flex items-center gap-3">
+                  <span className="text-green-400">✓</span>
+                  <span>Application Firewall</span>
+                  <span className="text-gray-500 ml-auto">"Is this request safe?"</span>
+                </div>
+                <div className="flex items-center gap-3">
+                  <span className="text-red-400">?</span>
+                  <span className="text-red-400">Economic Firewall</span>
+                  <span className="text-gray-500 ml-auto">"Should this agent spend this?"</span>
+                </div>
+              </div>
+            </div>
+
+            <p>
+              Routing gateways live in the infrastructure layer. They make sure requests get to 
+              the right place efficiently. But they don't answer the economic question.
+            </p>
+
+            <p>
+              That's the gap. And it's the gap that will cause six-figure surprises when agents 
+              start running autonomously at scale.
+            </p>
+
+            <h2 className="text-2xl font-bold text-white mt-12 mb-4">What Governance Looks Like</h2>
+
+            <p>
+              Economic governance for AI agents isn't just "budget tracking." It's enforcement:
+            </p>
+
+            <div className="bg-gray-900 border border-gray-800 rounded-xl p-6 my-6">
+              <div className="space-y-4">
+                <div>
+                  <h4 className="font-bold text-white mb-1">Hard Budget Caps</h4>
+                  <p className="text-gray-400 text-sm">
+                    When an agent hits its budget, requests are blocked. Not logged. Not alerted. Blocked.
+                    The CFO knows exactly what will be spent — not what was spent.
+                  </p>
+                </div>
+                <div>
+                  <h4 className="font-bold text-white mb-1">Per-Tool Cost Attribution</h4>
+                  <p className="text-gray-400 text-sm">
+                    In MCP, agents call tools by name. Governance means knowing that Agent X 
+                    spent $47 on the <code className="bg-gray-800 px-1 rounded">search_database</code> tool 
+                    and $12 on <code className="bg-gray-800 px-1 rounded">send_email</code>. 
+                    Not just "Agent X made 1,000 requests."
+                  </p>
+                </div>
+                <div>
+                  <h4 className="font-bold text-white mb-1">Delegation Without Escalation</h4>
+                  <p className="text-gray-400 text-sm">
+                    When Agent A spawns Agent B, it should be able to give B a subset of its 
+                    budget — not the master key. Macaroon-based credentials enable this; API keys don't.
+                  </p>
+                </div>
+              </div>
+            </div>
+
+            <h2 className="text-2xl font-bold text-white mt-12 mb-4">Routing + Governance</h2>
+
+            <p>
+              This isn't an either/or situation. Routing gateways and economic gateways solve 
+              different problems. You might use both:
+            </p>
+
+            <div className="bg-gray-900 border border-gray-800 rounded-xl p-4 my-6 font-mono text-sm text-center">
+              Agent → <span className="text-cyan-400">Economic Gateway</span> → <span className="text-purple-400">Routing Gateway</span> → LLM Providers
+            </div>
+
+            <p>
+              The economic gateway enforces budgets and tracks attribution. The routing gateway 
+              optimizes which provider handles each call. Different layers, different concerns.
+            </p>
+
+            <h2 className="text-2xl font-bold text-white mt-12 mb-4">The Question to Ask</h2>
+
+            <p>
+              When evaluating your AI infrastructure, ask this:
+            </p>
+
+            <p className="text-xl font-medium text-white my-6">
+              "If my agent makes 10,000 calls tonight while I'm asleep, 
+              who decides when it stops?"
+            </p>
+
+            <p>
+              If the answer is "when it finishes the task" or "when the API rate limits kick in," 
+              you have a routing gateway.
+            </p>
+
+            <p>
+              If the answer is "when it hits its $50 budget cap," you have governance.
+            </p>
+
+            <p>
+              The agent economy needs both. But right now, almost everyone has routing. 
+              Almost no one has governance.
+            </p>
+
+            <p className="text-gray-500 mt-12">
+              That's the gap we're building SatGate to fill.
+            </p>
+
+          </div>
+        </article>
+
+        {/* CTA */}
+        <section className="mt-16 bg-gradient-to-r from-cyan-900/20 to-purple-900/20 border border-cyan-800/30 rounded-xl p-8 text-center">
+          <h2 className="text-2xl font-bold mb-3">Ready to add economic governance?</h2>
+          <p className="text-gray-400 mb-6">
+            Start with free Observe mode. See what your agents are actually spending.
+          </p>
+          <div className="flex flex-col sm:flex-row gap-4 justify-center">
+            <Link 
+              href="/design-partners" 
+              className="inline-flex items-center justify-center gap-2 bg-white text-black px-6 py-3 rounded-lg font-bold hover:bg-gray-200 transition"
+            >
+              Apply for Design Partner Program
+            </Link>
+            <Link 
+              href="/compare" 
+              className="inline-flex items-center justify-center gap-2 bg-gray-800 text-white px-6 py-3 rounded-lg font-bold hover:bg-gray-700 transition"
+            >
+              See How We Compare
+            </Link>
+          </div>
+        </section>
+
+      </div>
+    </div>
+  );
+}

--- a/satgate-landing/app/page.tsx
+++ b/satgate-landing/app/page.tsx
@@ -670,6 +670,7 @@ curl -H <span className="text-green-400">"Authorization: L402 &lt;macaroon&gt;:&
                 <li><Link href="/design-partners" className="hover:text-white transition">Design Partners</Link></li>
                 <li><Link href="/pricing" className="hover:text-white transition">Pricing</Link></li>
                 <li><Link href="/compare" className="hover:text-white transition">Compare</Link></li>
+                <li><Link href="/blog" className="hover:text-white transition">Blog</Link></li>
                 <li><a href="https://cloud.satgate.io" target="_blank" rel="noopener noreferrer" className="hover:text-white transition">Cloud Dashboard</a></li>
               </ul>
             </div>


### PR DESCRIPTION
## Summary
Adds blog infrastructure to satgate.io with first article.

### New Pages
- **/blog** — Index page with post listings
- **/blog/why-routing-isnt-governance** — First article

### First Post: "Why Routing Isn't Governance"
Explains the key difference between routing gateways (Bifrost, LiteLLM) and economic governance (SatGate):
- Routing = "which provider handles this request?"
- Governance = "how much is this agent allowed to spend?"

Positions the "Economic Firewall" as the missing layer in the stack.

### Also Includes
- Blog link added to footer Resources section
- Newsletter CTA on blog index
- Consistent styling with rest of site