### PR TITLE
security: fix remaining medium and low vulnerabilities

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ RUN CGO_ENABLED=0 GOOS=linux go build \
     -o satgate ./cmd/satgate
 
 # Runtime stage
-FROM alpine:3.19
+FROM alpine:3.21
 
 # Install runtime dependencies
 RUN apk add --no-cache ca-certificates tzdata

--- a/cmd/satgate/main.go
+++ b/cmd/satgate/main.go
@@ -101,8 +101,8 @@ func main() {
 			log.Fatal().Err(err).Msg("Failed to generate random root key")
 		}
 		rootKey = hex.EncodeToString(keyBytes)
-		log.Warn().Msg("CAPABILITY_ROOT_KEY not set - using auto-generated key (demo mode)")
-		log.Warn().Msg("Tokens will NOT persist across restarts. Set CAPABILITY_ROOT_KEY for production.")
+		log.Error().Msg("SECURITY WARNING: Using ephemeral root key. Set CAPABILITY_ROOT_KEY for production use.")
+		log.Error().Msg("Tokens will NOT persist across restarts. This is NOT safe for production.")
 	}
 
 	log.Info().Bool("key_configured", rootKey != "").

--- a/pkg/proxy/proxy_oss.go
+++ b/pkg/proxy/proxy_oss.go
@@ -17,6 +17,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net"
 	"net/http"
 	"net/http/httputil"
@@ -24,6 +25,7 @@ import (
 	"os"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/rs/zerolog/log"
@@ -49,13 +51,13 @@ type Gateway struct {
 	metricsHook MetricsHook
 }
 
-// Metrics tracks gateway statistics.
+// Metrics tracks gateway statistics using atomic counters for concurrent safety.
 type Metrics struct {
-	TotalRequests   int64
-	TotalPublic     int64
-	TotalCapability int64
-	TotalL402       int64
-	TotalErrors     int64
+	TotalRequests   atomic.Int64
+	TotalPublic     atomic.Int64
+	TotalCapability atomic.Int64
+	TotalL402       atomic.Int64
+	TotalErrors     atomic.Int64
 }
 
 // MetricsHook allows external metrics collection.
@@ -167,8 +169,8 @@ func (g *Gateway) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Admin endpoint: Token delegation (both direct and demo path)
-	if (r.URL.Path == "/api/capability/delegate" || r.URL.Path == "/api/capability/demo/delegate") && r.Method == "POST" {
+	// Admin endpoint: Token delegation
+	if r.URL.Path == "/api/capability/delegate" && r.Method == "POST" {
 		g.handleCapabilityDelegate(w, r)
 		return
 	}
@@ -204,13 +206,13 @@ func (g *Gateway) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	start := time.Now()
-	g.metrics.TotalRequests++
+	g.metrics.TotalRequests.Add(1)
 
 	// Find matching route
 	route := g.matchRoute(r)
 	if route == nil {
 		http.Error(w, "No matching route", http.StatusNotFound)
-		g.metrics.TotalErrors++
+		g.metrics.TotalErrors.Add(1)
 		return
 	}
 
@@ -226,15 +228,15 @@ func (g *Gateway) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// Handle based on policy
 	switch policyKind {
 	case "public":
-		g.metrics.TotalPublic++
+		g.metrics.TotalPublic.Add(1)
 		g.handlePublic(wrapped, r, route)
 
 	case "capability":
-		g.metrics.TotalCapability++
+		g.metrics.TotalCapability.Add(1)
 		g.handleCapability(wrapped, r, route)
 
 	case "l402":
-		g.metrics.TotalL402++
+		g.metrics.TotalL402.Add(1)
 		g.handleL402(wrapped, r, route)
 
 	default:
@@ -242,7 +244,7 @@ func (g *Gateway) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		log.Warn().Str("policy", policyKind).Str("route", route.Name).
 			Msg("Unknown policy kind in OSS build")
 		http.Error(w, fmt.Sprintf("Policy '%s' not supported in OSS", policyKind), http.StatusNotImplemented)
-		g.metrics.TotalErrors++
+		g.metrics.TotalErrors.Add(1)
 		return
 	}
 
@@ -765,7 +767,8 @@ func (g *Gateway) handleCapabilityMint(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Parse request body
+	// Parse request body (limit to 1MB)
+	r.Body = io.NopCloser(io.LimitReader(r.Body, 1048576))
 	var req struct {
 		Scope    string `json:"scope"`
 		Duration string `json:"duration"`
@@ -858,6 +861,7 @@ func (g *Gateway) handleCapabilityValidate(w http.ResponseWriter, r *http.Reques
 
 // handleCapabilityDelegate handles POST /api/capability/delegate - Delegate a token with additional caveats.
 func (g *Gateway) handleCapabilityDelegate(w http.ResponseWriter, r *http.Request) {
+	r.Body = io.NopCloser(io.LimitReader(r.Body, 1048576))
 	var req struct {
 		ParentToken string   `json:"parentToken"`
 		Caveats     []string `json:"caveats"`
@@ -1106,6 +1110,7 @@ func (g *Gateway) handleGovernanceBan(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	r.Body = io.NopCloser(io.LimitReader(r.Body, 1048576))
 	var req struct {
 		TokenSignature string `json:"tokenSignature"`
 		Reason         string `json:"reason"`


### PR DESCRIPTION
## Changes

### Medium Priority
- **M4**: Add 1MB request body size limit on admin endpoints (`handleCapabilityMint`, `handleCapabilityDelegate`, `handleGovernanceBan`) using `io.LimitReader` to prevent memory exhaustion from oversized payloads
- **M5**: Remove undocumented `/api/capability/demo/delegate` path that was an unprotected alias for the delegate endpoint

### Low Priority
- **L1**: Convert `Metrics` struct fields to `atomic.Int64` types for concurrent safety (previously bare `int64` with non-atomic increments)
- **L2**: Update Docker runtime image from Alpine 3.19 to Alpine 3.21 (latest stable)
- **L4**: Escalate ephemeral root key warning from `Warn` to `Error` level with clear security message

### Note
M6 (Go toolchain update) was not applicable — the repo is on Go 1.24.1/toolchain 1.24.11, not the version mentioned in the audit.