### PR TITLE
chore: gofmt all Go files

### DIFF
--- a/cmd/satgate/main.go
+++ b/cmd/satgate/main.go
@@ -87,7 +87,7 @@ func main() {
 	rootKey := cfg.Admin.CapabilityRootKey
 	log.Info().Bool("key_configured", rootKey != "").
 		Msg("Root key from config")
-	
+
 	if rootKey == "" || rootKey == "${CAPABILITY_ROOT_KEY}" {
 		// YAML didn't expand the env var, try direct read
 		rootKey = os.Getenv("CAPABILITY_ROOT_KEY")

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -659,8 +659,8 @@ func TestRouteMatches_Methods(t *testing.T) {
 	}{
 		{"GET", true},
 		{"POST", true},
-		{"get", true},   // case insensitive
-		{"post", true},  // case insensitive
+		{"get", true},  // case insensitive
+		{"post", true}, // case insensitive
 		{"PUT", false},
 		{"DELETE", false},
 	}
@@ -876,10 +876,10 @@ func TestIsPrivateIP(t *testing.T) {
 		{"10.0.0.1", true},
 		{"172.16.0.1", true},
 		{"192.168.1.1", true},
-		{"169.254.1.1", true},   // link-local
-		{"8.8.8.8", false},      // public
-		{"1.1.1.1", false},      // public
-		{"example.com", false},  // DNS name, not IP
+		{"169.254.1.1", true},  // link-local
+		{"8.8.8.8", false},     // public
+		{"1.1.1.1", false},     // public
+		{"example.com", false}, // DNS name, not IP
 	}
 	for _, tt := range tests {
 		t.Run(tt.host, func(t *testing.T) {
@@ -895,11 +895,11 @@ func TestIsPrivateIP(t *testing.T) {
 
 func TestParseURL(t *testing.T) {
 	tests := []struct {
-		url       string
-		scheme    string
-		host      string
-		hasUser   bool
-		wantErr   bool
+		url     string
+		scheme  string
+		host    string
+		hasUser bool
+		wantErr bool
 	}{
 		{"https://api.example.com", "https", "api.example.com", false, false},
 		{"http://api.example.com:8080/path", "http", "api.example.com:8080", false, false},

--- a/pkg/governance/governance.go
+++ b/pkg/governance/governance.go
@@ -14,10 +14,10 @@ type Service struct {
 	store Store // Backing store (Redis or memory)
 
 	// Local cache for hot path (IsBanned checks)
-	banned  map[string]BanRecord
-	usage   map[string]*UsageStats
-	minted  map[string]*MintedToken
-	mu      sync.RWMutex
+	banned map[string]BanRecord
+	usage  map[string]*UsageStats
+	minted map[string]*MintedToken
+	mu     sync.RWMutex
 
 	// Counters for dashboard stats
 	blockedRequests int64 // Unpaid requests (402s)
@@ -27,13 +27,13 @@ type Service struct {
 
 // MintedToken tracks a minted token
 type MintedToken struct {
-	Signature  string
-	Scope      string
-	CreatedAt  time.Time
-	ExpiresAt  time.Time
-	ParentSig  string // Parent token signature (empty for root tokens)
-	Depth      int    // 0 = root, 1 = minted, 2+ = delegated
-	Label      string // Human-readable label
+	Signature string
+	Scope     string
+	CreatedAt time.Time
+	ExpiresAt time.Time
+	ParentSig string // Parent token signature (empty for root tokens)
+	Depth     int    // 0 = root, 1 = minted, 2+ = delegated
+	Label     string // Human-readable label
 }
 
 // BanRecord represents a banned token
@@ -46,24 +46,24 @@ type BanRecord struct {
 
 // UsageStats tracks token usage
 type UsageStats struct {
-	Signature    string
+	Signature     string
 	TotalRequests int64
-	LastUsed     time.Time
-	Routes       map[string]int64 // route -> count
+	LastUsed      time.Time
+	Routes        map[string]int64 // route -> count
 }
 
 // TokenInfo represents token status for API responses
 type TokenInfo struct {
-	Signature     string            `json:"signature"`
-	Status        string            `json:"status"`
-	Scope         string            `json:"scope,omitempty"`
-	CreatedAt     *time.Time        `json:"createdAt,omitempty"`
-	ExpiresAt     *time.Time        `json:"expiresAt,omitempty"`
-	TotalRequests int64             `json:"totalRequests"`
-	LastUsed      *time.Time        `json:"lastUsed,omitempty"`
-	Routes        map[string]int64  `json:"routes,omitempty"`
-	BannedAt      *time.Time        `json:"bannedAt,omitempty"`
-	BanReason     string            `json:"banReason,omitempty"`
+	Signature     string           `json:"signature"`
+	Status        string           `json:"status"`
+	Scope         string           `json:"scope,omitempty"`
+	CreatedAt     *time.Time       `json:"createdAt,omitempty"`
+	ExpiresAt     *time.Time       `json:"expiresAt,omitempty"`
+	TotalRequests int64            `json:"totalRequests"`
+	LastUsed      *time.Time       `json:"lastUsed,omitempty"`
+	Routes        map[string]int64 `json:"routes,omitempty"`
+	BannedAt      *time.Time       `json:"bannedAt,omitempty"`
+	BanReason     string           `json:"banReason,omitempty"`
 }
 
 // NewService creates a new governance service with the given store
@@ -543,7 +543,7 @@ func (s *Service) GetGraph() GraphResponse {
 		constraints := []string{
 			fmt.Sprintf("scope = %s", token.Scope),
 		}
-		
+
 		// Add expiry as relative time
 		expiresIn := time.Until(token.ExpiresAt)
 		if expiresIn > 0 {
@@ -669,4 +669,3 @@ func (s *Service) Close() error {
 func (s *Service) GetStore() Store {
 	return s.store
 }
-

--- a/pkg/governance/governance_test.go
+++ b/pkg/governance/governance_test.go
@@ -226,4 +226,3 @@ func BenchmarkIsBanned(b *testing.B) {
 		svc.IsBanned("test-token")
 	}
 }
-

--- a/pkg/governance/redis_store.go
+++ b/pkg/governance/redis_store.go
@@ -11,13 +11,13 @@ import (
 
 const (
 	// Redis key prefixes
-	keyBanList   = "satgate:banlist"      // SET of banned signatures
-	keyBanRecord = "satgate:ban:"         // HASH for ban record details
-	keyMinted    = "satgate:minted:"      // HASH for minted token details
-	keyMintedSet = "satgate:minted:all"   // SET of all minted signatures
-	keyUsage     = "satgate:usage:"       // HASH for usage stats
-	keyUsageSet  = "satgate:usage:all"    // SET of all usage signatures
-	keyCounter   = "satgate:counter:"     // STRING for counters (rate limiting)
+	keyBanList   = "satgate:banlist"    // SET of banned signatures
+	keyBanRecord = "satgate:ban:"       // HASH for ban record details
+	keyMinted    = "satgate:minted:"    // HASH for minted token details
+	keyMintedSet = "satgate:minted:all" // SET of all minted signatures
+	keyUsage     = "satgate:usage:"     // HASH for usage stats
+	keyUsageSet  = "satgate:usage:all"  // SET of all usage signatures
+	keyCounter   = "satgate:counter:"   // STRING for counters (rate limiting)
 )
 
 // RedisStore implements Store using Redis for HA persistence
@@ -328,4 +328,3 @@ func (r *RedisStore) Close() error {
 func (r *RedisStore) IncrWithTTL(ctx context.Context, key string, ttl time.Duration) (int64, error) {
 	return r.IncrementCounter(ctx, key, ttl)
 }
-

--- a/pkg/governance/store.go
+++ b/pkg/governance/store.go
@@ -168,4 +168,3 @@ func (m *MemoryStore) Reset(ctx context.Context) error {
 func (m *MemoryStore) Close() error {
 	return nil
 }
-

--- a/pkg/lightning/interface.go
+++ b/pkg/lightning/interface.go
@@ -9,13 +9,13 @@ import (
 type Provider interface {
 	// CreateInvoice generates a new Lightning invoice
 	CreateInvoice(amountSats int64, memo string) (*Invoice, error)
-	
+
 	// CheckPayment verifies if a payment has been received
 	CheckPayment(paymentHash string) (bool, error)
-	
+
 	// GetBalance returns the node's balance in sats
 	GetBalance() (int64, error)
-	
+
 	// GetInfo returns node information
 	GetInfo() (*NodeInfo, error)
 }
@@ -27,16 +27,16 @@ type Invoice struct {
 	Preimage    string // Hex-encoded preimage (for verification)
 	Amount      int64  // Amount in sats
 	Memo        string
-	ExpiresAt   int64  // Unix timestamp
+	ExpiresAt   int64 // Unix timestamp
 }
 
 // NodeInfo contains Lightning node information
 type NodeInfo struct {
-	Alias      string
-	PubKey     string
-	Network    string // mainnet, testnet, signet
+	Alias       string
+	PubKey      string
+	Network     string // mainnet, testnet, signet
 	BlockHeight int64
-	Synced     bool
+	Synced      bool
 }
 
 // NewProvider creates a Lightning provider by name
@@ -46,7 +46,7 @@ func NewProvider(name string, config map[string]interface{}) (Provider, error) {
 	if name == "" {
 		name = "mock" // Default to mock if no provider specified
 	}
-	
+
 	switch name {
 	case "phoenixd":
 		return NewPhoenixdProvider(config)
@@ -70,6 +70,3 @@ func getConfigString(config map[string]interface{}, key string) string {
 	}
 	return ""
 }
-
-
-

--- a/pkg/lightning/lnd.go
+++ b/pkg/lightning/lnd.go
@@ -21,7 +21,7 @@ type LNDProvider struct {
 }
 
 // NewLNDProvider creates a new LND provider
-// 
+//
 // Security: TLS verification is ENABLED by default. You must provide either:
 // - tlsCert: Base64-encoded PEM certificate for custom CA
 // - tlsServerName: Expected server name for SNI verification
@@ -36,7 +36,7 @@ func NewLNDProvider(config map[string]interface{}) (*LNDProvider, error) {
 	if macaroon == "" {
 		return nil, fmt.Errorf("LND requires macaroon")
 	}
-	
+
 	// LND REST API requires hex-encoded macaroon
 	// Support both base64-encoded and hex-encoded input
 	if _, err := hex.DecodeString(macaroon); err != nil {
@@ -63,7 +63,7 @@ func NewLNDProvider(config map[string]interface{}) (*LNDProvider, error) {
 	// If TLS cert is provided, use it for CA verification
 	if tlsCert := getConfigString(config, "tlsCert"); tlsCert != "" {
 		certPool := x509.NewCertPool()
-		
+
 		// Support both base64-encoded and raw PEM
 		var certBytes []byte
 		decoded, err := base64.StdEncoding.DecodeString(tlsCert)
@@ -73,7 +73,7 @@ func NewLNDProvider(config map[string]interface{}) (*LNDProvider, error) {
 		} else {
 			certBytes = decoded
 		}
-		
+
 		if ok := certPool.AppendCertsFromPEM(certBytes); !ok {
 			return nil, fmt.Errorf("failed to add TLS cert to pool - invalid PEM format")
 		}
@@ -232,14 +232,14 @@ func (l *LNDProvider) GetInfo() (*NodeInfo, error) {
 	defer resp.Body.Close()
 
 	var result struct {
-		Alias           string `json:"alias"`
-		IdentityPubkey  string `json:"identity_pubkey"`
-		Chains          []struct {
+		Alias          string `json:"alias"`
+		IdentityPubkey string `json:"identity_pubkey"`
+		Chains         []struct {
 			Chain   string `json:"chain"`
 			Network string `json:"network"`
 		} `json:"chains"`
-		BlockHeight     int64 `json:"block_height"`
-		SyncedToChain   bool  `json:"synced_to_chain"`
+		BlockHeight   int64 `json:"block_height"`
+		SyncedToChain bool  `json:"synced_to_chain"`
 	}
 	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
 		return nil, err
@@ -258,4 +258,3 @@ func (l *LNDProvider) GetInfo() (*NodeInfo, error) {
 		Synced:      result.SyncedToChain,
 	}, nil
 }
-

--- a/pkg/lightning/mock.go
+++ b/pkg/lightning/mock.go
@@ -31,7 +31,7 @@ func (m *MockProvider) CreateInvoice(amountSats int64, memo string) (*Invoice, e
 	preimageBytes := make([]byte, 32)
 	rand.Read(preimageBytes)
 	preimage := hex.EncodeToString(preimageBytes)
-	
+
 	// Calculate payment hash
 	paymentHashBytes := sha256.Sum256(preimageBytes)
 	paymentHash := hex.EncodeToString(paymentHashBytes[:])
@@ -45,14 +45,14 @@ func (m *MockProvider) CreateInvoice(amountSats int64, memo string) (*Invoice, e
 	} else if amountSats >= 100 {
 		amountStr = "100u" // 100 sats
 	} else if amountSats >= 10 {
-		amountStr = "10u" // 10 sats  
+		amountStr = "10u" // 10 sats
 	}
-	
+
 	// Generate enough random data to look realistic (real invoices are 200+ chars)
 	extraData := make([]byte, 100)
 	rand.Read(extraData)
-	bolt11 := "lnbc" + amountStr + "1p" + hex.EncodeToString(paymentHashBytes[:])[:40] + 
-		"pp" + hex.EncodeToString(extraData)[:120] + 
+	bolt11 := "lnbc" + amountStr + "1p" + hex.EncodeToString(paymentHashBytes[:])[:40] +
+		"pp" + hex.EncodeToString(extraData)[:120] +
 		"qp" + hex.EncodeToString(preimageBytes)[:32]
 
 	invoice := &Invoice{
@@ -75,7 +75,7 @@ func (m *MockProvider) CreateInvoice(amountSats int64, memo string) (*Invoice, e
 func (m *MockProvider) CheckPayment(paymentHash string) (bool, error) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
-	
+
 	if paid, ok := m.paid[paymentHash]; ok {
 		return paid, nil
 	}
@@ -86,7 +86,7 @@ func (m *MockProvider) CheckPayment(paymentHash string) (bool, error) {
 func (m *MockProvider) SimulatePayment(paymentHash string) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	
+
 	m.paid[paymentHash] = true
 	if inv, ok := m.invoices[paymentHash]; ok {
 		m.balance += inv.Amount
@@ -110,6 +110,3 @@ func (m *MockProvider) GetInfo() (*NodeInfo, error) {
 		Synced:      true,
 	}, nil
 }
-
-
-

--- a/pkg/lightning/nwc.go
+++ b/pkg/lightning/nwc.go
@@ -24,9 +24,9 @@ type NWCProvider struct {
 	clientPubkey string
 	sharedSecret []byte // Precomputed shared secret for NIP-04 encryption
 
-	mu       sync.Mutex
-	conn     *websocket.Conn
-	pending  map[string]chan *nwcResponse
+	mu      sync.Mutex
+	conn    *websocket.Conn
+	pending map[string]chan *nwcResponse
 }
 
 // NWC request/response structures (NIP-47)

--- a/pkg/lightning/phoenixd.go
+++ b/pkg/lightning/phoenixd.go
@@ -49,7 +49,7 @@ func (p *PhoenixdProvider) CreateInvoice(amountSats int64, memo string) (*Invoic
 		return nil, fmt.Errorf("failed to generate preimage: %w", err)
 	}
 	preimage := hex.EncodeToString(preimageBytes)
-	
+
 	// Calculate payment hash (used as fallback if API doesn't return one)
 	paymentHashBytes := sha256.Sum256(preimageBytes)
 	_ = paymentHashBytes // Used below as fallback
@@ -187,4 +187,3 @@ func (p *PhoenixdProvider) GetInfo() (*NodeInfo, error) {
 		Synced:  true,
 	}, nil
 }
-

--- a/pkg/macaroon/macaroon.go
+++ b/pkg/macaroon/macaroon.go
@@ -30,10 +30,10 @@ func NewService(secret string) (*Service, error) {
 	if secret == "" {
 		return nil, fmt.Errorf("secret key required")
 	}
-	
+
 	// Derive root key from secret
 	h := sha256.Sum256([]byte(secret))
-	
+
 	return &Service{
 		rootKey: h[:],
 	}, nil
@@ -50,7 +50,7 @@ func (s *Service) Mint(scope string, expiresAt time.Time) (*Macaroon, error) {
 
 	// Add expiry caveat
 	mac.Caveats = append(mac.Caveats, fmt.Sprintf("expires = %d", expiresAt.UnixMilli()))
-	
+
 	// Add scope caveat
 	if scope != "" {
 		mac.Caveats = append(mac.Caveats, fmt.Sprintf("scope = %s", scope))
@@ -153,15 +153,15 @@ func (s *Service) RecalculateSignature(mac *Macaroon) string {
 // calculateSignatureWithKey computes signature with a specific key
 func (s *Service) calculateSignatureWithKey(mac *Macaroon, key []byte) string {
 	h := hmac.New(sha256.New, key)
-	
+
 	// Include identifier
 	h.Write([]byte(mac.Identifier))
-	
+
 	// Include each caveat
 	for _, caveat := range mac.Caveats {
 		h.Write([]byte(caveat))
 	}
-	
+
 	return hex.EncodeToString(h.Sum(nil))
 }
 
@@ -179,7 +179,7 @@ func (s *Service) verifyCaveat(caveat string) error {
 	case "expires":
 		// Check expiration - support both Unix timestamp (ms) and duration strings
 		// IMPORTANT: Check duration first because fmt.Sscanf partially parses "5m" as 5!
-		
+
 		// Try parsing as duration string first (e.g., "5m", "1h")
 		if _, durErr := time.ParseDuration(value); durErr == nil {
 			// Duration caveats are relative to token creation time
@@ -187,7 +187,7 @@ func (s *Service) verifyCaveat(caveat string) error {
 			// (they're mainly for display purposes in delegated tokens)
 			return nil
 		}
-		
+
 		// Try parsing as Unix timestamp in milliseconds (must be all digits)
 		var expiresMs int64
 		if n, err := fmt.Sscanf(value, "%d", &expiresMs); err == nil && n == 1 {
@@ -206,7 +206,7 @@ func (s *Service) verifyCaveat(caveat string) error {
 				return nil
 			}
 		}
-		
+
 		// Try parsing as RFC3339 timestamp
 		if ts, tsErr := time.Parse(time.RFC3339, value); tsErr == nil {
 			if time.Now().After(ts) {
@@ -214,7 +214,7 @@ func (s *Service) verifyCaveat(caveat string) error {
 			}
 			return nil
 		}
-		
+
 		// Unknown format - fail safe by rejecting
 		return fmt.Errorf("invalid expires value: %s", value)
 
@@ -357,4 +357,3 @@ func (w *MintWrapper) Delegate(parentToken string, additionalCaveats []string) (
 	}
 	return w.svc.Encode(child), nil
 }
-

--- a/pkg/macaroon/macaroon_test.go
+++ b/pkg/macaroon/macaroon_test.go
@@ -200,6 +200,3 @@ func BenchmarkVerify(b *testing.B) {
 		svc.Verify(token)
 	}
 }
-
-
-

--- a/pkg/proxy/proxy_oss.go
+++ b/pkg/proxy/proxy_oss.go
@@ -319,7 +319,7 @@ func (g *Gateway) handleL402(w http.ResponseWriter, r *http.Request, route *conf
 // verifyL402Token verifies an L402 payment proof.
 func (g *Gateway) verifyL402Token(ctx context.Context, token string, route *config.Route) bool {
 	log.Info().Str("token_len", fmt.Sprintf("%d", len(token))).Msg("verifyL402Token: starting verification")
-	
+
 	// L402 format: macaroon:preimage
 	parts := strings.SplitN(token, ":", 2)
 	if len(parts) != 2 {
@@ -618,8 +618,8 @@ func (g *Gateway) getDemoResponse(route *config.Route) map[string]interface{} {
 					{"asset": "SOL", "signal": "HOLD", "score": 0.54},
 				},
 				"whale_activity": map[string]interface{}{
-					"large_txs_24h": 847,
-					"net_flow":      "+12,450 BTC",
+					"large_txs_24h":  847,
+					"net_flow":       "+12,450 BTC",
 					"exchange_trend": "outflow",
 				},
 				"risk_score": 0.34,
@@ -705,7 +705,7 @@ func extractBearerToken(r *http.Request) string {
 func extractL402Token(r *http.Request) string {
 	auth := r.Header.Get("Authorization")
 	log.Debug().Str("auth_header", auth).Msg("extractL402Token: checking Authorization header")
-	
+
 	if strings.HasPrefix(auth, "L402 ") {
 		token := strings.TrimPrefix(auth, "L402 ")
 		log.Debug().Str("token_preview", token[:min(30, len(token))]+"...").Msg("extractL402Token: found L402 format")
@@ -716,7 +716,7 @@ func extractL402Token(r *http.Request) string {
 		log.Debug().Str("token_preview", token[:min(30, len(token))]+"...").Msg("extractL402Token: found LSAT format")
 		return token
 	}
-	
+
 	log.Debug().Msg("extractL402Token: no L402/LSAT token found")
 	return ""
 }
@@ -740,7 +740,7 @@ func getEnv(key, defaultValue string) string {
 func (g *Gateway) handleCapabilityMint(w http.ResponseWriter, r *http.Request) {
 	// Check admin token - try multiple sources
 	adminToken := r.Header.Get("X-Admin-Token")
-	
+
 	// Build list of valid tokens from config and environment
 	validTokens := []string{}
 	if g.config.Admin.Token != "" {
@@ -750,7 +750,7 @@ func (g *Gateway) handleCapabilityMint(w http.ResponseWriter, r *http.Request) {
 	if envToken := strings.TrimSpace(getEnv("ADMIN_TOKEN", "")); envToken != "" {
 		validTokens = append(validTokens, envToken)
 	}
-	
+
 	// Verify token matches one of the valid tokens
 	tokenValid := false
 	for _, vt := range validTokens {
@@ -759,7 +759,7 @@ func (g *Gateway) handleCapabilityMint(w http.ResponseWriter, r *http.Request) {
 			break
 		}
 	}
-	
+
 	if adminToken == "" || !tokenValid {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusUnauthorized)
@@ -1037,18 +1037,18 @@ func (g *Gateway) handleCapabilityAdmin(w http.ResponseWriter, r *http.Request) 
 	requiredScope := "api:capability:admin"
 	mostRestrictiveScope := "" // Track the most restrictive scope found
 	allScopesAllow := true     // Assume allowed until proven otherwise
-	
+
 	for _, caveat := range mac.Caveats {
 		if strings.HasPrefix(caveat, "scope = ") {
 			scopeValue := strings.TrimPrefix(caveat, "scope = ")
 			mostRestrictiveScope = scopeValue // Keep track of last (most restrictive) scope
-			
+
 			// Check if this specific scope caveat allows the required scope
-			scopeAllows := scopeValue == requiredScope || 
-			              scopeValue == "api:capability:*" || 
-			              scopeValue == "api:*" ||
-			              (strings.HasSuffix(scopeValue, ":*") && strings.HasPrefix(requiredScope, strings.TrimSuffix(scopeValue, "*")))
-			
+			scopeAllows := scopeValue == requiredScope ||
+				scopeValue == "api:capability:*" ||
+				scopeValue == "api:*" ||
+				(strings.HasSuffix(scopeValue, ":*") && strings.HasPrefix(requiredScope, strings.TrimSuffix(scopeValue, "*")))
+
 			// If ANY scope caveat denies access, the token is denied (macaroon AND semantics)
 			if !scopeAllows {
 				allScopesAllow = false
@@ -1084,7 +1084,7 @@ func (g *Gateway) handleCapabilityAdmin(w http.ResponseWriter, r *http.Request) 
 func (g *Gateway) handleGovernanceBan(w http.ResponseWriter, r *http.Request) {
 	// Check admin token
 	adminToken := r.Header.Get("X-Admin-Token")
-	
+
 	// Build list of valid tokens from config and environment
 	validTokens := []string{}
 	if g.config.Admin.Token != "" {
@@ -1093,7 +1093,7 @@ func (g *Gateway) handleGovernanceBan(w http.ResponseWriter, r *http.Request) {
 	if envToken := strings.TrimSpace(getEnv("ADMIN_TOKEN", "")); envToken != "" {
 		validTokens = append(validTokens, envToken)
 	}
-	
+
 	// Verify token matches one of the valid tokens
 	tokenValid := false
 	for _, vt := range validTokens {
@@ -1102,7 +1102,7 @@ func (g *Gateway) handleGovernanceBan(w http.ResponseWriter, r *http.Request) {
 			break
 		}
 	}
-	
+
 	if adminToken == "" || !tokenValid {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusUnauthorized)
@@ -1134,7 +1134,7 @@ func (g *Gateway) handleGovernanceBan(w http.ResponseWriter, r *http.Request) {
 		g.governance.Ban(req.TokenSignature, req.Reason, "admin")
 		g.governance.RecordBannedHit() // Increment kill switch counter
 	}
-	
+
 	log.Info().
 		Str("token_signature", req.TokenSignature[:min(16, len(req.TokenSignature))]).
 		Str("reason", req.Reason).
@@ -1179,7 +1179,7 @@ func (g *Gateway) handleGovernanceGraph(w http.ResponseWriter, r *http.Request) 
 	}
 
 	w.Header().Set("Content-Type", "application/json")
-	
+
 	if g.governance == nil {
 		// Return empty graph if governance not initialized
 		json.NewEncoder(w).Encode(map[string]interface{}{
@@ -1194,7 +1194,7 @@ func (g *Gateway) handleGovernanceGraph(w http.ResponseWriter, r *http.Request) 
 		})
 		return
 	}
-	
+
 	graph := g.governance.GetGraph()
 	json.NewEncoder(w).Encode(graph)
 }
@@ -1203,7 +1203,7 @@ func (g *Gateway) handleGovernanceGraph(w http.ResponseWriter, r *http.Request) 
 func (g *Gateway) handleGovernanceReset(w http.ResponseWriter, r *http.Request) {
 	// Check admin token
 	adminToken := r.Header.Get("X-Admin-Token")
-	
+
 	// Build list of valid tokens from config and environment
 	validTokens := []string{}
 	if g.config.Admin.Token != "" {
@@ -1212,7 +1212,7 @@ func (g *Gateway) handleGovernanceReset(w http.ResponseWriter, r *http.Request) 
 	if envToken := strings.TrimSpace(getEnv("ADMIN_TOKEN", "")); envToken != "" {
 		validTokens = append(validTokens, envToken)
 	}
-	
+
 	// Verify token matches one of the valid tokens
 	tokenValid := false
 	for _, vt := range validTokens {
@@ -1221,20 +1221,20 @@ func (g *Gateway) handleGovernanceReset(w http.ResponseWriter, r *http.Request) 
 			break
 		}
 	}
-	
+
 	if adminToken == "" || !tokenValid {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusUnauthorized)
 		json.NewEncoder(w).Encode(map[string]string{"error": "Invalid or missing X-Admin-Token"})
 		return
 	}
-	
+
 	if g.governance != nil {
 		g.governance.Reset()
 	}
-	
+
 	log.Info().Msg("Dashboard data reset")
-	
+
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
 	json.NewEncoder(w).Encode(map[string]interface{}{

--- a/pkg/proxy/proxy_oss_test.go
+++ b/pkg/proxy/proxy_oss_test.go
@@ -938,9 +938,9 @@ func TestDemoRoutes_ReturnMockData(t *testing.T) {
 
 func TestExtractBearerToken(t *testing.T) {
 	tests := []struct {
-		name  string
-		auth  string
-		want  string
+		name string
+		auth string
+		want string
 	}{
 		{"bearer", "Bearer abc123", "abc123"},
 		{"no prefix", "raw-token", "raw-token"},


### PR DESCRIPTION
Run `gofmt -w .` across the repo to fix CI formatting check failures.

**Files formatted (15):**
- cmd/satgate/main.go
- pkg/config/config_test.go
- pkg/governance/governance.go, governance_test.go, redis_store.go, store.go
- pkg/lightning/interface.go, lnd.go, mock.go, nwc.go, phoenixd.go
- pkg/macaroon/macaroon.go, macaroon_test.go
- pkg/proxy/proxy_oss.go, proxy_oss_test.go

Verified with `go build ./...` — compiles cleanly.