### PR TITLE
fix: Node.js SDK ESLint config + lint fixes

### DIFF
--- a/sdk/nodejs/.eslintrc.json
+++ b/sdk/nodejs/.eslintrc.json
@@ -1,0 +1,16 @@
+{
+  "parser": "@typescript-eslint/parser",
+  "plugins": ["@typescript-eslint"],
+  "extends": [
+    "eslint:recommended",
+    "plugin:@typescript-eslint/recommended"
+  ],
+  "parserOptions": {
+    "ecmaVersion": 2020,
+    "sourceType": "module"
+  },
+  "rules": {
+    "@typescript-eslint/no-explicit-any": "warn",
+    "@typescript-eslint/no-unused-vars": ["warn", { "argsIgnorePattern": "^_" }]
+  }
+}

--- a/sdk/nodejs/src/agent-client.ts
+++ b/sdk/nodejs/src/agent-client.ts
@@ -30,7 +30,6 @@ import {
   AuthenticationError,
   PaymentRequiredError,
   PaymentFailedError,
-  BudgetExceededError,
 } from './errors';
 
 export interface AgentResponse<T = unknown> {
@@ -333,7 +332,7 @@ export class SatGateAgentClient {
     if (contentType.includes('application/json')) {
       try {
         challenge = await response.json() as Record<string, unknown>;
-      } catch {}
+      } catch { /* ignore parse errors */ }
     }
     
     if (!this.wallet) {


### PR DESCRIPTION
- Add .eslintrc.json with TypeScript config
- Remove unused BudgetExceededError import
- Fix empty catch block
- ESLint passes clean