### PR TITLE
fix: Node.js SDK test config + initial test

### DIFF
--- a/sdk/nodejs/jest.config.js
+++ b/sdk/nodejs/jest.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  testMatch: ['**/__tests__/**/*.test.ts'],
+};

--- a/sdk/nodejs/src/__tests__/client.test.ts
+++ b/sdk/nodejs/src/__tests__/client.test.ts
@@ -1,0 +1,11 @@
+import { SatGateClient } from '../client';
+
+describe('SatGateClient', () => {
+  it('should create a client with base URL', () => {
+    const client = new SatGateClient({
+      url: 'http://localhost:8080',
+      token: 'test-token',
+    });
+    expect(client).toBeDefined();
+  });
+});


### PR DESCRIPTION
- Add jest.config.js with ts-jest preset
- Add initial client construction test
- Jest now finds and runs tests successfully