### PR TITLE
fix: remove X/Twitter links (empty account)

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,7 +256,6 @@ Apache License 2.0 — see [LICENSE](LICENSE) for details.
 
 - 🌐 [satgate.io](https://satgate.io)
 - 📝 [Blog](https://satgate.io/blog)
-- 🐦 [Twitter](https://twitter.com/satgate_io)
 - 📧 [contact@satgate.io](mailto:contact@satgate.io)
 
 ---

--- a/satgate-landing/app/page.tsx
+++ b/satgate-landing/app/page.tsx
@@ -686,7 +686,6 @@ curl -H <span className="text-green-400">"Authorization: L402 &lt;macaroon&gt;:&
               <h4 className="font-bold text-white mb-4">Contact</h4>
               <ul className="space-y-2 text-sm text-gray-500">
                 <li><a href="mailto:contact@satgate.io" className="hover:text-white transition">contact@satgate.io</a></li>
-                <li><a href="https://x.com/SatGateIO" target="_blank" rel="noopener noreferrer" className="hover:text-white transition">@SatGateIO</a></li>
               </ul>
             </div>
           </div>

--- a/satgate-landing/app/pricing/page.tsx
+++ b/satgate-landing/app/pricing/page.tsx
@@ -313,7 +313,6 @@ const PricingPage = () => {
               <h4 className="font-bold text-white mb-4">Contact</h4>
               <ul className="space-y-2 text-sm text-gray-500">
                 <li><a href="mailto:contact@satgate.io" className="hover:text-white transition">contact@satgate.io</a></li>
-                <li><a href="https://x.com/SatGateIO" target="_blank" rel="noopener noreferrer" className="hover:text-white transition">@SatGateIO</a></li>
               </ul>
             </div>
           </div>


### PR DESCRIPTION
Removes Twitter/X links from README and landing pages. Empty account hurts credibility — better no link than zero-tweet account, especially with HN traffic incoming.