### PR TITLE
fix: implement proper HMAC-chained macaroon delegation (H5)

### DIFF
--- a/pkg/macaroon/macaroon.go
+++ b/pkg/macaroon/macaroon.go
@@ -11,7 +11,19 @@ import (
 	"time"
 )
 
-// Macaroon represents a capability token
+// Macaroon represents a capability token using chained HMAC signatures.
+//
+// Signature chaining works as follows:
+//
+//	sig₀ = HMAC(rootKey, identifier)
+//	sig₁ = HMAC(sig₀, caveat₁)
+//	sig₂ = HMAC(sig₁, caveat₂)
+//	...
+//	sigₙ = final signature
+//
+// This enables third-party attenuation: anyone holding a macaroon can add
+// caveats by chaining from the current signature without knowing the root key.
+// The verifier reconstructs the chain from the root key to verify.
 type Macaroon struct {
 	Version    int      `json:"v"`
 	Location   string   `json:"l"`
@@ -56,21 +68,22 @@ func (s *Service) Mint(scope string, expiresAt time.Time) (*Macaroon, error) {
 		mac.Caveats = append(mac.Caveats, fmt.Sprintf("scope = %s", scope))
 	}
 
-	// Calculate signature
-	mac.Signature = s.calculateSignature(mac)
+	// Calculate chained signature
+	mac.Signature = s.chainedSignature(mac)
 
 	return mac, nil
 }
 
-// Verify validates a macaroon token
+// Verify validates a macaroon token by reconstructing the HMAC chain
+// from the root key and comparing the final signature.
 func (s *Service) Verify(token string) (*Macaroon, error) {
 	mac, err := s.Decode(token)
 	if err != nil {
 		return nil, fmt.Errorf("failed to decode token: %w", err)
 	}
 
-	// Verify signature
-	expectedSig := s.calculateSignature(mac)
+	// Reconstruct the chained signature from root key
+	expectedSig := s.chainedSignature(mac)
 	if !hmac.Equal([]byte(mac.Signature), []byte(expectedSig)) {
 		return nil, fmt.Errorf("invalid signature")
 	}
@@ -85,31 +98,80 @@ func (s *Service) Verify(token string) (*Macaroon, error) {
 	return mac, nil
 }
 
-// Delegate creates a child macaroon with additional caveats
+// Delegate creates a child macaroon with additional caveats using proper
+// HMAC chaining. The new caveats are chained from the parent's signature,
+// meaning the delegator does NOT need the root key — only the current token.
+//
+// This is the core macaroon attenuation property: permissions can only be
+// narrowed, never widened, because caveats are cumulative and signatures
+// are cryptographically chained.
 func (s *Service) Delegate(parentToken string, additionalCaveats []string) (*Macaroon, error) {
 	parent, err := s.Decode(parentToken)
 	if err != nil {
 		return nil, fmt.Errorf("failed to decode parent: %w", err)
 	}
 
-	// Verify parent first - only valid tokens can be delegated
+	// Verify parent first — only valid tokens can be delegated
 	if _, err := s.Verify(parentToken); err != nil {
 		return nil, fmt.Errorf("invalid parent token: %w", err)
 	}
 
-	// Create child with parent's caveats plus new ones
-	// Caveats are cumulative - can only add restrictions, never remove
+	// Create child with parent's identifier, all parent caveats, plus new ones
 	child := &Macaroon{
 		Version:    parent.Version,
 		Location:   parent.Location,
-		Identifier: fmt.Sprintf("%s:child:%d", parent.Identifier, time.Now().UnixMilli()),
+		Identifier: parent.Identifier,
 		Caveats:    append(append([]string{}, parent.Caveats...), additionalCaveats...),
 	}
 
-	// Calculate signature using root key for verification compatibility
-	// Security note: The attenuation property is preserved because caveats
-	// are cumulative (child has all parent caveats plus additional ones)
-	child.Signature = s.calculateSignature(child)
+	// Chain signature: start from parent's signature and chain through new caveats.
+	// This is equivalent to reconstructing from root key through ALL caveats,
+	// but demonstrates that delegation only needs the parent signature.
+	sig, err := hex.DecodeString(parent.Signature)
+	if err != nil {
+		return nil, fmt.Errorf("invalid parent signature: %w", err)
+	}
+	for _, caveat := range additionalCaveats {
+		mac := hmac.New(sha256.New, sig)
+		mac.Write([]byte(caveat))
+		sig = mac.Sum(nil)
+	}
+	child.Signature = hex.EncodeToString(sig)
+
+	return child, nil
+}
+
+// DelegateWithoutVerify creates an attenuated child macaroon without
+// requiring the root key for verification. This enables true third-party
+// delegation: any token holder can add caveats by chaining from their
+// token's signature.
+//
+// WARNING: The caller is responsible for ensuring the parent token is valid.
+// Use Delegate() when the service has the root key available.
+func (s *Service) DelegateWithoutVerify(parentToken string, additionalCaveats []string) (*Macaroon, error) {
+	parent, err := s.Decode(parentToken)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode parent: %w", err)
+	}
+
+	child := &Macaroon{
+		Version:    parent.Version,
+		Location:   parent.Location,
+		Identifier: parent.Identifier,
+		Caveats:    append(append([]string{}, parent.Caveats...), additionalCaveats...),
+	}
+
+	// Chain from parent signature through new caveats
+	sig, err := hex.DecodeString(parent.Signature)
+	if err != nil {
+		return nil, fmt.Errorf("invalid parent signature: %w", err)
+	}
+	for _, caveat := range additionalCaveats {
+		mac := hmac.New(sha256.New, sig)
+		mac.Write([]byte(caveat))
+		sig = mac.Sum(nil)
+	}
+	child.Signature = hex.EncodeToString(sig)
 
 	return child, nil
 }
@@ -139,30 +201,30 @@ func (s *Service) Decode(token string) (*Macaroon, error) {
 	return &mac, nil
 }
 
-// calculateSignature computes the HMAC signature
-func (s *Service) calculateSignature(mac *Macaroon) string {
-	return s.calculateSignatureWithKey(mac, s.rootKey)
-}
-
-// RecalculateSignature recalculates the signature for a macaroon
-// This MUST be called after adding caveats to ensure signature validity
-func (s *Service) RecalculateSignature(mac *Macaroon) string {
-	return s.calculateSignature(mac)
-}
-
-// calculateSignatureWithKey computes signature with a specific key
-func (s *Service) calculateSignatureWithKey(mac *Macaroon, key []byte) string {
-	h := hmac.New(sha256.New, key)
-
-	// Include identifier
+// chainedSignature computes the chained HMAC signature for a macaroon.
+//
+//	sig₀ = HMAC(rootKey, identifier)
+//	sigₙ = HMAC(sigₙ₋₁, caveatₙ)
+func (s *Service) chainedSignature(mac *Macaroon) string {
+	// sig₀ = HMAC(rootKey, identifier)
+	h := hmac.New(sha256.New, s.rootKey)
 	h.Write([]byte(mac.Identifier))
+	sig := h.Sum(nil)
 
-	// Include each caveat
+	// sigₙ = HMAC(sigₙ₋₁, caveatₙ)
 	for _, caveat := range mac.Caveats {
+		h = hmac.New(sha256.New, sig)
 		h.Write([]byte(caveat))
+		sig = h.Sum(nil)
 	}
 
-	return hex.EncodeToString(h.Sum(nil))
+	return hex.EncodeToString(sig)
+}
+
+// RecalculateSignature recalculates the chained signature for a macaroon.
+// This MUST be called after adding caveats to ensure signature validity.
+func (s *Service) RecalculateSignature(mac *Macaroon) string {
+	return s.chainedSignature(mac)
 }
 
 // verifyCaveat checks if a caveat is satisfied
@@ -286,7 +348,7 @@ func (m *Macaroon) GetScope() string {
 var _ = (*Macaroon)(nil) // Ensure Macaroon type exists
 
 // AddCaveat adds a new caveat to the macaroon
-// Note: This must be done BEFORE calculating the signature
+// Note: After adding caveats, call RecalculateSignature to update the signature.
 func (m *Macaroon) AddCaveat(key, value string) {
 	m.Caveats = append(m.Caveats, fmt.Sprintf("%s = %s", key, value))
 }
@@ -340,8 +402,8 @@ func (w *MintWrapper) Mint(scope string, expiresAt time.Time) (interface{ AddCav
 // Encode serializes the macaroon to a string
 func (w *MintWrapper) Encode(mac interface{}) string {
 	if wrapper, ok := mac.(*MacaroonWrapper); ok {
-		// Recalculate signature after adding caveats
-		wrapper.mac.Signature = w.svc.calculateSignature(wrapper.mac)
+		// Recalculate chained signature after adding caveats
+		wrapper.mac.Signature = w.svc.chainedSignature(wrapper.mac)
 		return w.svc.Encode(wrapper.mac)
 	}
 	return ""

--- a/pkg/macaroon/macaroon_test.go
+++ b/pkg/macaroon/macaroon_test.go
@@ -123,6 +123,202 @@ func TestService_Delegate(t *testing.T) {
 	}
 }
 
+func TestService_Delegate_ChainedVerification(t *testing.T) {
+	svc, err := NewService("test-secret")
+	if err != nil {
+		t.Fatalf("Failed to create service: %v", err)
+	}
+
+	// Mint root token
+	root, err := svc.Mint("api:*", time.Now().Add(time.Hour))
+	if err != nil {
+		t.Fatalf("Failed to mint root: %v", err)
+	}
+	rootToken := svc.Encode(root)
+
+	// Delegate: root → child (restrict to api:read)
+	child, err := svc.Delegate(rootToken, []string{"scope = api:read"})
+	if err != nil {
+		t.Fatalf("Failed to delegate to child: %v", err)
+	}
+	childToken := svc.Encode(child)
+
+	// Verify child token with root key — chained signature must verify
+	verified, err := svc.Verify(childToken)
+	if err != nil {
+		t.Fatalf("Failed to verify delegated child: %v", err)
+	}
+
+	// Child must have parent's caveats plus new one
+	if len(verified.Caveats) != len(root.Caveats)+1 {
+		t.Errorf("Expected %d caveats, got %d", len(root.Caveats)+1, len(verified.Caveats))
+	}
+}
+
+func TestService_Delegate_MultiLevel(t *testing.T) {
+	svc, err := NewService("test-secret")
+	if err != nil {
+		t.Fatalf("Failed to create service: %v", err)
+	}
+
+	// Mint root with wide scope
+	root, err := svc.Mint("api:*", time.Now().Add(time.Hour))
+	if err != nil {
+		t.Fatalf("Failed to mint root: %v", err)
+	}
+	rootToken := svc.Encode(root)
+
+	// Level 1: restrict to read
+	level1, err := svc.Delegate(rootToken, []string{"scope = api:read"})
+	if err != nil {
+		t.Fatalf("Failed L1 delegation: %v", err)
+	}
+	level1Token := svc.Encode(level1)
+
+	// Level 2: add rate limit
+	level2, err := svc.Delegate(level1Token, []string{"rate_limit = 100"})
+	if err != nil {
+		t.Fatalf("Failed L2 delegation: %v", err)
+	}
+	level2Token := svc.Encode(level2)
+
+	// Level 3: add IP restriction
+	level3, err := svc.Delegate(level2Token, []string{"ip = 192.168.1.0/24"})
+	if err != nil {
+		t.Fatalf("Failed L3 delegation: %v", err)
+	}
+	level3Token := svc.Encode(level3)
+
+	// All levels must verify against root key
+	for name, token := range map[string]string{
+		"root":   rootToken,
+		"level1": level1Token,
+		"level2": level2Token,
+		"level3": level3Token,
+	} {
+		if _, err := svc.Verify(token); err != nil {
+			t.Errorf("Failed to verify %s: %v", name, err)
+		}
+	}
+
+	// Level 3 should have root caveats + 3 additional
+	if len(level3.Caveats) != len(root.Caveats)+3 {
+		t.Errorf("Expected %d caveats at level 3, got %d", len(root.Caveats)+3, len(level3.Caveats))
+	}
+}
+
+func TestService_Delegate_PreservesIdentifier(t *testing.T) {
+	svc, err := NewService("test-secret")
+	if err != nil {
+		t.Fatalf("Failed to create service: %v", err)
+	}
+
+	root, err := svc.Mint("api:*", time.Now().Add(time.Hour))
+	if err != nil {
+		t.Fatalf("Failed to mint: %v", err)
+	}
+	rootToken := svc.Encode(root)
+
+	child, err := svc.Delegate(rootToken, []string{"scope = api:read"})
+	if err != nil {
+		t.Fatalf("Failed to delegate: %v", err)
+	}
+
+	// Child must keep parent's identifier (same chain)
+	if child.Identifier != root.Identifier {
+		t.Errorf("Child identifier %q should match parent %q", child.Identifier, root.Identifier)
+	}
+}
+
+func TestService_Delegate_TamperedCaveatFails(t *testing.T) {
+	svc, err := NewService("test-secret")
+	if err != nil {
+		t.Fatalf("Failed to create service: %v", err)
+	}
+
+	root, err := svc.Mint("api:*", time.Now().Add(time.Hour))
+	if err != nil {
+		t.Fatalf("Failed to mint: %v", err)
+	}
+	rootToken := svc.Encode(root)
+
+	child, err := svc.Delegate(rootToken, []string{"scope = api:read"})
+	if err != nil {
+		t.Fatalf("Failed to delegate: %v", err)
+	}
+
+	// Tamper: try to widen scope by modifying a caveat
+	child.Caveats[len(child.Caveats)-1] = "scope = api:*"
+	tamperedToken := svc.Encode(child)
+
+	_, err = svc.Verify(tamperedToken)
+	if err == nil {
+		t.Error("Tampered caveat should fail verification — attenuation must be enforced cryptographically")
+	}
+}
+
+func TestService_Delegate_RemovedCaveatFails(t *testing.T) {
+	svc, err := NewService("test-secret")
+	if err != nil {
+		t.Fatalf("Failed to create service: %v", err)
+	}
+
+	root, err := svc.Mint("api:*", time.Now().Add(time.Hour))
+	if err != nil {
+		t.Fatalf("Failed to mint: %v", err)
+	}
+	rootToken := svc.Encode(root)
+
+	child, err := svc.Delegate(rootToken, []string{"scope = api:read", "rate_limit = 50"})
+	if err != nil {
+		t.Fatalf("Failed to delegate: %v", err)
+	}
+
+	// Tamper: remove the rate limit caveat (try to widen permissions)
+	child.Caveats = child.Caveats[:len(child.Caveats)-1]
+	tamperedToken := svc.Encode(child)
+
+	_, err = svc.Verify(tamperedToken)
+	if err == nil {
+		t.Error("Removing a caveat should fail verification — caveats are cryptographically bound")
+	}
+}
+
+func TestService_DelegateWithoutVerify(t *testing.T) {
+	svc, err := NewService("test-secret")
+	if err != nil {
+		t.Fatalf("Failed to create service: %v", err)
+	}
+
+	// Mint and delegate normally
+	root, err := svc.Mint("api:*", time.Now().Add(time.Hour))
+	if err != nil {
+		t.Fatalf("Failed to mint: %v", err)
+	}
+	rootToken := svc.Encode(root)
+
+	// DelegateWithoutVerify should produce same result as Delegate
+	child1, err := svc.Delegate(rootToken, []string{"scope = api:read"})
+	if err != nil {
+		t.Fatalf("Delegate failed: %v", err)
+	}
+
+	child2, err := svc.DelegateWithoutVerify(rootToken, []string{"scope = api:read"})
+	if err != nil {
+		t.Fatalf("DelegateWithoutVerify failed: %v", err)
+	}
+
+	if child1.Signature != child2.Signature {
+		t.Error("DelegateWithoutVerify should produce same signature as Delegate")
+	}
+
+	// And it should verify
+	childToken := svc.Encode(child2)
+	if _, err := svc.Verify(childToken); err != nil {
+		t.Fatalf("DelegateWithoutVerify token should verify: %v", err)
+	}
+}
+
 func TestMacaroon_HasScope(t *testing.T) {
 	tests := []struct {
 		tokenScope    string
@@ -198,5 +394,19 @@ func BenchmarkVerify(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		svc.Verify(token)
+	}
+}
+
+func BenchmarkDelegateMultiLevel(b *testing.B) {
+	svc, _ := NewService("bench-secret")
+	root, _ := svc.Mint("api:*", time.Now().Add(time.Hour))
+	rootToken := svc.Encode(root)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		l1, _ := svc.Delegate(rootToken, []string{"scope = api:read"})
+		l1Token := svc.Encode(l1)
+		l2, _ := svc.Delegate(l1Token, []string{"rate_limit = 100"})
+		svc.Verify(svc.Encode(l2))
 	}
 }


### PR DESCRIPTION
## What

Replaces the flat HMAC signature scheme with proper chained signatures per the [macaroon specification](https://research.google/pubs/pub41892/).

**Before:** `sig = HMAC(rootKey, identifier + all_caveats)` — delegation required the root key, defeating the purpose of macaroons.

**After:**
```
sig₀ = HMAC(rootKey, identifier)
sig₁ = HMAC(sig₀, caveat₁)
sig₂ = HMAC(sig₁, caveat₂)
```

This is the core property that makes macaroons *macaroons* — anyone holding a token can add caveats (narrow permissions) by chaining from the current signature, without knowing the root key.

## What changes

- `chainedSignature()` replaces `calculateSignature()` — iterative HMAC chain
- `Delegate()` chains from parent signature through new caveats
- `DelegateWithoutVerify()` enables true third-party delegation
- Child macaroons preserve parent identifier (same chain, not new token)
- Caveats are cryptographically bound — tampering or removal breaks verification

## Tests (13 pass)

- Multi-level delegation (root → L1 → L2 → L3) all verify ✅
- Tampered caveat detection ✅
- Removed caveat detection ✅
- `DelegateWithoutVerify` equivalence ✅
- All existing tests pass ✅
- Benchmark for multi-level delegate+verify added

## Why now

This is a key value proposition we market — attenuated delegation via macaroons. The implementation needs to match the promise before Show HN tomorrow.