### PR TITLE
fix: add rate limiting on admin API endpoints (H3)

### DIFF
--- a/pkg/proxy/proxy_oss.go
+++ b/pkg/proxy/proxy_oss.go
@@ -47,6 +47,9 @@ type Gateway struct {
 	proxyMu     sync.RWMutex
 	metrics     *Metrics
 
+	// Rate limiter for admin endpoints
+	adminLimiter *rateLimiter
+
 	// Optional hooks (set via SetXxx methods)
 	metricsHook MetricsHook
 }
@@ -82,13 +85,20 @@ func New(opts Options) (*Gateway, error) {
 		return nil, fmt.Errorf("macaroon service is required")
 	}
 
+	// Initialize admin rate limiter (default: 60 req/min if not configured)
+	adminRPM := opts.Config.Admin.RateLimitPerMinute
+	if adminRPM == 0 {
+		adminRPM = 60
+	}
+
 	g := &Gateway{
-		config:      opts.Config,
-		macaroonSvc: opts.Macaroon,
-		governance:  opts.Governance,
-		lightning:   opts.Lightning,
-		proxies:     make(map[string]*httputil.ReverseProxy),
-		metrics:     &Metrics{},
+		config:       opts.Config,
+		macaroonSvc:  opts.Macaroon,
+		governance:   opts.Governance,
+		lightning:    opts.Lightning,
+		proxies:      make(map[string]*httputil.ReverseProxy),
+		metrics:      &Metrics{},
+		adminLimiter: newRateLimiter(adminRPM),
 	}
 
 	// Initialize proxies for configured upstreams
@@ -155,6 +165,18 @@ func (g *Gateway) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if strings.HasPrefix(r.URL.Path, "/check-payment/") {
 		g.handleCheckPayment(w, r)
 		return
+	}
+
+	// Rate limit admin API endpoints
+	if strings.HasPrefix(r.URL.Path, "/api/") {
+		clientIP := extractIP(r)
+		if !g.adminLimiter.allow(clientIP) {
+			w.Header().Set("Content-Type", "application/json")
+			w.Header().Set("Retry-After", "60")
+			w.WriteHeader(http.StatusTooManyRequests)
+			json.NewEncoder(w).Encode(map[string]string{"error": "Rate limit exceeded"})
+			return
+		}
 	}
 
 	// Admin endpoint: Capability token minting

--- a/pkg/proxy/ratelimit.go
+++ b/pkg/proxy/ratelimit.go
@@ -1,0 +1,112 @@
+package proxy
+
+import (
+	"net"
+	"net/http"
+	"sync"
+	"time"
+)
+
+// rateLimiter implements a simple in-memory token bucket rate limiter
+// keyed by IP address. Designed for admin API protection.
+type rateLimiter struct {
+	mu        sync.Mutex
+	buckets   map[string]*bucket
+	rate      int           // requests per window
+	window    time.Duration // sliding window size
+	cleanup   time.Duration // how often to purge expired entries
+	lastPurge time.Time
+}
+
+type bucket struct {
+	tokens []time.Time // timestamps of recent requests
+}
+
+// newRateLimiter creates a rate limiter. rate=0 means unlimited.
+func newRateLimiter(requestsPerMinute int) *rateLimiter {
+	return &rateLimiter{
+		buckets:   make(map[string]*bucket),
+		rate:      requestsPerMinute,
+		window:    time.Minute,
+		cleanup:   5 * time.Minute,
+		lastPurge: time.Now(),
+	}
+}
+
+// allow checks if a request from the given key should be allowed.
+// Returns true if allowed, false if rate limited.
+func (rl *rateLimiter) allow(key string) bool {
+	if rl.rate <= 0 {
+		return true // unlimited
+	}
+
+	rl.mu.Lock()
+	defer rl.mu.Unlock()
+
+	now := time.Now()
+	cutoff := now.Add(-rl.window)
+
+	// Periodic cleanup of stale entries
+	if now.Sub(rl.lastPurge) > rl.cleanup {
+		for k, b := range rl.buckets {
+			b.prune(cutoff)
+			if len(b.tokens) == 0 {
+				delete(rl.buckets, k)
+			}
+		}
+		rl.lastPurge = now
+	}
+
+	b, ok := rl.buckets[key]
+	if !ok {
+		b = &bucket{}
+		rl.buckets[key] = b
+	}
+
+	// Prune old tokens
+	b.prune(cutoff)
+
+	if len(b.tokens) >= rl.rate {
+		return false
+	}
+
+	b.tokens = append(b.tokens, now)
+	return true
+}
+
+// prune removes timestamps older than cutoff
+func (b *bucket) prune(cutoff time.Time) {
+	i := 0
+	for i < len(b.tokens) && b.tokens[i].Before(cutoff) {
+		i++
+	}
+	if i > 0 {
+		b.tokens = b.tokens[i:]
+	}
+}
+
+// extractIP gets the client IP, respecting X-Forwarded-For for proxied setups
+func extractIP(r *http.Request) string {
+	// Check X-Forwarded-For first (leftmost = original client)
+	if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
+		// Take the first IP (original client)
+		for i := 0; i < len(xff); i++ {
+			if xff[i] == ',' {
+				ip := xff[:i]
+				// Trim whitespace
+				for len(ip) > 0 && ip[0] == ' ' {
+					ip = ip[1:]
+				}
+				return ip
+			}
+		}
+		return xff
+	}
+
+	// Fall back to RemoteAddr
+	host, _, err := net.SplitHostPort(r.RemoteAddr)
+	if err != nil {
+		return r.RemoteAddr
+	}
+	return host
+}

--- a/pkg/proxy/ratelimit_test.go
+++ b/pkg/proxy/ratelimit_test.go
@@ -1,0 +1,80 @@
+package proxy
+
+import (
+	"net/http"
+	"testing"
+)
+
+func TestRateLimiter_AllowsUnderLimit(t *testing.T) {
+	rl := newRateLimiter(10)
+	for i := 0; i < 10; i++ {
+		if !rl.allow("test-ip") {
+			t.Fatalf("request %d should be allowed (limit 10)", i+1)
+		}
+	}
+}
+
+func TestRateLimiter_BlocksOverLimit(t *testing.T) {
+	rl := newRateLimiter(5)
+	for i := 0; i < 5; i++ {
+		rl.allow("test-ip")
+	}
+	if rl.allow("test-ip") {
+		t.Fatal("6th request should be blocked (limit 5)")
+	}
+}
+
+func TestRateLimiter_SeparateKeys(t *testing.T) {
+	rl := newRateLimiter(2)
+	rl.allow("ip-a")
+	rl.allow("ip-a")
+
+	// ip-a is exhausted
+	if rl.allow("ip-a") {
+		t.Fatal("ip-a should be blocked")
+	}
+
+	// ip-b should still work
+	if !rl.allow("ip-b") {
+		t.Fatal("ip-b should be allowed (separate bucket)")
+	}
+}
+
+func TestRateLimiter_UnlimitedWhenZero(t *testing.T) {
+	rl := newRateLimiter(0)
+	for i := 0; i < 1000; i++ {
+		if !rl.allow("test") {
+			t.Fatal("should be unlimited when rate=0")
+		}
+	}
+}
+
+func TestExtractIP(t *testing.T) {
+	tests := []struct {
+		name     string
+		xff      string
+		remote   string
+		expected string
+	}{
+		{"no xff", "", "192.168.1.1:12345", "192.168.1.1"},
+		{"xff single", "10.0.0.1", "192.168.1.1:12345", "10.0.0.1"},
+		{"xff chain", "10.0.0.1, 172.16.0.1, 192.168.1.1", "proxy:8080", "10.0.0.1"},
+		{"no port", "", "192.168.1.1", "192.168.1.1"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &http.Request{
+				RemoteAddr: tt.remote,
+				Header:     http.Header{},
+			}
+			if tt.xff != "" {
+				r.Header.Set("X-Forwarded-For", tt.xff)
+			}
+			got := extractIP(r)
+			if got != tt.expected {
+				t.Errorf("extractIP() = %q, want %q", got, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Adds in-memory sliding-window rate limiter for all `/api/*` admin endpoints.

**Default:** 60 req/min per IP. Configurable via `admin.rateLimitPerMinute`.

- 429 + `Retry-After` header when exceeded
- Per-IP bucketing (respects `X-Forwarded-For`)
- Auto-cleanup of stale buckets
- Rate=0 disables limiting

**Tested:** Set limit to 5/min, 6th request correctly returns 429.