### PR TITLE
fix: match tenant-prefixed MCP scopes

### DIFF
--- a/pkg/mcpserver/proxy.go
+++ b/pkg/mcpserver/proxy.go
@@ -796,10 +796,14 @@ func matchScope(scope, toolName string) bool {
 	for _, s := range strings.Split(scope, ",") {
 		s = strings.TrimSpace(s)
 
-		// Strip tenant UUID prefix if present (format: "uuid:scope")
-		// UUIDs are 36 chars with hyphens (8-4-4-4-12)
-		if len(s) > 37 && s[36] == ':' && s[8] == '-' && s[13] == '-' {
-			s = s[37:]
+		// Strip tenant prefix if present (format: "tenant-id:scope").
+		// SaaS tokens are minted with tenant-prefixed scopes such as
+		// "demo-82712860:*"; older logic only handled UUID tenant IDs.
+		if idx := strings.IndexByte(s, ':'); idx > 0 {
+			rest := s[idx+1:]
+			if rest == "*" || rest == "api:*" || rest == "mcp:*" || strings.HasSuffix(rest, ":*") {
+				s = rest
+			}
 		}
 
 		if s == "*" || s == "api:*" || s == "mcp:*" {

--- a/pkg/mcpserver/scope_test.go
+++ b/pkg/mcpserver/scope_test.go
@@ -1,0 +1,28 @@
+package mcpserver
+
+import "testing"
+
+func TestMatchScopeTenantPrefixedWildcard(t *testing.T) {
+	tests := []struct {
+		name     string
+		scope    string
+		toolName string
+		want     bool
+	}{
+		{name: "tenant slug wildcard", scope: "demo-82712860:*", toolName: "ping", want: true},
+		{name: "tenant slug mcp wildcard", scope: "demo-82712860:mcp:*", toolName: "ping", want: true},
+		{name: "tenant slug namespaced wildcard", scope: "demo-82712860:db:*", toolName: "db:query", want: true},
+		{name: "uuid wildcard", scope: "123e4567-e89b-12d3-a456-426614174000:*", toolName: "ping", want: true},
+		{name: "unrelated exact colon tool remains exact", scope: "db:query", toolName: "db:query", want: true},
+		{name: "unrelated exact colon tool does not widen", scope: "db:query", toolName: "query", want: false},
+		{name: "tenant prefix does not widen exact unrelated", scope: "demo-82712860:db:query", toolName: "query", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := matchScope(tt.scope, tt.toolName); got != tt.want {
+				t.Fatalf("matchScope(%q, %q) = %v, want %v", tt.scope, tt.toolName, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- allow MCP scope matching to strip non-UUID tenant prefixes such as `demo-82712860:*`
- preserve exact colon-scoped tool matching so this does not widen unrelated scopes
- add regression coverage for tenant-slug wildcard and namespaced scopes

## Validation
- `go test ./pkg/mcpserver`

Freeze-4 context: staging SaaS MCP tokens are tenant-prefixed by slug, but the deployed matcher only stripped UUID prefixes, causing `tools/call` to fail with `tool ... not in scope ...` after dashboard tenant/session fixes.
