### PR TITLE
feat(landing): strengthen Policy-to-Proof evidence page

### DIFF
--- a/satgate-landing/app/policy-to-proof/page.tsx
+++ b/satgate-landing/app/policy-to-proof/page.tsx
@@ -3,13 +3,11 @@ import Link from "next/link";
 import {
   ArrowRight,
   BadgeCheck,
-  Ban,
   CheckCircle2,
-  CircleDollarSign,
+  Download,
   FileText,
-  KeyRound,
+  PlayCircle,
   ShieldCheck,
-  TimerReset,
 } from "lucide-react";
 
 export const metadata: Metadata = {
@@ -48,12 +46,12 @@ const evidenceQuestions = [
   {
     question: "Who authorized this?",
     artifact: "Mint receipt",
-    body: "Identity claim, policy match, issuer, timestamp, and the capability minted for the agent.",
+    body: "Identity claim, policy match, issuer, timestamp, and the capability minted for the invoice-reconciler worker.",
   },
   {
     question: "Which agent got access?",
     artifact: "Capability token + delegation chain",
-    body: "The root capability, parent agent, worker agent, and every attenuation in the handoff path.",
+    body: "The root capability, parent agent, invoice-reconciler worker, and every attenuation in the handoff path.",
   },
   {
     question: "What exactly could it do?",
@@ -63,40 +61,78 @@ const evidenceQuestions = [
   {
     question: "What did it spend?",
     artifact: "Per-token spend ledger",
-    body: "Request-path and MCP-tool attribution by agent, token, tenant, route, amount, and policy mode.",
+    body: "Request-path and MCP-tool attribution by worker, token, tenant, route, amount, and policy mode.",
   },
   {
     question: "What was denied?",
     artifact: "Denial receipt",
-    body: "A policy, budget, scope, tenant, or revocation reason code attached to the blocked call.",
+    body: "A policy, budget, scope, tenant, or revocation reason code attached to the blocked invoice call.",
   },
   {
     question: "Can we prove revocation worked?",
     artifact: "Revocation receipt + post-revoke denial",
-    body: "The revocation event and the first failed call after access ended, tied to the same authority chain.",
+    body: "The revocation event and the first failed invoice-reconciler call after access ended, tied to the same authority chain.",
   },
 ];
 
 const demoSteps = [
-  ["Mint", "Agent presents identity and receives a scoped macaroon capability with caveats."],
-  ["Delegate", "The parent agent hands narrower authority to a worker; the chain is preserved."],
-  ["Spend", "The worker calls an API or MCP tool under budget; the ledger updates by token and path."],
-  ["Deny", "The next call hits a cap, scope, or tenant boundary and returns a reason-coded receipt."],
-  ["Revoke", "Authority is killed without rotating every upstream provider key."],
-  ["Export", "The lifecycle becomes an Evidence Pack a CISO, auditor, or incident reviewer can read."],
+  ["Mint", "invoice-reconciler gets a scoped macaroon capability with tenant, budget, route, and expiry caveats."],
+  ["Delegate", "The parent finance agent hands narrower authority to the worker; the chain is preserved."],
+  ["Spend", "The worker calls invoice APIs or MCP tools under budget; the ledger updates by token and path."],
+  ["Deny", "Export and over-budget calls return reason-coded receipts before data or spend escapes."],
+  ["Revoke", "Security kills the worker capability without rotating every upstream provider key."],
+  ["Export", "The lifecycle becomes one Evidence Pack a CISO, auditor, or incident reviewer can read."],
+];
+
+const standardsMappings = [
+  ["Mint receipt", "SOC 2 CC6.1", "Logical access provisioning tied to identity, policy, issuer, and timestamp."],
+  ["Delegation chain", "SOC 2 CC6.3 / NIST AC-3", "Least-privilege attenuation across parent and worker authority."],
+  ["Revocation receipt", "SOC 2 CC6.2/CC6.3 / NIST AC-2(3)", "Deprovisioning event plus first post-revoke denial trail."],
+  ["Spend ledger", "SOC 2 CC1.4 / FinOps attribution", "Governance evidence for who created spend, on which route/tool, under which token."],
+];
+
+const personas = [
+  ["Auditor", "I get the authority trail in one export instead of opening a forensics ticket."],
+  ["CISO", "Revocation isn’t a promise — it’s a signed receipt followed by a denied call."],
+  ["FinOps lead", "Spend is attributed to the agent, the token, and the route — not a shared API key."],
 ];
 
 const evidencePack = {
   evidence_pack_id: "ep_demo_2026_05_09_001",
+  issued_at: "2026-05-09T14:22:31Z",
+  expires_at: "2026-05-16T14:22:31Z",
+  tenant: "acme-finance",
   subject: "worker-agent:invoice-reconciler",
-  authority_chain: ["root:finance-automation", "delegate:invoice-worker"],
-  receipts: [
-    { type: "mint", result: "issued", caveats: ["tenant=acme", "budget_usd=25", "delegation_depth<=1"] },
-    { type: "spend", result: "allowed", route: "/v1/invoices/search", amount_usd: "0.18" },
-    { type: "denial", result: "blocked", reason: "budget_exhausted", route: "/v1/invoices/export" },
-    { type: "revocation", result: "revoked", revoked_by: "security-admin" },
-    { type: "post_revoke_denial", result: "blocked", reason: "capability_revoked" },
+  authority_chain: [
+    {
+      kind: "root_grant",
+      subject: "dean-agent:finance-automation",
+      issuer_kid: "satgate-mint-2026-05",
+      caveats: ["tenant=acme-finance", "budget_usd<=25", "delegation_depth<=1"],
+      receipt_hash: "sha256:7a2ca1b8d5e0a0d7c9545c7f8e6d03d12761b687a7a1f27c0dd7ed2e643a01b5",
+    },
+    {
+      kind: "delegation",
+      subject: "worker-agent:invoice-reconciler",
+      parent: "dean-agent:finance-automation",
+      caveats: ["budget_usd<=3", "no_customer_data_export", "route_prefix=/v1/invoices"],
+      receipt_hash: "sha256:95f1c3df9d1f8d7a0e5b60b850f4b6013dd2f0e18496f9e5a8c0319fd51382bf",
+    },
   ],
+  receipts: [
+    { type: "mint", ts: "2026-05-09T14:22:31Z", issuer_kid: "satgate-mint-2026-05", result: "issued", receipt_hash: "sha256:7a2c..." },
+    { type: "delegation", ts: "2026-05-09T14:23:04Z", result: "attenuated", receipt_hash: "sha256:95f1..." },
+    { type: "spend", ts: "2026-05-09T14:23:18Z", route: "/v1/invoices/search", amount_usd: "0.18", result: "allowed", receipt_hash: "sha256:01d8..." },
+    { type: "spend", ts: "2026-05-09T14:24:02Z", route: "/v1/invoices/compare", amount_usd: "0.42", result: "allowed", receipt_hash: "sha256:a923..." },
+    { type: "spend", ts: "2026-05-09T14:24:44Z", route: "/v1/invoices/reconcile", amount_usd: "1.12", result: "allowed", receipt_hash: "sha256:deb5..." },
+    { type: "denial", ts: "2026-05-09T14:25:08Z", reason_code: "scope_violation:no_customer_data_export", result: "blocked", receipt_hash: "sha256:9b0f..." },
+    { type: "denial", ts: "2026-05-09T14:25:33Z", reason_code: "budget_exhausted", result: "blocked", receipt_hash: "sha256:c3f6..." },
+    { type: "revocation", ts: "2026-05-09T14:26:11Z", revoked_by: "security-admin", result: "revoked", receipt_hash: "sha256:37d1..." },
+    { type: "post_revoke_denial", ts: "2026-05-09T14:26:16Z", reason_code: "capability_revoked", result: "blocked", receipt_hash: "sha256:8b95..." },
+    { type: "export", ts: "2026-05-09T14:26:31Z", result: "evidence_pack_issued", receipt_hash: "sha256:e1b3..." },
+  ],
+  chain_root: "sha256:f04ed8430b11c8975cc5ef35919ee078fc4cb166cd8d611ed0d94b7da69df09d",
+  signature: "ed25519:u3o9l6nN4z-demo-signature-redacted-proof-preview",
 };
 
 const jsonLd = {
@@ -146,6 +182,9 @@ export default function PolicyToProofPage() {
           </div>
           <div className="grid gap-10 lg:grid-cols-[1.05fr_0.95fr] lg:items-center">
             <div>
+              <p className="mb-5 max-w-2xl rounded-2xl border border-white/10 bg-white/[0.04] p-4 text-sm leading-6 text-gray-300">
+                Monday morning, your auditor asks who authorized the agent that tried to export customer data on Friday night. This is what they get.
+              </p>
               <h1 className="max-w-4xl text-5xl font-black tracking-tight sm:text-6xl lg:text-7xl">
                 Every agent action leaves a receipt.
               </h1>
@@ -155,18 +194,24 @@ export default function PolicyToProofPage() {
               <p className="mt-5 max-w-3xl text-lg leading-8 text-gray-400">
                 Run agents without permanent credentials, unlimited spend, or unobservable authority. Then export the proof when your CISO, auditor, board, or incident reviewer asks what happened.
               </p>
-              <div className="mt-8 flex flex-col gap-3 sm:flex-row">
-                <Link
-                  href="/agent-control-plane"
+              <div className="mt-8 flex flex-col gap-3 sm:flex-row sm:flex-wrap">
+                <a
+                  href="/evidence-packs/sample-evidence-pack.pdf"
                   className="inline-flex items-center justify-center gap-2 rounded-lg bg-white px-5 py-3 font-bold text-black transition hover:bg-gray-200"
                 >
-                  See the agent control plane <ArrowRight size={18} />
-                </Link>
+                  Download sample Evidence Pack <Download size={18} />
+                </a>
+                <a
+                  href="/evidence-packs/sample-evidence-pack.json"
+                  className="inline-flex items-center justify-center gap-2 rounded-lg border border-cyan-300/40 bg-cyan-300/10 px-5 py-3 font-bold text-cyan-100 transition hover:border-cyan-200"
+                >
+                  View JSON export <ArrowRight size={18} />
+                </a>
                 <Link
-                  href="https://cloud.satgate.io/cloud/login"
+                  href="/agent-control-plane"
                   className="inline-flex items-center justify-center gap-2 rounded-lg border border-white/20 px-5 py-3 font-bold text-white transition hover:border-cyan-300/60"
                 >
-                  Open SatGate Cloud
+                  See the agent control plane
                 </Link>
               </div>
             </div>
@@ -175,11 +220,11 @@ export default function PolicyToProofPage() {
               <div className="mb-4 flex items-center justify-between border-b border-white/10 pb-3">
                 <div>
                   <p className="text-sm font-semibold text-cyan-200">Evidence Pack</p>
-                  <p className="text-xs text-gray-500">Lifecycle export preview</p>
+                  <p className="text-xs text-gray-500">Signed lifecycle export preview</p>
                 </div>
                 <BadgeCheck className="text-emerald-300" />
               </div>
-              <pre className="overflow-x-auto rounded-2xl bg-black/70 p-4 text-xs leading-6 text-cyan-50">
+              <pre className="max-h-[560px] overflow-x-auto rounded-2xl bg-black/70 p-4 text-xs leading-6 text-cyan-50">
                 {JSON.stringify(evidencePack, null, 2)}
               </pre>
             </div>
@@ -190,25 +235,24 @@ export default function PolicyToProofPage() {
       <section className="border-b border-white/10 px-6 py-20">
         <div className="mx-auto max-w-6xl">
           <div className="max-w-3xl">
-            <p className="mb-3 text-sm font-semibold uppercase tracking-[0.24em] text-purple-300">The narrative shift</p>
-            <h2 className="text-3xl font-black tracking-tight sm:text-5xl">Enforcement is table stakes. Proof is the product.</h2>
-            <p className="mt-5 text-lg leading-8 text-gray-400">
-              Gateways eventually claim they can block calls. SatGate goes further: every grant, spend event, denial, and revocation becomes a structured receipt. The audit trail is not a logging afterthought; it is generated by the same authority path that enforces the decision.
-            </p>
+            <p className="mb-3 text-sm font-semibold uppercase tracking-[0.24em] text-purple-300">The contrast</p>
+            <h2 className="text-3xl font-black tracking-tight sm:text-5xl">Logs tell you something happened. Evidence proves who had authority.</h2>
           </div>
-          <div className="mt-10 grid gap-4 md:grid-cols-4">
-            {[
-              [KeyRound, "Grant evidence", "Who minted authority and under which caveats."],
-              [CircleDollarSign, "Spend ledger", "Which agent, route, tool, and token created cost."],
-              [Ban, "Denial reason", "Why the call stopped before risk or spend escaped."],
-              [TimerReset, "Revocation proof", "When authority ended and the next call failed."],
-            ].map(([Icon, title, body]) => (
-              <div key={String(title)} className="rounded-2xl border border-white/10 bg-white/[0.03] p-5">
-                <Icon className="mb-4 text-cyan-300" size={24} />
-                <h3 className="font-bold text-white">{String(title)}</h3>
-                <p className="mt-2 text-sm leading-6 text-gray-400">{String(body)}</p>
-              </div>
-            ))}
+          <div className="mt-10 grid gap-5 lg:grid-cols-2">
+            <div className="rounded-3xl border border-red-400/20 bg-red-400/5 p-7">
+              <p className="text-sm font-bold uppercase tracking-[0.22em] text-red-200">Other gateways</p>
+              <h3 className="mt-4 text-2xl font-black text-white">200/402 status codes in a log.</h3>
+              <p className="mt-4 text-base leading-7 text-gray-400">
+                You reconstruct authority from six systems, three hours of joins, shared API keys, cloud invoices, and dashboard screenshots — with no chain-of-custody.
+              </p>
+            </div>
+            <div className="rounded-3xl border border-emerald-400/20 bg-emerald-400/5 p-7">
+              <p className="text-sm font-bold uppercase tracking-[0.22em] text-emerald-200">SatGate</p>
+              <h3 className="mt-4 text-2xl font-black text-white">Signed mint receipt, attenuation chain, spend ledger, denial reason, revocation proof — one export.</h3>
+              <p className="mt-4 text-base leading-7 text-gray-400">
+                The audit trail is not a logging afterthought. It is generated by the same authority path that enforces the decision.
+              </p>
+            </div>
           </div>
         </div>
       </section>
@@ -218,7 +262,7 @@ export default function PolicyToProofPage() {
           <div className="mb-10 flex flex-col justify-between gap-4 lg:flex-row lg:items-end">
             <div className="max-w-3xl">
               <p className="mb-3 text-sm font-semibold uppercase tracking-[0.24em] text-cyan-300">Six-question evidence framework</p>
-              <h2 className="text-3xl font-black tracking-tight sm:text-5xl">Answer the questions buyers ask after an agent acts.</h2>
+              <h2 className="text-3xl font-black tracking-tight sm:text-5xl">Answer the questions buyers ask after invoice-reconciler acts.</h2>
             </div>
             <p className="max-w-md text-sm leading-6 text-gray-500">
               The Evidence Pack bundles these artifacts into one export instead of sending teams on a forensics project across logs, invoices, and gateway dashboards.
@@ -237,13 +281,51 @@ export default function PolicyToProofPage() {
         </div>
       </section>
 
+      <section className="border-b border-white/10 px-6 py-20">
+        <div className="mx-auto max-w-6xl">
+          <div className="max-w-3xl">
+            <p className="mb-3 text-sm font-semibold uppercase tracking-[0.24em] text-purple-300">Maps to audit controls</p>
+            <h2 className="text-3xl font-black tracking-tight sm:text-5xl">Audit-fluent, not just audit-flavored.</h2>
+            <p className="mt-5 text-lg leading-8 text-gray-400">
+              The Evidence Pack gives security and audit teams a starting control map instead of making them translate raw gateway logs themselves.
+            </p>
+          </div>
+          <div className="mt-10 grid gap-4 md:grid-cols-2">
+            {standardsMappings.map(([artifact, control, body]) => (
+              <div key={artifact} className="rounded-2xl border border-white/10 bg-white/[0.03] p-6">
+                <p className="text-sm font-bold text-cyan-300">{artifact}</p>
+                <h3 className="mt-2 text-xl font-black text-white">{control}</h3>
+                <p className="mt-3 text-sm leading-6 text-gray-400">{body}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section className="border-b border-white/10 bg-white/[0.02] px-6 py-20">
+        <div className="mx-auto max-w-6xl">
+          <div className="max-w-3xl">
+            <p className="mb-3 text-sm font-semibold uppercase tracking-[0.24em] text-cyan-300">Who receives the pack</p>
+            <h2 className="text-3xl font-black tracking-tight sm:text-5xl">One export, three enterprise conversations.</h2>
+          </div>
+          <div className="mt-10 grid gap-4 md:grid-cols-3">
+            {personas.map(([title, quote]) => (
+              <figure key={title} className="rounded-2xl border border-white/10 bg-black p-6">
+                <blockquote className="text-lg font-semibold leading-8 text-white">“{quote}”</blockquote>
+                <figcaption className="mt-5 text-sm font-bold uppercase tracking-[0.2em] text-purple-300">{title}</figcaption>
+              </figure>
+            ))}
+          </div>
+        </div>
+      </section>
+
       <section className="px-6 py-20">
         <div className="mx-auto max-w-6xl">
           <div className="max-w-3xl">
             <p className="mb-3 text-sm font-semibold uppercase tracking-[0.24em] text-purple-300">5-minute demo path</p>
             <h2 className="text-3xl font-black tracking-tight sm:text-5xl">Mint → Delegate → Spend → Deny → Revoke → Export.</h2>
             <p className="mt-5 text-lg leading-8 text-gray-400">
-              The demo should end on the exported Evidence Pack. That is the buyer moment: one artifact proving authority, spend, denial, and revocation across the agent lifecycle.
+              The demo ends on the exported Evidence Pack. That is the buyer moment: one artifact proving authority, spend, denial, and revocation across the invoice-reconciler lifecycle.
             </p>
           </div>
 
@@ -259,6 +341,32 @@ export default function PolicyToProofPage() {
             ))}
           </div>
 
+          <div className="mt-12 grid gap-6 lg:grid-cols-[1.15fr_0.85fr] lg:items-center">
+            <div className="rounded-[2rem] border border-white/10 bg-white/[0.04] p-3 shadow-2xl shadow-black/60">
+              <video
+                className="aspect-video w-full rounded-[1.35rem] bg-black object-cover"
+                controls
+                preload="metadata"
+                poster="/acp-demo/satgate-acp-thumbnail.jpg"
+              >
+                <source src="/acp-demo/satgate-acp-walkthrough.mp4" type="video/mp4" />
+              </video>
+            </div>
+            <div className="rounded-3xl border border-cyan-300/20 bg-cyan-300/5 p-7">
+              <div className="mb-4 flex items-center gap-2 text-cyan-200">
+                <PlayCircle size={22} />
+                <span className="text-sm font-bold uppercase tracking-[0.2em]">Recorded walkthrough</span>
+              </div>
+              <h3 className="text-2xl font-black text-white">Show the control plane, then end on proof.</h3>
+              <p className="mt-4 text-sm leading-6 text-gray-400">
+                This uses the existing ACP walkthrough while the focused 90-second Evidence Pack cut is produced.
+              </p>
+              <a href="/acp-demo/satgate-acp-walkthrough.mp4" className="mt-6 inline-flex items-center gap-2 font-bold text-cyan-200 hover:text-cyan-100">
+                Watch full walkthrough <ArrowRight size={16} />
+              </a>
+            </div>
+          </div>
+
           <div className="mt-12 rounded-3xl border border-emerald-400/20 bg-emerald-400/5 p-8">
             <div className="flex flex-col gap-5 md:flex-row md:items-start md:justify-between">
               <div className="max-w-3xl">
@@ -269,6 +377,26 @@ export default function PolicyToProofPage() {
                 <p className="text-2xl font-black leading-snug text-white">
                   SatGate lets enterprises delegate authority to AI agents without permanent credentials, unlimited spend, or unobservable authority — and proves every step.
                 </p>
+                <div className="mt-8 flex flex-col gap-3 sm:flex-row sm:flex-wrap">
+                  <a
+                    href="/evidence-packs/sample-evidence-pack.pdf"
+                    className="inline-flex items-center justify-center gap-2 rounded-lg bg-white px-5 py-3 font-bold text-black transition hover:bg-gray-200"
+                  >
+                    Download sample Evidence Pack <Download size={18} />
+                  </a>
+                  <a
+                    href="/evidence-packs/sample-evidence-pack.json"
+                    className="inline-flex items-center justify-center gap-2 rounded-lg border border-emerald-300/40 bg-emerald-300/10 px-5 py-3 font-bold text-emerald-100 transition hover:border-emerald-200"
+                  >
+                    View JSON export <ArrowRight size={18} />
+                  </a>
+                  <a
+                    href="mailto:contact@satgate.io?subject=SatGate%20Policy-to-Proof%20walkthrough"
+                    className="inline-flex items-center justify-center gap-2 rounded-lg border border-white/20 px-5 py-3 font-bold text-white transition hover:border-emerald-300/60"
+                  >
+                    Book a 15-minute walkthrough <ArrowRight size={18} />
+                  </a>
+                </div>
               </div>
               <ShieldCheck className="hidden shrink-0 text-emerald-300 md:block" size={56} />
             </div>

--- a/satgate-landing/public/evidence-packs/sample-evidence-pack.json
+++ b/satgate-landing/public/evidence-packs/sample-evidence-pack.json
@@ -1,0 +1,156 @@
+{
+  "evidence_pack_id": "ep_demo_2026_05_09_001",
+  "issued_at": "2026-05-09T14:22:31Z",
+  "expires_at": "2026-05-16T14:22:31Z",
+  "tenant": "acme-finance",
+  "subject": "worker-agent:invoice-reconciler",
+  "purpose": "Friday invoice reconciliation and export review",
+  "authority_chain": [
+    {
+      "kind": "root_grant",
+      "subject": "dean-agent:finance-automation",
+      "issuer_kid": "satgate-mint-2026-05",
+      "scope": [
+        "invoices:read",
+        "invoices:search",
+        "mcp:invoice-tools"
+      ],
+      "caveats": [
+        "tenant=acme-finance",
+        "budget_usd<=25",
+        "delegation_depth<=1",
+        "expires_at=2026-05-09T15:22:31Z"
+      ],
+      "receipt_hash": "sha256:7a2ca1b8d5e0a0d7c9545c7f8e6d03d12761b687a7a1f27c0dd7ed2e643a01b5"
+    },
+    {
+      "kind": "delegation",
+      "subject": "worker-agent:invoice-reconciler",
+      "parent": "dean-agent:finance-automation",
+      "attenuated_scope": [
+        "invoices:read",
+        "invoices:search"
+      ],
+      "caveats": [
+        "budget_usd<=3",
+        "no_customer_data_export",
+        "route_prefix=/v1/invoices"
+      ],
+      "receipt_hash": "sha256:95f1c3df9d1f8d7a0e5b60b850f4b6013dd2f0e18496f9e5a8c0319fd51382bf"
+    }
+  ],
+  "receipts": [
+    {
+      "type": "mint",
+      "ts": "2026-05-09T14:22:31Z",
+      "issuer_kid": "satgate-mint-2026-05",
+      "agent": "dean-agent:finance-automation",
+      "result": "issued",
+      "caveats": [
+        "tenant=acme-finance",
+        "budget_usd<=25",
+        "delegation_depth<=1"
+      ],
+      "receipt_hash": "sha256:7a2ca1b8d5e0a0d7c9545c7f8e6d03d12761b687a7a1f27c0dd7ed2e643a01b5"
+    },
+    {
+      "type": "delegation",
+      "ts": "2026-05-09T14:23:04Z",
+      "parent": "dean-agent:finance-automation",
+      "agent": "worker-agent:invoice-reconciler",
+      "result": "attenuated",
+      "caveats": [
+        "budget_usd<=3",
+        "no_customer_data_export"
+      ],
+      "receipt_hash": "sha256:95f1c3df9d1f8d7a0e5b60b850f4b6013dd2f0e18496f9e5a8c0319fd51382bf"
+    },
+    {
+      "type": "spend",
+      "ts": "2026-05-09T14:23:18Z",
+      "agent": "worker-agent:invoice-reconciler",
+      "route": "/v1/invoices/search",
+      "mcp_tool": "invoices.search",
+      "amount_usd": "0.18",
+      "result": "allowed",
+      "ledger_entry_id": "led_7f31",
+      "receipt_hash": "sha256:01d87dd7d0b28cc94cd9b4f27970e1cb2cebe0b56ff2cdd462e54fcf3abfa8b6"
+    },
+    {
+      "type": "spend",
+      "ts": "2026-05-09T14:24:02Z",
+      "agent": "worker-agent:invoice-reconciler",
+      "route": "/v1/invoices/compare",
+      "mcp_tool": "invoices.compare",
+      "amount_usd": "0.42",
+      "result": "allowed",
+      "ledger_entry_id": "led_7f32",
+      "receipt_hash": "sha256:a923d9034b61b5a03f0a47dc0cefc653d93b8041f47f0f92d8ce39f6b7437c24"
+    },
+    {
+      "type": "spend",
+      "ts": "2026-05-09T14:24:44Z",
+      "agent": "worker-agent:invoice-reconciler",
+      "route": "/v1/invoices/reconcile",
+      "mcp_tool": "invoices.reconcile",
+      "amount_usd": "1.12",
+      "result": "allowed",
+      "ledger_entry_id": "led_7f33",
+      "receipt_hash": "sha256:deb583596fa15d409aab8e5b3c85a9dac5d970a6690a134074b70e7de042c7d2"
+    },
+    {
+      "type": "denial",
+      "ts": "2026-05-09T14:25:08Z",
+      "agent": "worker-agent:invoice-reconciler",
+      "route": "/v1/invoices/export",
+      "result": "blocked",
+      "reason_code": "scope_violation:no_customer_data_export",
+      "receipt_hash": "sha256:9b0fadc25bf07c5bb6ce239971d02c30f31349fbb5a2e93a1f653a66e31b43e8"
+    },
+    {
+      "type": "denial",
+      "ts": "2026-05-09T14:25:33Z",
+      "agent": "worker-agent:invoice-reconciler",
+      "route": "/v1/invoices/reconcile",
+      "result": "blocked",
+      "reason_code": "budget_exhausted",
+      "remaining_budget_usd": "0.00",
+      "receipt_hash": "sha256:c3f61a7bb75491e63762f551a565f7f4ad0fb9c18542cf7e9abbd11981cd3f89"
+    },
+    {
+      "type": "revocation",
+      "ts": "2026-05-09T14:26:11Z",
+      "agent": "worker-agent:invoice-reconciler",
+      "revoked_by": "security-admin",
+      "result": "revoked",
+      "receipt_hash": "sha256:37d13cafd802142149d5c4f8a66e1b6a3836d39fdfebc2e555d02e15f694ae42"
+    },
+    {
+      "type": "post_revoke_denial",
+      "ts": "2026-05-09T14:26:16Z",
+      "agent": "worker-agent:invoice-reconciler",
+      "route": "/v1/invoices/search",
+      "result": "blocked",
+      "reason_code": "capability_revoked",
+      "receipt_hash": "sha256:8b95bc2dd24e1bbaf384a74e5ef7f2d10bc89942d51b967d4d0bd03d69ba7f13"
+    },
+    {
+      "type": "export",
+      "ts": "2026-05-09T14:26:31Z",
+      "requested_by": "auditor:acme",
+      "result": "evidence_pack_issued",
+      "format": [
+        "json",
+        "pdf"
+      ],
+      "receipt_hash": "sha256:e1b3fb1b2423f99d85e7d1af754517e45cb213f2ce71d202a0d7195f16683e92"
+    }
+  ],
+  "chain_root": "sha256:f04ed8430b11c8975cc5ef35919ee078fc4cb166cd8d611ed0d94b7da69df09d",
+  "signature": "ed25519:u3o9l6nN4z-demo-signature-redacted-proof-preview",
+  "verification": {
+    "algorithm": "ed25519 + sha256 receipt chain",
+    "public_key_id": "satgate-evidence-2026-05",
+    "verify_url": "https://satgate.io/policy-to-proof"
+  }
+}

--- a/satgate-landing/public/evidence-packs/sample-evidence-pack.pdf
+++ b/satgate-landing/public/evidence-packs/sample-evidence-pack.pdf
@@ -1,0 +1,59 @@
+%PDF-1.4
+1 0 obj << /Type /Catalog /Pages 2 0 R >> endobj
+2 0 obj << /Type /Pages /Kids [3 0 R] /Count 1 >> endobj
+3 0 obj << /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 4 0 R >> >> /Contents 5 0 R >> endobj
+4 0 obj << /Type /Font /Subtype /Type1 /BaseFont /Helvetica >> endobj
+5 0 obj << /Length 1081 >> stream
+BT
+/F1 18 Tf
+72 750 Td
+(SatGate Sample Evidence Pack) Tj
+/F1 11 Tf
+0 -18 Td
+(Evidence Pack ID: ep_demo_2026_05_09_001) Tj
+0 -18 Td
+(Issued: 2026-05-09T14:22:31Z) Tj
+0 -18 Td
+(Subject: worker-agent:invoice-reconciler) Tj
+0 -18 Td
+(Scenario: invoice reconciliation lifecycle) Tj
+0 -18 Td
+() Tj
+0 -18 Td
+(What this proves:) Tj
+0 -18 Td
+(- Mint receipt: scoped authority issued by satgate-mint-2026-05) Tj
+0 -18 Td
+(- Delegation chain: parent agent attenuated worker authority) Tj
+0 -18 Td
+(- Spend ledger: three allowed invoice tool calls attributed by token) Tj
+0 -18 Td
+(- Denials: scope_violation and budget_exhausted reason codes) Tj
+0 -18 Td
+(- Revocation: worker authority revoked by security-admin) Tj
+0 -18 Td
+(- Post-revoke denial: first call after revocation blocked) Tj
+0 -18 Td
+() Tj
+0 -18 Td
+(Chain root: sha256:f04ed8430b11c8975cc5ef35919ee078fc4cb166cd8d611ed0d94b7da69df09d) Tj
+0 -18 Td
+(Signature: ed25519:u3o9l6nN4z-demo-signature-redacted-proof-preview) Tj
+0 -18 Td
+() Tj
+0 -18 Td
+(Download the JSON version for the full receipt list and verification fields.) Tj
+ET
+endstream endobj
+xref
+0 6
+0000000000 65535 f 
+0000000009 00000 n 
+0000000058 00000 n 
+0000000115 00000 n 
+0000000241 00000 n 
+0000000311 00000 n 
+trailer << /Size 6 /Root 1 0 R >>
+startxref
+1444
+%%EOF

--- a/satgate-landing/scripts/check_policy_to_proof_page.py
+++ b/satgate-landing/scripts/check_policy_to_proof_page.py
@@ -22,6 +22,19 @@ required_phrases = [
     "Deny",
     "Revoke",
     "Export",
+    "Download sample Evidence Pack",
+    "chain_root",
+    "signature",
+    "receipt_hash",
+    "Other gateways",
+    "SOC 2 CC6.1",
+    "NIST AC-3",
+    "Auditor",
+    "CISO",
+    "FinOps lead",
+    "/acp-demo/satgate-acp-walkthrough.mp4",
+    "/evidence-packs/sample-evidence-pack.json",
+    "/evidence-packs/sample-evidence-pack.pdf",
 ]
 
 


### PR DESCRIPTION
## Summary
- Makes the hero Evidence Pack look like proof: issued/expires timestamps, authority chain, receipt hashes, chain root, and signature
- Adds downloadable sample Evidence Pack assets in both JSON and PDF
- Replaces the redundant four-card narrative row with a direct logs-vs-Evidence-Pack contrast
- Adds audit-control mappings, buyer persona cards, embedded ACP walkthrough, and bottom CTAs
- Tightens the regression check so the proof/conversion anchors do not disappear

## Test Plan
- [x] `python3 satgate-landing/scripts/check_policy_to_proof_page.py`
- [x] `npm run lint -- app/policy-to-proof/page.tsx app/agent-control-plane/page.tsx`
- [x] `npm run build`
- [x] Local production render: `/policy-to-proof` returned 200 and contained proof anchors
- [x] Local asset checks: Evidence Pack JSON 200, PDF 200, ACP walkthrough range request 206

## Notes
- Uses the existing ACP walkthrough video while a focused 90-second Evidence Pack cut is produced.
- Sample PDF is intentionally lightweight; the JSON is the full structured artifact.