### PR TITLE
feat(landing): polish Evidence Pack handoff artifacts

### DIFF
--- a/satgate-landing/app/policy-to-proof/page.tsx
+++ b/satgate-landing/app/policy-to-proof/page.tsx
@@ -132,7 +132,7 @@ const evidencePack = {
     { type: "export", ts: "2026-05-09T14:26:31Z", result: "evidence_pack_issued", receipt_hash: "sha256:e1b3..." },
   ],
   chain_root: "sha256:f04ed8430b11c8975cc5ef35919ee078fc4cb166cd8d611ed0d94b7da69df09d",
-  signature: "ed25519:u3o9l6nN4z-demo-signature-redacted-proof-preview",
+  signature: "ed25519:REDACTED_DEMO_SAMPLE_DO_NOT_VERIFY",
 };
 
 const jsonLd = {
@@ -265,7 +265,7 @@ export default function PolicyToProofPage() {
               <h2 className="text-3xl font-black tracking-tight sm:text-5xl">Answer the questions buyers ask after invoice-reconciler acts.</h2>
             </div>
             <p className="max-w-md text-sm leading-6 text-gray-500">
-              The Evidence Pack bundles these artifacts into one export instead of sending teams on a forensics project across logs, invoices, and gateway dashboards.
+              The Evidence Pack bundles these artifacts into one export instead of sending teams on a forensics project across logs, invoices, and gateway dashboards. Authority-chain entries preserve lineage; matching receipts preserve the event log, so auditors can verify both structure and sequence.
             </p>
           </div>
 
@@ -325,7 +325,7 @@ export default function PolicyToProofPage() {
             <p className="mb-3 text-sm font-semibold uppercase tracking-[0.24em] text-purple-300">5-minute demo path</p>
             <h2 className="text-3xl font-black tracking-tight sm:text-5xl">Mint → Delegate → Spend → Deny → Revoke → Export.</h2>
             <p className="mt-5 text-lg leading-8 text-gray-400">
-              The demo ends on the exported Evidence Pack. That is the buyer moment: one artifact proving authority, spend, denial, and revocation across the invoice-reconciler lifecycle.
+              The demo ends on the exported Evidence Pack. That is the buyer moment: one artifact proving authority, spend, denial, and revocation across the invoice-reconciler lifecycle. Even producing the Evidence Pack is itself an auditable event.
             </p>
           </div>
 

--- a/satgate-landing/public/evidence-packs/sample-evidence-pack.json
+++ b/satgate-landing/public/evidence-packs/sample-evidence-pack.json
@@ -147,7 +147,7 @@
     }
   ],
   "chain_root": "sha256:f04ed8430b11c8975cc5ef35919ee078fc4cb166cd8d611ed0d94b7da69df09d",
-  "signature": "ed25519:u3o9l6nN4z-demo-signature-redacted-proof-preview",
+  "signature": "ed25519:REDACTED_DEMO_SAMPLE_DO_NOT_VERIFY",
   "verification": {
     "algorithm": "ed25519 + sha256 receipt chain",
     "public_key_id": "satgate-evidence-2026-05",

--- a/satgate-landing/public/evidence-packs/sample-evidence-pack.pdf
+++ b/satgate-landing/public/evidence-packs/sample-evidence-pack.pdf
@@ -1,59 +1,349 @@
 %PDF-1.4
 1 0 obj << /Type /Catalog /Pages 2 0 R >> endobj
 2 0 obj << /Type /Pages /Kids [3 0 R] /Count 1 >> endobj
-3 0 obj << /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 4 0 R >> >> /Contents 5 0 R >> endobj
+3 0 obj << /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 4 0 R /F2 5 0 R >> >> /Contents 6 0 R >> endobj
 4 0 obj << /Type /Font /Subtype /Type1 /BaseFont /Helvetica >> endobj
-5 0 obj << /Length 1081 >> stream
+5 0 obj << /Type /Font /Subtype /Type1 /BaseFont /Helvetica-Bold >> endobj
+6 0 obj << /Length 4710 >> stream
+0.030 0.050 0.080 rg
+0 0 612 792 re f
+0.020 0.350 0.420 rg
+0 704 612 88 re f
+0.170 0.080 0.320 rg
+0 704 230 88 re f
+1.000 1.000 1.000 rg
 BT
-/F1 18 Tf
-72 750 Td
-(SatGate Sample Evidence Pack) Tj
-/F1 11 Tf
-0 -18 Td
-(Evidence Pack ID: ep_demo_2026_05_09_001) Tj
-0 -18 Td
-(Issued: 2026-05-09T14:22:31Z) Tj
-0 -18 Td
-(Subject: worker-agent:invoice-reconciler) Tj
-0 -18 Td
-(Scenario: invoice reconciliation lifecycle) Tj
-0 -18 Td
-() Tj
-0 -18 Td
-(What this proves:) Tj
-0 -18 Td
-(- Mint receipt: scoped authority issued by satgate-mint-2026-05) Tj
-0 -18 Td
-(- Delegation chain: parent agent attenuated worker authority) Tj
-0 -18 Td
-(- Spend ledger: three allowed invoice tool calls attributed by token) Tj
-0 -18 Td
-(- Denials: scope_violation and budget_exhausted reason codes) Tj
-0 -18 Td
-(- Revocation: worker authority revoked by security-admin) Tj
-0 -18 Td
-(- Post-revoke denial: first call after revocation blocked) Tj
-0 -18 Td
-() Tj
-0 -18 Td
-(Chain root: sha256:f04ed8430b11c8975cc5ef35919ee078fc4cb166cd8d611ed0d94b7da69df09d) Tj
-0 -18 Td
-(Signature: ed25519:u3o9l6nN4z-demo-signature-redacted-proof-preview) Tj
-0 -18 Td
-() Tj
-0 -18 Td
-(Download the JSON version for the full receipt list and verification fields.) Tj
+/F2 22 Tf
+54 750 Td
+(SatGate) Tj
+ET
+0.800 0.950 1.000 rg
+BT
+/F2 15 Tf
+54 728 Td
+(Policy-to-Proof Evidence Pack) Tj
+ET
+0.860 0.900 0.960 rg
+BT
+/F1 9 Tf
+54 710 Td
+(Sample hand-off artifact for enterprise agent authority review) Tj
+ET
+1.000 1.000 1.000 rg
+BT
+/F2 18 Tf
+402 750 Td
+(SAMPLE) Tj
+ET
+0.900 0.950 1.000 rg
+BT
+/F1 9 Tf
+402 730 Td
+(Do not verify demo signature) Tj
+ET
+1.000 1.000 1.000 rg
+42 58 528 622 re f
+0.200 0.240 0.320 rg
+BT
+/F2 8 Tf
+62 650 Td
+(Evidence Pack ID) Tj
+ET
+0.050 0.070 0.100 rg
+BT
+/F1 9 Tf
+170 650 Td
+(ep_demo_2026_05_09_001) Tj
+ET
+0.200 0.240 0.320 rg
+BT
+/F2 8 Tf
+62 632 Td
+(Issued) Tj
+ET
+0.050 0.070 0.100 rg
+BT
+/F1 9 Tf
+170 632 Td
+(2026-05-09T14:22:31Z) Tj
+ET
+0.200 0.240 0.320 rg
+BT
+/F2 8 Tf
+62 614 Td
+(Subject) Tj
+ET
+0.050 0.070 0.100 rg
+BT
+/F1 9 Tf
+170 614 Td
+(worker-agent:invoice-reconciler) Tj
+ET
+0.200 0.240 0.320 rg
+BT
+/F2 8 Tf
+62 596 Td
+(Purpose) Tj
+ET
+0.050 0.070 0.100 rg
+BT
+/F1 9 Tf
+170 596 Td
+(Friday invoice reconciliation and export review) Tj
+ET
+0.900 0.980 1.000 rg
+62 448 488 126 re f
+0.020 0.200 0.280 rg
+BT
+/F2 13 Tf
+78 554 Td
+(What this proves) Tj
+ET
+0.000 0.450 0.550 rg
+BT
+/F2 10 Tf
+82 534 Td
+(-) Tj
+ET
+0.080 0.110 0.160 rg
+BT
+/F1 8.4 Tf
+96 534 Td
+(Mint receipt: scoped authority issued by satgate-mint-2026-05.) Tj
+ET
+0.000 0.450 0.550 rg
+BT
+/F2 10 Tf
+82 518 Td
+(-) Tj
+ET
+0.080 0.110 0.160 rg
+BT
+/F1 8.4 Tf
+96 518 Td
+(Delegation chain: parent authority attenuated to invoice-reconciler.) Tj
+ET
+0.000 0.450 0.550 rg
+BT
+/F2 10 Tf
+82 502 Td
+(-) Tj
+ET
+0.080 0.110 0.160 rg
+BT
+/F1 8.4 Tf
+96 502 Td
+(Spend ledger: three allowed invoice tool calls attributed by token and route.) Tj
+ET
+0.000 0.450 0.550 rg
+BT
+/F2 10 Tf
+82 486 Td
+(-) Tj
+ET
+0.080 0.110 0.160 rg
+BT
+/F1 8.4 Tf
+96 486 Td
+(Denials: scope_violation:no_customer_data_export and budget_exhausted.) Tj
+ET
+0.000 0.450 0.550 rg
+BT
+/F2 10 Tf
+82 470 Td
+(-) Tj
+ET
+0.080 0.110 0.160 rg
+BT
+/F1 8.4 Tf
+96 470 Td
+(Revocation: worker authority revoked, then first post-revoke call blocked.) Tj
+ET
+0.000 0.450 0.550 rg
+BT
+/F2 10 Tf
+82 454 Td
+(-) Tj
+ET
+0.080 0.110 0.160 rg
+BT
+/F1 8.4 Tf
+96 454 Td
+(Export receipt: producing this Evidence Pack is itself auditable.) Tj
+ET
+0.970 0.970 0.990 rg
+62 258 488 168 re f
+0.120 0.100 0.220 rg
+BT
+/F2 13 Tf
+78 406 Td
+(Maps to audit controls) Tj
+ET
+0.120 0.100 0.220 rg
+78 378 456 22 re f
+1.000 1.000 1.000 rg
+BT
+/F2 8 Tf
+88 385 Td
+(Artifact) Tj
+ET
+1.000 1.000 1.000 rg
+BT
+/F2 8 Tf
+218 385 Td
+(Control mapping) Tj
+ET
+1.000 1.000 1.000 rg
+BT
+/F2 8 Tf
+382 385 Td
+(Why it matters) Tj
+ET
+0.940 0.980 0.990 rg
+78 352 456 24 re f
+0.050 0.070 0.100 rg
+BT
+/F1 8 Tf
+88 358 Td
+(Mint receipt) Tj
+ET
+0.050 0.070 0.100 rg
+BT
+/F1 8 Tf
+218 358 Td
+(SOC 2 CC6.1 / ISO 27001 A.9) Tj
+ET
+0.050 0.070 0.100 rg
+BT
+/F1 8 Tf
+382 358 Td
+(Logical access provisioning evidence) Tj
+ET
+0.050 0.070 0.100 rg
+BT
+/F1 8 Tf
+88 330 Td
+(Delegation chain) Tj
+ET
+0.050 0.070 0.100 rg
+BT
+/F1 8 Tf
+218 330 Td
+(SOC 2 CC6.3 / NIST AC-3) Tj
+ET
+0.050 0.070 0.100 rg
+BT
+/F1 8 Tf
+382 330 Td
+(Least-privilege attenuation) Tj
+ET
+0.940 0.980 0.990 rg
+78 296 456 24 re f
+0.050 0.070 0.100 rg
+BT
+/F1 8 Tf
+88 302 Td
+(Revocation proof) Tj
+ET
+0.050 0.070 0.100 rg
+BT
+/F1 8 Tf
+218 302 Td
+(SOC 2 CC6.2/CC6.3 / NIST AC-2\(3\)) Tj
+ET
+0.050 0.070 0.100 rg
+BT
+/F1 8 Tf
+382 302 Td
+(Deprovisioning + denied call) Tj
+ET
+0.050 0.070 0.100 rg
+BT
+/F1 8 Tf
+88 274 Td
+(Spend ledger) Tj
+ET
+0.050 0.070 0.100 rg
+BT
+/F1 8 Tf
+218 274 Td
+(SOC 2 CC1.4 / FinOps) Tj
+ET
+0.050 0.070 0.100 rg
+BT
+/F1 8 Tf
+382 274 Td
+(Governance and spend attribution) Tj
+ET
+0.980 0.940 0.900 rg
+62 158 488 78 re f
+0.300 0.120 0.040 rg
+BT
+/F2 13 Tf
+78 216 Td
+(Why this beats logs) Tj
+ET
+0.160 0.120 0.100 rg
+BT
+/F1 8.2 Tf
+78 198 Td
+(Reconstructing agent authority from gateway logs, invoices, IAM records, and screenshots can) Tj
+ET
+0.160 0.120 0.100 rg
+BT
+/F1 8.2 Tf
+78 185 Td
+(take hours across multiple systems. SatGate packages the signed mint receipt, attenuation) Tj
+ET
+0.160 0.120 0.100 rg
+BT
+/F1 8.2 Tf
+78 172 Td
+(chain, spend ledger, denial reasons, revocation proof, and export receipt into one file.) Tj
+ET
+0.050 0.070 0.100 rg
+62 80 488 58 re f
+0.700 0.940 1.000 rg
+BT
+/F2 8 Tf
+78 120 Td
+(Chain root) Tj
+ET
+0.920 0.980 1.000 rg
+BT
+/F1 6.8 Tf
+146 120 Td
+(sha256:f04ed8430b11c8975cc5ef35919ee078fc4cb166cd8d611ed0d94b7da69df09d) Tj
+ET
+0.700 0.940 1.000 rg
+BT
+/F2 8 Tf
+78 104 Td
+(Signature) Tj
+ET
+0.920 0.980 1.000 rg
+BT
+/F1 7.5 Tf
+146 104 Td
+(ed25519:REDACTED_DEMO_SAMPLE_DO_NOT_VERIFY) Tj
+ET
+0.800 1.000 0.820 rg
+BT
+/F2 8 Tf
+78 88 Td
+(Verify / download JSON at https://satgate.io/policy-to-proof  |  contact@satgate.io) Tj
 ET
 endstream endobj
 xref
-0 6
+0 7
 0000000000 65535 f 
 0000000009 00000 n 
 0000000058 00000 n 
 0000000115 00000 n 
-0000000241 00000 n 
-0000000311 00000 n 
-trailer << /Size 6 /Root 1 0 R >>
+0000000251 00000 n 
+0000000321 00000 n 
+0000000396 00000 n 
+trailer << /Size 7 /Root 1 0 R >>
 startxref
-1444
+5158
 %%EOF

--- a/satgate-landing/scripts/check_policy_to_proof_page.py
+++ b/satgate-landing/scripts/check_policy_to_proof_page.py
@@ -35,6 +35,9 @@ required_phrases = [
     "/acp-demo/satgate-acp-walkthrough.mp4",
     "/evidence-packs/sample-evidence-pack.json",
     "/evidence-packs/sample-evidence-pack.pdf",
+    "REDACTED_DEMO_SAMPLE_DO_NOT_VERIFY",
+    "Even producing the Evidence Pack is itself an auditable event",
+    "Authority-chain entries preserve lineage",
 ]
 
 


### PR DESCRIPTION
## Summary
- Polishes the sample Evidence Pack PDF into a branded hand-off artifact with proof summary, controls mapping, logs-vs-proof contrast, chain root/signature block, and CTA footer
- Makes the public sample signature explicitly redacted: `ed25519:REDACTED_DEMO_SAMPLE_DO_NOT_VERIFY`
- Adds page copy for the two schema questions Wayne flagged: authority-chain entries preserve lineage, matching receipts preserve event sequence
- Surfaces that producing the Evidence Pack is itself an auditable event
- Extends regression anchors for the new page copy

## Test Plan
- [x] `python3 satgate-landing/scripts/check_policy_to_proof_page.py`
- [x] Validate JSON parses, has 10 receipts, signature, chain root
- [x] Validate PDF header and key strings exist
- [x] `npm run lint -- app/policy-to-proof/page.tsx app/agent-control-plane/page.tsx`
- [x] `npm run build`