### PR TITLE
feat(landing): sharpen Policy-to-Proof conversion polish

### DIFF
--- a/satgate-landing/app/policy-to-proof/page.tsx
+++ b/satgate-landing/app/policy-to-proof/page.tsx
@@ -4,10 +4,13 @@ import {
   ArrowRight,
   BadgeCheck,
   CheckCircle2,
+  ClipboardCheck,
   Download,
   FileText,
   PlayCircle,
+  ShieldAlert,
   ShieldCheck,
+  WalletCards,
 } from "lucide-react";
 
 export const metadata: Metadata = {
@@ -86,15 +89,28 @@ const demoSteps = [
 
 const standardsMappings = [
   ["Mint receipt", "SOC 2 CC6.1", "Logical access provisioning tied to identity, policy, issuer, and timestamp."],
+  ["Mint receipt", "ISO 27001 A.9.2.1", "User registration and de-registration evidence for agent authority issuance."],
   ["Delegation chain", "SOC 2 CC6.3 / NIST AC-3", "Least-privilege attenuation across parent and worker authority."],
   ["Revocation receipt", "SOC 2 CC6.2/CC6.3 / NIST AC-2(3)", "Deprovisioning event plus first post-revoke denial trail."],
   ["Spend ledger", "SOC 2 CC1.4 / FinOps attribution", "Governance evidence for who created spend, on which route/tool, under which token."],
 ];
 
 const personas = [
-  ["Auditor", "I get the authority trail in one export instead of opening a forensics ticket."],
-  ["CISO", "Revocation isn’t a promise — it’s a signed receipt followed by a denied call."],
-  ["FinOps lead", "Spend is attributed to the agent, the token, and the route — not a shared API key."],
+  {
+    title: "Auditor",
+    icon: ClipboardCheck,
+    quote: "I get the authority trail in one export instead of opening a forensics ticket.",
+  },
+  {
+    title: "CISO",
+    icon: ShieldAlert,
+    quote: "Revocation isn’t a promise — it’s a signed receipt followed by a denied call.",
+  },
+  {
+    title: "FinOps lead",
+    icon: WalletCards,
+    quote: "Spend is attributed to the agent, the token, and the route — not a shared API key.",
+  },
 ];
 
 const evidencePack = {
@@ -120,7 +136,7 @@ const evidencePack = {
     },
   ],
   receipts: [
-    { type: "mint", ts: "2026-05-09T14:22:31Z", issuer_kid: "satgate-mint-2026-05", result: "issued", receipt_hash: "sha256:7a2c..." },
+    { type: "mint", ts: "2026-05-09T14:22:31Z", issuer_kid: "satgate-mint-2026-05", result: "issued", caveats: ["tenant=acme-finance", "budget_usd<=25", "delegation_depth<=1"], receipt_hash: "sha256:7a2c..." },
     { type: "delegation", ts: "2026-05-09T14:23:04Z", result: "attenuated", receipt_hash: "sha256:95f1..." },
     { type: "spend", ts: "2026-05-09T14:23:18Z", route: "/v1/invoices/search", amount_usd: "0.18", result: "allowed", receipt_hash: "sha256:01d8..." },
     { type: "spend", ts: "2026-05-09T14:24:02Z", route: "/v1/invoices/compare", amount_usd: "0.42", result: "allowed", receipt_hash: "sha256:a923..." },
@@ -207,12 +223,6 @@ export default function PolicyToProofPage() {
                 >
                   View JSON export <ArrowRight size={18} />
                 </a>
-                <Link
-                  href="/agent-control-plane"
-                  className="inline-flex items-center justify-center gap-2 rounded-lg border border-white/20 px-5 py-3 font-bold text-white transition hover:border-cyan-300/60"
-                >
-                  See the agent control plane
-                </Link>
               </div>
             </div>
 
@@ -227,6 +237,9 @@ export default function PolicyToProofPage() {
               <pre className="max-h-[560px] overflow-x-auto rounded-2xl bg-black/70 p-4 text-xs leading-6 text-cyan-50">
                 {JSON.stringify(evidencePack, null, 2)}
               </pre>
+              <p className="mt-3 text-xs leading-5 text-gray-500">
+                Inline hashes are shortened for readability. Full hashes, ed25519 signature, and verification block are in the downloadable JSON.
+              </p>
             </div>
           </div>
         </div>
@@ -309,10 +322,15 @@ export default function PolicyToProofPage() {
             <h2 className="text-3xl font-black tracking-tight sm:text-5xl">One export, three enterprise conversations.</h2>
           </div>
           <div className="mt-10 grid gap-4 md:grid-cols-3">
-            {personas.map(([title, quote]) => (
+            {personas.map(({ title, quote, icon: Icon }) => (
               <figure key={title} className="rounded-2xl border border-white/10 bg-black p-6">
+                <div className="mb-5 flex h-11 w-11 items-center justify-center rounded-2xl bg-purple-400/10 text-purple-200">
+                  <Icon size={22} />
+                </div>
+                <figcaption className="mb-3 text-sm font-bold uppercase tracking-[0.2em] text-purple-300">
+                  What the {title} gets
+                </figcaption>
                 <blockquote className="text-lg font-semibold leading-8 text-white">“{quote}”</blockquote>
-                <figcaption className="mt-5 text-sm font-bold uppercase tracking-[0.2em] text-purple-300">{title}</figcaption>
               </figure>
             ))}
           </div>
@@ -347,7 +365,7 @@ export default function PolicyToProofPage() {
                 className="aspect-video w-full rounded-[1.35rem] bg-black object-cover"
                 controls
                 preload="metadata"
-                poster="/acp-demo/satgate-acp-thumbnail.jpg"
+                poster="/evidence-packs/evidence-pack-export-poster.svg"
               >
                 <source src="/acp-demo/satgate-acp-walkthrough.mp4" type="video/mp4" />
               </video>
@@ -361,9 +379,14 @@ export default function PolicyToProofPage() {
               <p className="mt-4 text-sm leading-6 text-gray-400">
                 This uses the existing ACP walkthrough while the focused 90-second Evidence Pack cut is produced.
               </p>
-              <a href="/acp-demo/satgate-acp-walkthrough.mp4" className="mt-6 inline-flex items-center gap-2 font-bold text-cyan-200 hover:text-cyan-100">
-                Watch full walkthrough <ArrowRight size={16} />
-              </a>
+              <div className="mt-6 flex flex-col gap-3 text-sm font-bold sm:flex-row sm:flex-wrap">
+                <a href="/acp-demo/satgate-acp-walkthrough.mp4" className="inline-flex items-center gap-2 text-cyan-200 hover:text-cyan-100">
+                  Watch full walkthrough <ArrowRight size={16} />
+                </a>
+                <Link href="/agent-control-plane" className="inline-flex items-center gap-2 text-gray-300 hover:text-white">
+                  See the agent control plane <ArrowRight size={16} />
+                </Link>
+              </div>
             </div>
           </div>
 

--- a/satgate-landing/public/evidence-packs/evidence-pack-export-poster.svg
+++ b/satgate-landing/public/evidence-packs/evidence-pack-export-poster.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1600" height="900" viewBox="0 0 1600 900">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#06111f"/>
+      <stop offset="0.55" stop-color="#111827"/>
+      <stop offset="1" stop-color="#2e1065"/>
+    </linearGradient>
+    <filter id="glow"><feGaussianBlur stdDeviation="10" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
+  </defs>
+  <rect width="1600" height="900" fill="url(#bg)"/>
+  <circle cx="1220" cy="120" r="260" fill="#22d3ee" opacity="0.15"/>
+  <circle cx="220" cy="760" r="320" fill="#a855f7" opacity="0.18"/>
+  <text x="90" y="110" fill="#e0f2fe" font-family="Inter,Arial,sans-serif" font-size="34" font-weight="800" letter-spacing="4">SATGATE POLICY-TO-PROOF</text>
+  <text x="90" y="190" fill="white" font-family="Inter,Arial,sans-serif" font-size="72" font-weight="900">Evidence Pack exported</text>
+  <text x="94" y="246" fill="#cbd5e1" font-family="Inter,Arial,sans-serif" font-size="28">Mint → Delegate → Spend → Deny → Revoke → Export</text>
+  <rect x="90" y="305" width="1420" height="470" rx="34" fill="#020617" opacity="0.92" stroke="#67e8f9" stroke-opacity="0.35"/>
+  <text x="135" y="370" fill="#67e8f9" font-family="SFMono-Regular,Menlo,monospace" font-size="25">evidence_pack_id: ep_demo_2026_05_09_001</text>
+  <text x="135" y="425" fill="#e5e7eb" font-family="SFMono-Regular,Menlo,monospace" font-size="25">subject: worker-agent:invoice-reconciler</text>
+  <text x="135" y="480" fill="#e5e7eb" font-family="SFMono-Regular,Menlo,monospace" font-size="25">receipts: mint, delegation, spend, denial, revocation, export</text>
+  <text x="135" y="535" fill="#bbf7d0" font-family="SFMono-Regular,Menlo,monospace" font-size="25">chain_root: sha256:f04ed8430b11c897...</text>
+  <text x="135" y="590" fill="#bbf7d0" font-family="SFMono-Regular,Menlo,monospace" font-size="25">signature: ed25519:REDACTED_DEMO_SAMPLE_DO_NOT_VERIFY</text>
+  <rect x="135" y="640" width="330" height="70" rx="16" fill="#ffffff" filter="url(#glow)"/>
+  <text x="178" y="685" fill="#020617" font-family="Inter,Arial,sans-serif" font-size="24" font-weight="900">DOWNLOAD PROOF</text>
+  <circle cx="800" cy="810" r="42" fill="#ffffff" opacity="0.95"/>
+  <polygon points="788,786 788,834 830,810" fill="#020617"/>
+</svg>

--- a/satgate-landing/public/evidence-packs/sample-evidence-pack.pdf
+++ b/satgate-landing/public/evidence-packs/sample-evidence-pack.pdf
@@ -4,333 +4,353 @@
 3 0 obj << /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 4 0 R /F2 5 0 R >> >> /Contents 6 0 R >> endobj
 4 0 obj << /Type /Font /Subtype /Type1 /BaseFont /Helvetica >> endobj
 5 0 obj << /Type /Font /Subtype /Type1 /BaseFont /Helvetica-Bold >> endobj
-6 0 obj << /Length 4710 >> stream
-0.030 0.050 0.080 rg
+6 0 obj << /Length 4987 >> stream
+0.025 0.035 0.055 rg
 0 0 612 792 re f
 0.020 0.350 0.420 rg
 0 704 612 88 re f
 0.170 0.080 0.320 rg
-0 704 230 88 re f
+0 704 242 88 re f
 1.000 1.000 1.000 rg
 BT
-/F2 22 Tf
+/F2 23 Tf
 54 750 Td
 (SatGate) Tj
 ET
 0.800 0.950 1.000 rg
 BT
 /F2 15 Tf
-54 728 Td
+54 727 Td
 (Policy-to-Proof Evidence Pack) Tj
 ET
 0.860 0.900 0.960 rg
 BT
-/F1 9 Tf
+/F1 8.5 Tf
 54 710 Td
 (Sample hand-off artifact for enterprise agent authority review) Tj
 ET
 1.000 1.000 1.000 rg
 BT
 /F2 18 Tf
-402 750 Td
+396 750 Td
 (SAMPLE) Tj
 ET
 0.900 0.950 1.000 rg
 BT
-/F1 9 Tf
-402 730 Td
+/F1 8.5 Tf
+396 730 Td
 (Do not verify demo signature) Tj
 ET
 1.000 1.000 1.000 rg
-42 58 528 622 re f
+42 48 528 638 re f
 0.200 0.240 0.320 rg
 BT
 /F2 8 Tf
-62 650 Td
+62 656 Td
 (Evidence Pack ID) Tj
 ET
 0.050 0.070 0.100 rg
 BT
 /F1 9 Tf
-170 650 Td
+170 656 Td
 (ep_demo_2026_05_09_001) Tj
 ET
 0.200 0.240 0.320 rg
 BT
 /F2 8 Tf
-62 632 Td
+62 638 Td
 (Issued) Tj
 ET
 0.050 0.070 0.100 rg
 BT
 /F1 9 Tf
-170 632 Td
+170 638 Td
 (2026-05-09T14:22:31Z) Tj
 ET
 0.200 0.240 0.320 rg
 BT
 /F2 8 Tf
-62 614 Td
+62 620 Td
 (Subject) Tj
 ET
 0.050 0.070 0.100 rg
 BT
 /F1 9 Tf
-170 614 Td
+170 620 Td
 (worker-agent:invoice-reconciler) Tj
 ET
 0.200 0.240 0.320 rg
 BT
 /F2 8 Tf
-62 596 Td
+62 602 Td
 (Purpose) Tj
 ET
 0.050 0.070 0.100 rg
 BT
 /F1 9 Tf
-170 596 Td
+170 602 Td
 (Friday invoice reconciliation and export review) Tj
 ET
 0.900 0.980 1.000 rg
-62 448 488 126 re f
+62 450 488 130 re f
 0.020 0.200 0.280 rg
 BT
 /F2 13 Tf
-78 554 Td
+78 560 Td
 (What this proves) Tj
 ET
 0.000 0.450 0.550 rg
 BT
 /F2 10 Tf
-82 534 Td
+82 540 Td
 (-) Tj
 ET
 0.080 0.110 0.160 rg
 BT
 /F1 8.4 Tf
-96 534 Td
+96 540 Td
 (Mint receipt: scoped authority issued by satgate-mint-2026-05.) Tj
 ET
 0.000 0.450 0.550 rg
 BT
 /F2 10 Tf
-82 518 Td
+82 524 Td
 (-) Tj
 ET
 0.080 0.110 0.160 rg
 BT
 /F1 8.4 Tf
-96 518 Td
+96 524 Td
 (Delegation chain: parent authority attenuated to invoice-reconciler.) Tj
 ET
 0.000 0.450 0.550 rg
 BT
 /F2 10 Tf
-82 502 Td
+82 508 Td
 (-) Tj
 ET
 0.080 0.110 0.160 rg
 BT
 /F1 8.4 Tf
-96 502 Td
+96 508 Td
 (Spend ledger: three allowed invoice tool calls attributed by token and route.) Tj
 ET
 0.000 0.450 0.550 rg
 BT
 /F2 10 Tf
-82 486 Td
+82 492 Td
 (-) Tj
 ET
 0.080 0.110 0.160 rg
 BT
 /F1 8.4 Tf
-96 486 Td
+96 492 Td
 (Denials: scope_violation:no_customer_data_export and budget_exhausted.) Tj
 ET
 0.000 0.450 0.550 rg
 BT
 /F2 10 Tf
-82 470 Td
+82 476 Td
 (-) Tj
 ET
 0.080 0.110 0.160 rg
 BT
 /F1 8.4 Tf
-96 470 Td
+96 476 Td
 (Revocation: worker authority revoked, then first post-revoke call blocked.) Tj
 ET
 0.000 0.450 0.550 rg
 BT
 /F2 10 Tf
-82 454 Td
+82 460 Td
 (-) Tj
 ET
 0.080 0.110 0.160 rg
 BT
 /F1 8.4 Tf
-96 454 Td
+96 460 Td
 (Export receipt: producing this Evidence Pack is itself auditable.) Tj
 ET
 0.970 0.970 0.990 rg
-62 258 488 168 re f
+62 240 488 188 re f
 0.120 0.100 0.220 rg
 BT
 /F2 13 Tf
-78 406 Td
+78 408 Td
 (Maps to audit controls) Tj
 ET
 0.120 0.100 0.220 rg
-78 378 456 22 re f
+78 380 456 22 re f
 1.000 1.000 1.000 rg
 BT
 /F2 8 Tf
-88 385 Td
+88 387 Td
 (Artifact) Tj
 ET
 1.000 1.000 1.000 rg
 BT
 /F2 8 Tf
-218 385 Td
+218 387 Td
 (Control mapping) Tj
 ET
 1.000 1.000 1.000 rg
 BT
 /F2 8 Tf
-382 385 Td
+382 387 Td
 (Why it matters) Tj
 ET
 0.940 0.980 0.990 rg
-78 352 456 24 re f
+78 354 456 23 re f
 0.050 0.070 0.100 rg
 BT
-/F1 8 Tf
-88 358 Td
+/F1 7.8 Tf
+88 360 Td
 (Mint receipt) Tj
 ET
 0.050 0.070 0.100 rg
 BT
-/F1 8 Tf
-218 358 Td
-(SOC 2 CC6.1 / ISO 27001 A.9) Tj
+/F1 7.8 Tf
+218 360 Td
+(SOC 2 CC6.1) Tj
 ET
 0.050 0.070 0.100 rg
 BT
-/F1 8 Tf
-382 358 Td
+/F1 7.8 Tf
+382 360 Td
 (Logical access provisioning evidence) Tj
 ET
 0.050 0.070 0.100 rg
 BT
-/F1 8 Tf
-88 330 Td
+/F1 7.8 Tf
+88 334 Td
+(Mint receipt) Tj
+ET
+0.050 0.070 0.100 rg
+BT
+/F1 7.8 Tf
+218 334 Td
+(ISO 27001 A.9.2.1) Tj
+ET
+0.050 0.070 0.100 rg
+BT
+/F1 7.8 Tf
+382 334 Td
+(Registration/de-registration trail) Tj
+ET
+0.940 0.980 0.990 rg
+78 302 456 23 re f
+0.050 0.070 0.100 rg
+BT
+/F1 7.8 Tf
+88 308 Td
 (Delegation chain) Tj
 ET
 0.050 0.070 0.100 rg
 BT
-/F1 8 Tf
-218 330 Td
+/F1 7.8 Tf
+218 308 Td
 (SOC 2 CC6.3 / NIST AC-3) Tj
 ET
 0.050 0.070 0.100 rg
 BT
-/F1 8 Tf
-382 330 Td
+/F1 7.8 Tf
+382 308 Td
 (Least-privilege attenuation) Tj
 ET
-0.940 0.980 0.990 rg
-78 296 456 24 re f
 0.050 0.070 0.100 rg
 BT
-/F1 8 Tf
-88 302 Td
+/F1 7.8 Tf
+88 282 Td
 (Revocation proof) Tj
 ET
 0.050 0.070 0.100 rg
 BT
-/F1 8 Tf
-218 302 Td
+/F1 7.8 Tf
+218 282 Td
 (SOC 2 CC6.2/CC6.3 / NIST AC-2\(3\)) Tj
 ET
 0.050 0.070 0.100 rg
 BT
-/F1 8 Tf
-382 302 Td
+/F1 7.8 Tf
+382 282 Td
 (Deprovisioning + denied call) Tj
 ET
+0.940 0.980 0.990 rg
+78 250 456 23 re f
 0.050 0.070 0.100 rg
 BT
-/F1 8 Tf
-88 274 Td
+/F1 7.8 Tf
+88 256 Td
 (Spend ledger) Tj
 ET
 0.050 0.070 0.100 rg
 BT
-/F1 8 Tf
-218 274 Td
+/F1 7.8 Tf
+218 256 Td
 (SOC 2 CC1.4 / FinOps) Tj
 ET
 0.050 0.070 0.100 rg
 BT
-/F1 8 Tf
-382 274 Td
+/F1 7.8 Tf
+382 256 Td
 (Governance and spend attribution) Tj
 ET
 0.980 0.940 0.900 rg
-62 158 488 78 re f
+62 146 488 74 re f
 0.300 0.120 0.040 rg
 BT
 /F2 13 Tf
-78 216 Td
+78 201 Td
 (Why this beats logs) Tj
 ET
 0.160 0.120 0.100 rg
 BT
-/F1 8.2 Tf
-78 198 Td
+/F1 8.0 Tf
+78 184 Td
 (Reconstructing agent authority from gateway logs, invoices, IAM records, and screenshots can) Tj
 ET
 0.160 0.120 0.100 rg
 BT
-/F1 8.2 Tf
-78 185 Td
+/F1 8.0 Tf
+78 172 Td
 (take hours across multiple systems. SatGate packages the signed mint receipt, attenuation) Tj
 ET
 0.160 0.120 0.100 rg
 BT
-/F1 8.2 Tf
-78 172 Td
+/F1 8.0 Tf
+78 160 Td
 (chain, spend ledger, denial reasons, revocation proof, and export receipt into one file.) Tj
 ET
 0.050 0.070 0.100 rg
-62 80 488 58 re f
+62 70 488 58 re f
 0.700 0.940 1.000 rg
 BT
 /F2 8 Tf
-78 120 Td
+78 110 Td
 (Chain root) Tj
 ET
 0.920 0.980 1.000 rg
 BT
 /F1 6.8 Tf
-146 120 Td
+146 110 Td
 (sha256:f04ed8430b11c8975cc5ef35919ee078fc4cb166cd8d611ed0d94b7da69df09d) Tj
 ET
 0.700 0.940 1.000 rg
 BT
 /F2 8 Tf
-78 104 Td
+78 94 Td
 (Signature) Tj
 ET
 0.920 0.980 1.000 rg
 BT
 /F1 7.5 Tf
-146 104 Td
+146 94 Td
 (ed25519:REDACTED_DEMO_SAMPLE_DO_NOT_VERIFY) Tj
 ET
 0.800 1.000 0.820 rg
 BT
 /F2 8 Tf
-78 88 Td
+78 78 Td
 (Verify / download JSON at https://satgate.io/policy-to-proof  |  contact@satgate.io) Tj
 ET
 endstream endobj
@@ -345,5 +365,5 @@ xref
 0000000396 00000 n 
 trailer << /Size 7 /Root 1 0 R >>
 startxref
-5158
+5435
 %%EOF

--- a/satgate-landing/scripts/check_policy_to_proof_page.py
+++ b/satgate-landing/scripts/check_policy_to_proof_page.py
@@ -36,6 +36,10 @@ required_phrases = [
     "/evidence-packs/sample-evidence-pack.json",
     "/evidence-packs/sample-evidence-pack.pdf",
     "REDACTED_DEMO_SAMPLE_DO_NOT_VERIFY",
+    "evidence-pack-export-poster.svg",
+    "What the {title} gets",
+    "Full hashes, ed25519 signature, and verification block",
+    "ISO 27001 A.9.2.1",
     "Even producing the Evidence Pack is itself an auditable event",
     "Authority-chain entries preserve lineage",
 ]


### PR DESCRIPTION
## Summary
- Cuts the hero to the two Evidence Pack CTAs: PDF + JSON
- Keeps the Agent Control Plane link in context beside the demo video instead of competing in the hero
- Adds an Evidence Pack export poster frame for the video section and keeps the inline `<video>` player
- Adds ISO 27001 A.9.2.1 to the audit-control mappings
- Upgrades persona cards with icons and artifact-recipient framing
- Adds a caption clarifying that inline hashes are shortened and full hashes/signature/verification live in the downloadable JSON
- Regenerates the PDF with the ISO row preserved in the Maps-to table

## Test Plan
- [x] `python3 satgate-landing/scripts/check_policy_to_proof_page.py`
- [x] Verified hero ACP CTA removed, video poster present, ISO row present, PDF contains ISO row + footer CTA
- [x] `npm run lint -- app/policy-to-proof/page.tsx app/agent-control-plane/page.tsx`
- [x] `npm run build`