### PR TITLE
feat(landing): finish Policy-to-Proof v5 polish

### DIFF
--- a/satgate-landing/app/policy-to-proof/page.tsx
+++ b/satgate-landing/app/policy-to-proof/page.tsx
@@ -88,8 +88,8 @@ const demoSteps = [
 ];
 
 const standardsMappings = [
-  ["Mint receipt", "SOC 2 CC6.1", "Logical access provisioning tied to identity, policy, issuer, and timestamp."],
-  ["Mint receipt", "ISO 27001 A.9.2.1", "User registration and de-registration evidence for agent authority issuance."],
+  ["Mint receipt — US SOC 2", "SOC 2 CC6.1", "Logical access provisioning tied to identity, policy, issuer, and timestamp."],
+  ["Mint receipt — ISO 27001", "ISO 27001 A.9.2.1", "User registration and de-registration evidence for agent authority issuance."],
   ["Delegation chain", "SOC 2 CC6.3 / NIST AC-3", "Least-privilege attenuation across parent and worker authority."],
   ["Revocation receipt", "SOC 2 CC6.2/CC6.3 / NIST AC-2(3)", "Deprovisioning event plus first post-revoke denial trail."],
   ["Spend ledger", "SOC 2 CC1.4 / FinOps attribution", "Governance evidence for who created spend, on which route/tool, under which token."],
@@ -334,16 +334,36 @@ export default function PolicyToProofPage() {
               </figure>
             ))}
           </div>
+
+          <div className="mt-10 rounded-3xl border border-cyan-300/20 bg-cyan-300/5 p-7">
+            <div className="flex flex-col gap-5 md:flex-row md:items-center md:justify-between">
+              <div>
+                <p className="text-sm font-bold uppercase tracking-[0.2em] text-cyan-200">Want this for your stack?</p>
+                <p className="mt-3 max-w-2xl text-xl font-black leading-8 text-white">
+                  Bring an API, an agent workflow, and the evidence your auditor already asks for.
+                </p>
+              </div>
+              <a
+                href="mailto:contact@satgate.io?subject=SatGate%20Policy-to-Proof%20walkthrough"
+                className="inline-flex shrink-0 items-center justify-center gap-2 rounded-lg bg-white px-5 py-3 font-bold text-black transition hover:bg-gray-200"
+              >
+                Book a 15-minute walkthrough <ArrowRight size={18} />
+              </a>
+            </div>
+          </div>
         </div>
       </section>
 
       <section className="px-6 py-20">
         <div className="mx-auto max-w-6xl">
           <div className="max-w-3xl">
-            <p className="mb-3 text-sm font-semibold uppercase tracking-[0.24em] text-purple-300">5-minute demo path</p>
+            <p className="mb-3 text-sm font-semibold uppercase tracking-[0.24em] text-purple-300">Demo path</p>
             <h2 className="text-3xl font-black tracking-tight sm:text-5xl">Mint → Delegate → Spend → Deny → Revoke → Export.</h2>
             <p className="mt-5 text-lg leading-8 text-gray-400">
               The demo ends on the exported Evidence Pack. That is the buyer moment: one artifact proving authority, spend, denial, and revocation across the invoice-reconciler lifecycle. Even producing the Evidence Pack is itself an auditable event.
+            </p>
+            <p className="mt-4 text-sm leading-6 text-gray-500">
+              Read the six-step lifecycle below, or watch the 90-second cut.
             </p>
           </div>
 

--- a/satgate-landing/public/evidence-packs/sample-evidence-pack.pdf
+++ b/satgate-landing/public/evidence-packs/sample-evidence-pack.pdf
@@ -4,7 +4,7 @@
 3 0 obj << /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 4 0 R /F2 5 0 R >> >> /Contents 6 0 R >> endobj
 4 0 obj << /Type /Font /Subtype /Type1 /BaseFont /Helvetica >> endobj
 5 0 obj << /Type /Font /Subtype /Type1 /BaseFont /Helvetica-Bold >> endobj
-6 0 obj << /Length 4987 >> stream
+6 0 obj << /Length 5001 >> stream
 0.025 0.035 0.055 rg
 0 0 612 792 re f
 0.020 0.350 0.420 rg
@@ -205,7 +205,7 @@ ET
 BT
 /F1 7.8 Tf
 88 360 Td
-(Mint receipt) Tj
+(Mint receipt - SOC 2) Tj
 ET
 0.050 0.070 0.100 rg
 BT
@@ -223,7 +223,7 @@ ET
 BT
 /F1 7.8 Tf
 88 334 Td
-(Mint receipt) Tj
+(Mint receipt - ISO) Tj
 ET
 0.050 0.070 0.100 rg
 BT
@@ -365,5 +365,5 @@ xref
 0000000396 00000 n 
 trailer << /Size 7 /Root 1 0 R >>
 startxref
-5435
+5449
 %%EOF

--- a/satgate-landing/scripts/check_policy_to_proof_page.py
+++ b/satgate-landing/scripts/check_policy_to_proof_page.py
@@ -41,6 +41,12 @@ required_phrases = [
     "What the {title} gets",
     "Full hashes, ed25519 signature, and verification block",
     "ISO 27001 A.9.2.1",
+    "Mint receipt — US SOC 2",
+    "Mint receipt — ISO 27001",
+    "Demo path",
+    "Read the six-step lifecycle below, or watch the 90-second cut",
+    "Want this for your stack?",
+    "Book a 15-minute walkthrough",
     "Even producing the Evidence Pack is itself an auditable event",
     "Authority-chain entries preserve lineage",
 ]


### PR DESCRIPTION
## Summary
- visually confirm the video embed/poster path and keep the 90-second Evidence Pack player intact
- rename the demo section to "Demo path" and add the six-step vs 90-second clarifier
- add a mid-page walkthrough CTA after the persona cards
- differentiate SOC 2 vs ISO mint receipt labels on the page and PDF
- extend the Policy-to-Proof regression guard for the new polish

## Verification
- python3 scripts/check_policy_to_proof_page.py
- npx eslint app/policy-to-proof/page.tsx
- npm run build
- local browser visual check for persona CTA, Demo path clarifier, and video poster/player
- PDF file check + strings verification for updated audit labels