### PR TITLE
feat(landing): tighten authority proof positioning

### DIFF
--- a/satgate-landing/app/components/HomeClient.tsx
+++ b/satgate-landing/app/components/HomeClient.tsx
@@ -150,16 +150,16 @@ const LandingPage = () => {
               <Zap size={12} /> The Economic Firewall for AI Agents
             </div>
             <h1 className="text-5xl md:text-6xl font-extrabold tracking-tight mb-6">
-              Control what agents<br/>
+              Govern what agents<br/>
               <span className="sr-only"> </span><span className="text-transparent bg-clip-text bg-gradient-to-r from-purple-400 via-pink-400 to-cyan-400">
-                can spend.
+                can do — and prove it.
               </span>
             </h1>
             <p className="text-xl text-gray-400 mb-4 max-w-lg leading-relaxed">
               SatGate is the economic control plane for internal enterprise agents - with evidence that extends across paid external calls.
             </p>
             <p className="text-lg text-gray-500 mb-8 max-w-lg leading-relaxed">
-              Govern agent authority before it touches your API. Add budgets, scoped delegation, revocation, and proof across MCP, API keys, L402, x402-style rails, and enterprise billing.
+              Govern agent authority before it touches your API. Add budgets, scoped delegation, revocation, and proof across MCP, API keys, L402, x402-aware flows, and enterprise billing.
             </p>
             <div className="flex flex-wrap gap-4">
               <a href="https://cloud.satgate.io/cloud/login" target="_blank" rel="noopener noreferrer" className="bg-gradient-to-r from-purple-600 to-cyan-600 hover:from-purple-500 hover:to-cyan-500 text-white px-8 py-3 rounded-lg font-bold transition flex items-center gap-2 shadow-lg shadow-purple-500/20">
@@ -174,12 +174,16 @@ const LandingPage = () => {
             </div>
 
             {/* Proof strip */}
-            <div className="flex flex-wrap items-center gap-x-5 gap-y-2 mt-6 text-xs text-gray-500">
-              <span className="flex items-center gap-1.5"><CheckCircle size={12} className="text-green-500" /> REST · GraphQL · MCP</span>
-              <span className="flex items-center gap-1.5"><CheckCircle size={12} className="text-green-500" /> Gateway · Sidecar · MCP Proxy</span>
-              <span className="flex items-center gap-1.5"><CheckCircle size={12} className="text-green-500" /> Sub-ms verification</span>
-              <span className="flex items-center gap-1.5"><CheckCircle size={12} className="text-green-500" /> MCP · API keys · x402-style rails</span>
-              <span className="flex items-center gap-1.5"><CheckCircle size={12} className="text-green-500" /> <a href="https://github.com/SatGate-io/satgate" className="text-gray-400 hover:text-white transition underline underline-offset-2">Open source</a></span>
+            <div className="mt-6 space-y-2 text-xs text-gray-500">
+              <div className="flex flex-wrap items-center gap-x-5 gap-y-2">
+                <span className="flex items-center gap-1.5"><CheckCircle size={12} className="text-green-500" /> REST · GraphQL · MCP</span>
+                <span className="flex items-center gap-1.5"><CheckCircle size={12} className="text-green-500" /> Gateway · Sidecar · MCP Proxy</span>
+                <span className="flex items-center gap-1.5"><CheckCircle size={12} className="text-green-500" /> Sub-ms verification</span>
+              </div>
+              <div className="flex flex-wrap items-center gap-x-5 gap-y-2">
+                <span className="flex items-center gap-1.5"><CheckCircle size={12} className="text-green-500" /> MCP · API keys · x402-aware governance</span>
+                <span className="flex items-center gap-1.5"><CheckCircle size={12} className="text-green-500" /> <a href="https://github.com/SatGate-io/satgate" className="text-gray-400 hover:text-white transition underline underline-offset-2">Open source</a></span>
+              </div>
             </div>
           </div>
 
@@ -383,7 +387,7 @@ const LandingPage = () => {
               </p>
               <ul className="text-xs text-gray-500 space-y-1">
                 <li>✓ Let approved agents pay or access without long-lived shared secrets</li>
-                <li>✓ Preserve authority evidence above x402-style, L402, API-key, or enterprise billing rails</li>
+                <li>✓ Preserve authority evidence above x402, L402, API-key, or enterprise billing rails</li>
                 <li>✓ Per-request pricing and policy before upstream execution</li>
                 <li>✓ Autonomous agents discover, pay, and leave an audit trail</li>
               </ul>
@@ -655,7 +659,7 @@ const LandingPage = () => {
             {[
               ['What is SatGate?', 'SatGate is an economic firewall and economic control plane for internal enterprise agents. It sits in the request path to observe usage, enforce budgets, scope delegated authority, prove revocation, and preserve evidence across internal APIs and paid external calls.'],
               ['How does SatGate control AI agent spend?', 'SatGate applies per-agent, per-tool, per-team, and per-task budgets before each request reaches an API or MCP tool, so runaway loops and expensive calls can be blocked before spend occurs.'],
-              ['What are Observe, Control, and Charge?', 'Observe tracks agent traffic and cost without blocking. Control enforces budgets and scoped policy for internal agents. Charge preserves authorization evidence around external paid access across L402, x402-style, API-key, or enterprise billing rails.'],
+              ['What are Observe, Control, and Charge?', 'Observe tracks agent traffic and cost without blocking. Control enforces budgets and scoped policy for internal agents. Charge preserves authorization evidence around external paid access across L402, x402, API-key, or enterprise billing rails.'],
             ].map(([question, answer]) => (
               <div key={question} className="border-t border-gray-800 pt-6 first:border-t-0 first:pt-0">
                 <h3 className="mb-2 text-xl font-bold text-white">{question}</h3>

--- a/satgate-landing/app/page.tsx
+++ b/satgate-landing/app/page.tsx
@@ -4,7 +4,7 @@ import HomeClient from "./components/HomeClient";
 export const metadata: Metadata = {
   title: "SatGate — The Economic Firewall for AI Agent Requests",
   description:
-    "Control AI agent API spend before each request. SatGate adds internal-agent authority governance, per-agent budgets, delegation, revocation, and evidence across MCP, API keys, L402, x402-style rails, and enterprise billing.",
+    "Control AI agent API spend before each request. SatGate adds internal-agent authority governance, per-agent budgets, delegation, revocation, and evidence across MCP, API keys, L402, x402-aware flows, and enterprise billing.",
   alternates: {
     canonical: "https://satgate.io",
   },
@@ -44,7 +44,7 @@ export default function HomePage() {
         '@type': 'WebPage',
         name: 'SatGate — The Economic Firewall for AI Agent Requests',
         url: 'https://satgate.io',
-        description: 'Control AI agent API spend before each request with internal-agent governance, per-agent budgets, delegation, revocation, and evidence across MCP, API keys, L402, x402-style rails, and enterprise billing.',
+        description: 'Control AI agent API spend before each request with internal-agent governance, per-agent budgets, delegation, revocation, and evidence across MCP, API keys, L402, x402-aware flows, and enterprise billing.',
         datePublished: '2026-04-30',
         dateModified: '2026-05-05',
         isPartOf: { '@type': 'WebSite', name: 'SatGate', url: 'https://satgate.io' },
@@ -83,7 +83,7 @@ export default function HomePage() {
         name: 'What are Observe, Control, and Charge?',
         acceptedAnswer: {
           '@type': 'Answer',
-          text: 'Observe tracks agent traffic and cost without blocking. Control enforces budgets and scoped policy for internal agents. Charge preserves authorization evidence around external paid access across L402, x402-style, API-key, or enterprise billing rails.',
+          text: 'Observe tracks agent traffic and cost without blocking. Control enforces budgets and scoped policy for internal agents. Charge preserves authorization evidence around external paid access across L402, x402, API-key, or enterprise billing rails.',
         },
       },
     ],

--- a/satgate-landing/app/policy-to-proof/page.tsx
+++ b/satgate-landing/app/policy-to-proof/page.tsx
@@ -122,7 +122,7 @@ const evidencePack = {
   payment_context: {
     default_market: "internal_enterprise_agents",
     internal_rail: "existing_iam_service_account_or_api_key_billing",
-    optional_external_rails: ["x402-style", "l402", "api_key_billing", "enterprise_ledger"],
+    optional_external_rails: ["x402", "l402", "api_key_billing", "enterprise_ledger"],
     note: "The same authority chain and receipts can cover an internal agent call, or a governed bridge call to an external paid API.",
   },
   authority_chain: [
@@ -146,7 +146,7 @@ const evidencePack = {
     { type: "delegation", ts: "2026-05-09T14:23:04Z", result: "attenuated", receipt_hash: "sha256:95f1..." },
     { type: "spend", ts: "2026-05-09T14:23:18Z", route: "/v1/invoices/search", amount_usd: "0.18", payment_protocol: "internal_api", settlement: { rail: "internal_ledger", cost_center: "FIN-AP-042" }, result: "allowed", receipt_hash: "sha256:01d8..." },
     { type: "spend", ts: "2026-05-09T14:24:02Z", route: "/v1/invoices/compare", amount_usd: "0.42", payment_protocol: "internal_api", settlement: { rail: "internal_ledger", cost_center: "FIN-AP-042" }, result: "allowed", receipt_hash: "sha256:a923..." },
-    { type: "spend", ts: "2026-05-09T14:24:44Z", route: "/v1/invoices/ocr", mcp_tool: "document_ai.ocr", amount_usd: "1.12", payment_protocol: "x402-style", settlement: { chain: "solana", tx: "REDACTED_DEMO_SAMPLE", ms: 187 }, result: "allowed", receipt_hash: "sha256:deb5..." },
+    { type: "spend", ts: "2026-05-09T14:24:44Z", route: "/v1/invoices/ocr", mcp_tool: "document_ai.ocr", amount_usd: "0.18", payment_protocol: "x402", settlement: { chain: "solana", tx: "REDACTED_DEMO_SAMPLE", ms: 187 }, result: "allowed", receipt_hash: "sha256:deb5..." },
     { type: "denial", ts: "2026-05-09T14:25:08Z", reason_code: "scope_violation:no_customer_data_export", result: "blocked", receipt_hash: "sha256:9b0f..." },
     { type: "denial", ts: "2026-05-09T14:25:33Z", reason_code: "budget_exhausted", result: "blocked", receipt_hash: "sha256:c3f6..." },
     { type: "revocation", ts: "2026-05-09T14:26:11Z", revoked_by: "security-admin", result: "revoked", receipt_hash: "sha256:37d1..." },
@@ -251,6 +251,21 @@ export default function PolicyToProofPage() {
         </div>
       </section>
 
+      <section className="border-b border-white/10 bg-white/[0.02] px-6 py-20">
+        <div className="mx-auto max-w-6xl">
+          <div className="max-w-3xl">
+            <p className="mb-3 text-sm font-semibold uppercase tracking-[0.24em] text-cyan-300">Internal first, rail-aware when needed</p>
+            <h2 className="text-3xl font-black tracking-tight sm:text-5xl">Built for internal enterprise agents. Extends across paid external calls.</h2>
+            <p className="mt-5 text-lg leading-8 text-gray-400">
+              Most enterprise agents do not need a wallet to call internal APIs. They need scoped authority, budget controls, revocation, and audit evidence around the credentials they already have.
+            </p>
+            <p className="mt-4 text-base leading-7 text-gray-500">
+              When that same internal workflow crosses into an external paid API, SatGate keeps the proof intact: internal scope and delegation, plus spend attribution above x402 rails, L402, API-key billing, or enterprise ledgers. Payment proves value moved. SatGate proves the agent was allowed to move it.
+            </p>
+          </div>
+        </div>
+      </section>
+
       <section className="border-b border-white/10 px-6 py-20">
         <div className="mx-auto max-w-6xl">
           <div className="max-w-3xl">
@@ -276,20 +291,7 @@ export default function PolicyToProofPage() {
         </div>
       </section>
 
-      <section className="border-b border-white/10 bg-white/[0.02] px-6 py-20">
-        <div className="mx-auto max-w-6xl">
-          <div className="max-w-3xl">
-            <p className="mb-3 text-sm font-semibold uppercase tracking-[0.24em] text-cyan-300">Internal first, rail-aware when needed</p>
-            <h2 className="text-3xl font-black tracking-tight sm:text-5xl">Built for internal enterprise agents. Extends across paid external calls.</h2>
-            <p className="mt-5 text-lg leading-8 text-gray-400">
-              Most enterprise agents do not need a wallet to call internal APIs. They need scoped authority, budget controls, revocation, and audit evidence around the credentials they already have.
-            </p>
-            <p className="mt-4 text-base leading-7 text-gray-500">
-              When that same internal workflow crosses into an external paid API, SatGate keeps the proof intact: internal scope and delegation, plus spend attribution above x402-style rails, L402, API-key billing, or enterprise ledgers. Payment proves value moved. SatGate proves the agent was allowed to move it.
-            </p>
-          </div>
-        </div>
-      </section>
+
 
       <section className="border-b border-white/10 bg-white/[0.02] px-6 py-20">
         <div className="mx-auto max-w-6xl">

--- a/satgate-landing/public/evidence-packs/sample-evidence-pack.json
+++ b/satgate-landing/public/evidence-packs/sample-evidence-pack.json
@@ -103,11 +103,11 @@
       "agent": "worker-agent:invoice-reconciler",
       "route": "/v1/invoices/ocr",
       "mcp_tool": "document_ai.ocr",
-      "amount_usd": "1.12",
+      "amount_usd": "0.18",
       "result": "allowed",
       "ledger_entry_id": "led_7f33",
       "receipt_hash": "sha256:deb583596fa15d409aab8e5b3c85a9dac5d970a6690a134074b70e7de042c7d2",
-      "payment_protocol": "x402-style",
+      "payment_protocol": "x402",
       "settlement": {
         "chain": "solana",
         "tx": "REDACTED_DEMO_SAMPLE",
@@ -174,7 +174,7 @@
     "default_market": "internal_enterprise_agents",
     "internal_rail": "existing_iam_service_account_or_api_key_billing",
     "optional_external_rails": [
-      "x402-style",
+      "x402",
       "l402",
       "api_key_billing",
       "enterprise_ledger"

--- a/satgate-landing/public/evidence-packs/sample-evidence-pack.pdf
+++ b/satgate-landing/public/evidence-packs/sample-evidence-pack.pdf
@@ -4,7 +4,7 @@
 3 0 obj << /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 4 0 R /F2 5 0 R >> >> /Contents 6 0 R >> endobj
 4 0 obj << /Type /Font /Subtype /Type1 /BaseFont /Helvetica >> endobj
 5 0 obj << /Type /Font /Subtype /Type1 /BaseFont /Helvetica-Bold >> endobj
-6 0 obj << /Length 4992 >> stream
+6 0 obj << /Length 4980 >> stream
 0.025 0.035 0.055 rg
 0 0 612 792 re f
 0.020 0.350 0.420 rg
@@ -133,7 +133,7 @@ ET
 BT
 /F1 8.4 Tf
 96 508 Td
-(Spend ledger: internal API plus x402-style bridge spend attribution.) Tj
+(Spend ledger: internal API plus x402 bridge spend attribution.) Tj
 ET
 0.000 0.450 0.550 rg
 BT
@@ -351,7 +351,7 @@ ET
 BT
 /F2 8 Tf
 78 78 Td
-(Verify JSON with x402-style/L402/API-key rail context at https://satgate.io/policy-to-proof) Tj
+(Verify JSON with x402/L402/API-key rail context at https://satgate.io/policy-to-proof) Tj
 ET
 endstream endobj
 xref
@@ -365,5 +365,5 @@ xref
 0000000396 00000 n 
 trailer << /Size 7 /Root 1 0 R >>
 startxref
-5440
+5428
 %%EOF

--- a/satgate-landing/scripts/check_policy_to_proof_page.py
+++ b/satgate-landing/scripts/check_policy_to_proof_page.py
@@ -41,7 +41,7 @@ required_phrases = [
     "What the {title} gets",
     "Full hashes, payment rail context, ed25519 signature, and verification block",
     "payment_context",
-    "x402-style",
+    "x402",
     "internal_enterprise_agents",
     "Internal first, rail-aware when needed",
     "Payment proves value moved. SatGate proves the agent was allowed to move it.",


### PR DESCRIPTION
## Summary
- update homepage hero to lead with authority/proof: "Govern what agents can do — and prove it"
- split the homepage proof strip into deployment/perf and rail/open-source rows
- replace `x402-style` with clearer x402-aware/x402 wording
- lower the OCR bridge spend example to $0.18
- move the internal-first Policy-to-Proof section above the contrast block
- update Evidence Pack JSON/PDF and regression checks accordingly

## Verification
- `python3 -m json.tool public/evidence-packs/sample-evidence-pack.json`
- `python3 scripts/check_policy_to_proof_page.py`
- `npx eslint app/policy-to-proof/page.tsx app/page.tsx app/components/HomeClient.tsx` (warnings only in pre-existing HomeClient unused imports/helpers)
- `npm run build`
- local browser checks for `/` and `/policy-to-proof`
- PDF file/strings verification for x402/L402/API-key rail context
