### PR TITLE
Align /govern with Policy-to-Proof

### DIFF
--- a/satgate-landing/app/components/GovernClient.tsx
+++ b/satgate-landing/app/components/GovernClient.tsx
@@ -2,10 +2,10 @@
 
 import React, { useState } from 'react';
 import {
-  Eye, Sliders, CreditCard, Shield, AlertTriangle, Users, Building2,
-  ArrowRight, CheckCircle, Clock, DollarSign, Lock, Key, Bot,
-  GitBranch, Activity, Server, Cloud, Container, FileCode, Menu, X,
-  ChevronRight, Zap, UserCheck, FileSearch, BarChart3, ShieldCheck,
+  Eye, Sliders, Shield, AlertTriangle, Users,
+  ArrowRight, CheckCircle, DollarSign, Lock, Key, Bot,
+  GitBranch, Activity, Cloud, Container, FileCode, Menu, X,
+  ChevronRight, Zap, FileSearch,
   Network, Timer, Coins, Layers
 } from 'lucide-react';
 import Link from 'next/link';
@@ -66,23 +66,20 @@ export default function GovernPage() {
       <header className="pt-32 pb-20 px-6">
         <div className="max-w-4xl mx-auto text-center">
           <div className="inline-flex items-center gap-2 px-3 py-1 rounded-full bg-purple-900/30 border border-purple-500/30 text-purple-300 text-xs font-mono mb-6">
-            <Shield size={12} /> Economic Access Control (EAC)
+            <Shield size={12} /> Enterprise agent governance
           </div>
           <h1 className="text-5xl md:text-6xl font-extrabold tracking-tight mb-6">
-            Economic Access Control.{' '}
-            <span className="text-transparent bg-clip-text bg-gradient-to-r from-purple-400 via-pink-400 to-cyan-400">
-              Not &ldquo;Who Are You?&rdquo; — &ldquo;What Can You Afford?&rdquo;
+            Govern what agents can do.
+            <span className="block text-transparent bg-clip-text bg-gradient-to-r from-purple-400 via-pink-400 to-cyan-400">
+              Prove every decision.
             </span>
           </h1>
           <p className="text-xl text-gray-400 mb-10 max-w-2xl mx-auto leading-relaxed">
-            RBAC asks for identity. EAC asks for a budget. Your AI agents are spending money, calling APIs, and making decisions — with zero economic constraints.
-            SatGate enforces <strong className="text-white">Economic Access Control</strong>: <strong className="text-white">observe</strong> every call,{' '}
-            <strong className="text-white">control</strong> every budget, and{' '}
-            <strong className="text-white">charge</strong> for access to your high-value APIs.
+            SatGate is the economic control plane for enterprise agents: scope authority before work starts, enforce policy at runtime, and preserve evidence after every allowed, denied, delegated, or revoked action.
           </p>
           <div className="flex flex-col sm:flex-row gap-4 justify-center">
-            <Link href="/design-partners" className="bg-white text-black px-8 py-3 rounded-lg font-bold hover:bg-gray-200 transition flex items-center justify-center gap-2">
-              Become a Design Partner <ArrowRight size={18} />
+            <Link href="/policy-to-proof" className="bg-white text-black px-8 py-3 rounded-lg font-bold hover:bg-gray-200 transition flex items-center justify-center gap-2">
+              See Policy-to-Proof <ArrowRight size={18} />
             </Link>
             <Link href="https://cloud.satgate.io/cloud/login" className="border border-gray-700 px-8 py-3 rounded-lg font-bold hover:border-gray-500 transition flex items-center justify-center gap-2">
               Start Free <Eye size={18} />
@@ -94,9 +91,9 @@ export default function GovernPage() {
       {/* One Token, Two Threats */}
       <section className="py-16 px-6 border-t border-gray-800 bg-gradient-to-b from-gray-900/20 to-black">
         <div className="max-w-4xl mx-auto">
-          <h2 className="text-3xl font-bold text-center mb-3">Two Problems. One Token.</h2>
+          <h2 className="text-3xl font-bold text-center mb-3">Govern internal agents. Preserve proof across external rails.</h2>
           <p className="text-gray-500 text-center mb-10 max-w-2xl mx-auto">
-            SatGate uses capability tokens to prevent unauthorized spend from your agents and unauthorized access from theirs.
+            The same capability chain scopes authority, enforces spend limits, preserves delegation lineage, and proves what happened whether the call stays internal or crosses into paid external access.
           </p>
 
           <div className="grid grid-cols-1 md:grid-cols-2 gap-6 max-w-3xl mx-auto">
@@ -110,11 +107,11 @@ export default function GovernPage() {
                   <p className="text-xs font-mono text-cyan-400 uppercase tracking-wider">Your Agents (Internal)</p>
                 </div>
               </div>
-              <h3 className="text-xl font-bold text-white mb-2">Prevent Unauthorized <span className="text-cyan-400">Spend</span></h3>
-              <p className="text-gray-400 text-sm mb-3">No token → no spend. Request-path budget enforcement ensures agents can&apos;t exceed their allocation.</p>
+              <h3 className="text-xl font-bold text-white mb-2">Govern <span className="text-cyan-400">Authority</span></h3>
+              <p className="text-gray-400 text-sm mb-3">No scoped capability → no action. SatGate decides what each agent can do, spend, delegate, and continue doing before the request reaches your API.</p>
               <div className="flex items-center gap-2 text-xs text-gray-500">
                 <Shield size={12} className="text-cyan-400" />
-                <span>Observe → Control policy ratchet</span>
+                <span>Govern → enforce → prove policy ratchet</span>
               </div>
             </div>
 
@@ -128,11 +125,11 @@ export default function GovernPage() {
                   <p className="text-xs font-mono text-yellow-400 uppercase tracking-wider">Their Agents (External)</p>
                 </div>
               </div>
-              <h3 className="text-xl font-bold text-white mb-2">Prevent Unauthorized <span className="text-yellow-400">Access</span></h3>
-              <p className="text-gray-400 text-sm mb-3">No token → no access. Monetization via L402 ensures external agents pay per request.</p>
+              <h3 className="text-xl font-bold text-white mb-2">Preserve <span className="text-yellow-400">Proof</span></h3>
+              <p className="text-gray-400 text-sm mb-3">Payment proves value moved. SatGate proves the agent was allowed to move it across L402, x402, API-key billing, or enterprise ledgers.</p>
               <div className="flex items-center gap-2 text-xs text-gray-500">
                 <Zap size={12} className="text-yellow-400" />
-                <span>Charge policy with Lightning settlement</span>
+                <span>Rail-aware evidence, payment or not</span>
               </div>
             </div>
           </div>
@@ -140,7 +137,7 @@ export default function GovernPage() {
           <div className="text-center mt-8">
             <div className="inline-flex items-center gap-3 px-5 py-2.5 bg-gray-900 border border-gray-800 rounded-full text-sm">
               <Key size={16} className="text-purple-400" />
-              <span className="text-gray-400">Same <span className="text-white font-semibold">macaroon token</span> — same architecture — two problems solved</span>
+              <span className="text-gray-400">Same <span className="text-white font-semibold">macaroon capability</span> — same authority chain — one evidence trail</span>
             </div>
           </div>
         </div>
@@ -149,9 +146,9 @@ export default function GovernPage() {
       {/* Three Personas */}
       <section className="py-20 px-6 border-t border-gray-800">
         <div className="max-w-5xl mx-auto">
-          <h2 className="text-3xl font-bold text-center mb-4">Built for the C-Suite</h2>
-          <p className="text-gray-500 text-center mb-4">Margins. Risk. Growth.</p>
-          <p className="text-xs text-gray-600 text-center mb-12">Predictable AI costs. Cryptographic access control. Net-new machine-to-machine revenue.</p>
+          <h2 className="text-3xl font-bold text-center mb-4">Built for enterprise control owners</h2>
+          <p className="text-gray-500 text-center mb-4">Security. Finance. Platform.</p>
+          <p className="text-xs text-gray-600 text-center mb-12">Scoped authority, enforceable limits, and audit-ready evidence for autonomous agent work.</p>
 
           <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
             {/* CFO — Margins (Observe) */}
@@ -161,22 +158,22 @@ export default function GovernPage() {
                   <DollarSign className="text-cyan-400" size={22} />
                 </div>
                 <div>
-                  <h3 className="font-bold text-lg">CFO</h3>
-                  <span className="text-xs text-cyan-400 font-medium">Deterministic Cost Control</span>
+                  <h3 className="font-bold text-lg">FinOps</h3>
+                  <span className="text-xs text-cyan-400 font-medium">Attributed agent spend</span>
                 </div>
               </div>
               <p className="text-gray-400 text-sm leading-relaxed mb-3">
-                <span className="text-cyan-300 font-medium">The problem:</span> Unpredictable AI bills. An infinite loop on an expensive MCP tool burns thousands over a weekend. No one notices until the invoice arrives.
+                <span className="text-cyan-300 font-medium">The problem:</span> Shared API keys and pooled model bills hide which agent, route, token, or workflow created spend.
               </p>
               <p className="text-gray-300 text-sm leading-relaxed mb-4 border-l-2 border-cyan-800 pl-3">
-                &ldquo;SatGate ends faith-based accounting for AI. We enforce hard, real-time dollar caps on every agent and tool — turning unpredictable AI costs into predictable, hard-capped OpEx.&rdquo;
+                &ldquo;SatGate turns spend into evidence: who created it, which authority allowed it, which policy governed it, and where the budget stopped.&rdquo;
               </p>
               <div className="pt-3 border-t border-cyan-900/30">
                 <p className="text-xs text-cyan-400 font-medium mb-2">Metrics that matter:</p>
-                <p className="text-xs text-gray-400">Eliminate a major class of unbounded agent spend and AI bill shock</p>
+                <p className="text-xs text-gray-400">Attribute spend to agent, token, route, tool, and policy before finance has to reconstruct it</p>
               </div>
               <div className="mt-4">
-                <Link href="/sandbox" className="text-xs text-cyan-400 hover:text-cyan-300 transition">Stop the ghost spend →</Link>
+                <Link href="/policy-to-proof" className="text-xs text-cyan-400 hover:text-cyan-300 transition">See the evidence pack →</Link>
               </div>
             </div>
 
@@ -188,58 +185,58 @@ export default function GovernPage() {
                 </div>
                 <div>
                   <h3 className="font-bold text-lg">CISO</h3>
-                  <span className="text-xs text-red-400 font-medium">Economic Access Control</span>
+                  <span className="text-xs text-red-400 font-medium">Revocation proof</span>
                 </div>
               </div>
               <p className="text-gray-400 text-sm leading-relaxed mb-3">
-                <span className="text-red-300 font-medium">The problem:</span> A compromised AI agent gets inside the perimeter and spams a sensitive database at machine speed, bypassing traditional rate limits.
+                <span className="text-red-300 font-medium">The problem:</span> Agents now hold authority that used to require human approval. Security needs proof that scope, delegation, denial, and revocation actually worked.
               </p>
               <p className="text-gray-300 text-sm leading-relaxed mb-4 border-l-2 border-red-800 pl-3">
-                &ldquo;SatGate provides a deterministic, cryptographic kill-switch. We don&apos;t just alert you — we hard-cap agent spend before the blast radius expands.&rdquo;
+                &ldquo;SatGate gives us a kill switch with evidence: the revocation receipt, the first denied call after revoke, and the authority chain that led there.&rdquo;
               </p>
               <div className="pt-3 border-t border-red-900/30">
                 <p className="text-xs text-red-400 font-medium mb-2">Metrics that matter:</p>
-                <p className="text-xs text-gray-400">Reduce risk of runaway agent misuse and unauthorized spend</p>
+                <p className="text-xs text-gray-400">Prove unauthorized actions were blocked before data or spend moved</p>
               </div>
               <div className="mt-4">
-                <Link href="/protect" className="text-xs text-red-400 hover:text-red-300 transition">See it in action →</Link>
+                <Link href="/policy-to-proof" className="text-xs text-red-400 hover:text-red-300 transition">Review Policy-to-Proof →</Link>
               </div>
             </div>
 
-            {/* CEO/CRO — Growth (Charge) */}
+            {/* Platform — protocol-independent governance */}
             <div className="p-6 rounded-xl bg-gradient-to-br from-yellow-950/30 to-yellow-900/10 border border-yellow-800/30 hover:border-yellow-600/50 transition group">
               <div className="flex items-center gap-3 mb-4">
                 <div className="p-2.5 bg-yellow-900/50 rounded-lg group-hover:bg-yellow-900/70 transition">
                   <Zap className="text-yellow-400" size={22} />
                 </div>
                 <div>
-                  <h3 className="font-bold text-lg">CEO / CRO</h3>
-                  <span className="text-xs text-yellow-400 font-medium">Monetizing the Agentic Web</span>
+                  <h3 className="font-bold text-lg">Platform</h3>
+                  <span className="text-xs text-yellow-400 font-medium">Protocol-independent governance</span>
                 </div>
               </div>
               <p className="text-gray-400 text-sm leading-relaxed mb-3">
-                <span className="text-yellow-300 font-medium">The problem:</span> Getting left behind as the internet shifts from human-to-human commerce to machine-to-machine commerce. Your APIs are valuable — but you&apos;re giving them away.
+                <span className="text-yellow-300 font-medium">The problem:</span> Agents are moving across internal APIs, MCP tools, and paid external rails. Governance cannot depend on which protocol the agent used.
               </p>
               <p className="text-gray-300 text-sm leading-relaxed mb-4 border-l-2 border-yellow-800 pl-3">
-                &ldquo;SatGate turns your IT infrastructure from a cost center into an automated storefront. Expose APIs to external AI agents and charge micropayments for every call via L402.&rdquo;
+                &ldquo;SatGate sits above MCP, API keys, x402, L402, and enterprise billing rails so every authority decision is recorded — payment or not.&rdquo;
               </p>
               <div className="pt-3 border-t border-yellow-900/30">
                 <p className="text-xs text-yellow-400 font-medium mb-2">Metrics that matter:</p>
-                <p className="text-xs text-gray-400">Net-new revenue from machine-to-machine API transactions</p>
+                <p className="text-xs text-gray-400">One control path for internal workflows and governed external paid calls</p>
               </div>
               <div className="mt-4">
-                <Link href="/pay" className="text-xs text-yellow-400 hover:text-yellow-300 transition">Start earning →</Link>
+                <Link href="/agent-control-plane" className="text-xs text-yellow-400 hover:text-yellow-300 transition">See the control plane →</Link>
               </div>
             </div>
           </div>
         </div>
       </section>
 
-      {/* Observe → Control → Charge */}
+      {/* Govern → Enforce → Prove */}
       <section id="observe" className="py-20 px-6 border-t border-gray-800 bg-gradient-to-b from-gray-900/30 to-black">
         <div className="max-w-5xl mx-auto">
-          <h2 className="text-3xl font-bold text-center mb-4">Three Modes. One Gateway.</h2>
-          <p className="text-gray-500 text-center mb-12">Start with visibility. Add control when you're ready. Monetize when it makes sense.</p>
+          <h2 className="text-3xl font-bold text-center mb-4">Govern, enforce, prove.</h2>
+          <p className="text-gray-500 text-center mb-12">Start with visibility, move enforcement into the request path, then export the evidence when security, finance, or audit asks what happened.</p>
 
           <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
             {/* Observe */}
@@ -251,13 +248,13 @@ export default function GovernPage() {
                 <h3 className="font-bold text-lg">Observe</h3>
               </div>
               <p className="text-gray-400 text-sm leading-relaxed mb-4">
-                See every API call, every token, every agent — across MCP servers, REST APIs, and LLM endpoints. MCP proxy tracks per-tool costs in real time. Full visibility with zero enforcement.
+                Map every agent, token, route, MCP tool, model, and workflow before enforcing policy. Observe mode builds the authority and spend picture without disrupting teams.
               </p>
               <ul className="space-y-2 text-sm text-gray-500">
-                <li className="text-purple-400">✓ Real-time request logging</li>
-                <li className="text-purple-400">✓ Cost attribution dashboards</li>
-                <li className="text-purple-400">✓ Agent inventory</li>
-                <li className="text-purple-400">✓ Anomaly detection</li>
+                <li className="text-purple-400">✓ Agent and token inventory</li>
+                <li className="text-purple-400">✓ Route, tool, and tenant attribution</li>
+                <li className="text-purple-400">✓ Spend and authority mapping</li>
+                <li className="text-purple-400">✓ Evidence-ready event capture</li>
               </ul>
             </div>
 
@@ -270,32 +267,32 @@ export default function GovernPage() {
                 <h3 className="font-bold text-lg">Control</h3>
               </div>
               <p className="text-gray-400 text-sm leading-relaxed mb-4">
-                Set budgets per agent, per MCP tool, per team. Hard enforcement — agents get 402'd when budgets run out. Delegation hierarchies for sub-agents.
+                Enforce scoped capabilities, budgets, tenant boundaries, delegation depth, expiry, and revocation before the next request reaches an API or MCP tool.
               </p>
               <ul className="space-y-2 text-sm text-gray-500">
-                <li className="text-cyan-400">✓ Per-agent budget limits</li>
-                <li className="text-cyan-400">✓ Token scope enforcement</li>
-                <li className="text-cyan-400">✓ Rate limiting by team</li>
-                <li className="text-cyan-400">✓ Automatic revocation</li>
+                <li className="text-cyan-400">✓ Per-agent and per-route policy</li>
+                <li className="text-cyan-400">✓ Scope and caveat enforcement</li>
+                <li className="text-cyan-400">✓ Delegation containment</li>
+                <li className="text-cyan-400">✓ Revocation before execution</li>
               </ul>
             </div>
 
-            {/* Charge */}
+            {/* Prove */}
             <div className="p-6 rounded-xl bg-gray-900 border border-yellow-800/30 hover:border-yellow-600/50 transition">
               <div className="flex items-center gap-3 mb-4">
                 <div className="p-2.5 bg-yellow-900/50 rounded-lg">
-                  <DollarSign className="text-yellow-400" size={22} />
+                  <FileSearch className="text-yellow-400" size={22} />
                 </div>
-                <h3 className="font-bold text-lg">Charge</h3>
+                <h3 className="font-bold text-lg">Prove</h3>
               </div>
               <p className="text-gray-400 text-sm leading-relaxed mb-4">
-                Monetize your APIs with L402. Sub-second Lightning settlement, per-request pricing, no chargebacks. Machine-native payments.
+                Export mint receipts, delegation chains, spend ledgers, denial reasons, revocation proof, and paid-rail context in one Evidence Pack.
               </p>
               <ul className="space-y-2 text-sm text-gray-500">
-                <li className="text-yellow-400">✓ L402 protocol (HTTP 402 + Lightning)</li>
-                <li className="text-yellow-400">✓ Per-request micropayments</li>
-                <li className="text-yellow-400">✓ Sub-second settlement</li>
-                <li className="text-yellow-400">✓ No chargebacks, no invoices</li>
+                <li className="text-yellow-400">✓ Evidence Pack exports</li>
+                <li className="text-yellow-400">✓ Signed denial and revocation trail</li>
+                <li className="text-yellow-400">✓ x402/L402/API-key billing context</li>
+                <li className="text-yellow-400">✓ Audit-ready authority timeline</li>
               </ul>
             </div>
           </div>
@@ -308,23 +305,23 @@ export default function GovernPage() {
               <Sliders size={14} className="text-cyan-400" />
               <span>Control</span>
               <ChevronRight size={14} className="text-gray-600" />
-              <DollarSign size={14} className="text-yellow-400" />
-              <span>Charge</span>
+              <FileSearch size={14} className="text-yellow-400" />
+              <span>Prove</span>
             </div>
           </div>
         </div>
       </section>
 
-      {/* The Rogue Intern Story */}
+      {/* Runaway Agent Story */}
       <section className="py-20 px-6 border-t border-gray-800 bg-gradient-to-b from-red-950/10 to-black">
         <div className="max-w-4xl mx-auto">
           <div className="text-center mb-12">
             <div className="inline-flex items-center gap-2 px-3 py-1 rounded-full bg-red-900/30 border border-red-500/30 text-red-300 text-xs font-mono mb-6">
               <AlertTriangle size={12} /> Real-World Scenario
             </div>
-            <h2 className="text-3xl font-bold mb-4">The Rogue Intern Story</h2>
+            <h2 className="text-3xl font-bold mb-4">The runaway agent story</h2>
             <p className="text-gray-400 max-w-2xl mx-auto">
-              Friday afternoon. An intern creates an API token "to test something." By Monday, $47,000 in OpenAI charges. Here's how SatGate changes the ending.
+              Friday afternoon, an agent workflow gets a broad token “just to test something.” By Monday, it has created $47,000 in API calls. SatGate changes the ending by enforcing policy and preserving proof.
             </p>
           </div>
 
@@ -341,10 +338,10 @@ export default function GovernPage() {
                       <span className="text-red-400 font-mono text-xs">FRIDAY 4:47 PM</span>
                     </div>
                     <h4 className="font-semibold text-white mb-1 flex items-center gap-2 md:justify-end">
-                      <Bot size={16} className="text-red-400" /> Intern Creates Token
+                      <Bot size={16} className="text-red-400" /> Workflow Gets Broad Token
                     </h4>
                     <p className="text-gray-500 text-sm">
-                      "Just a quick test." Generates an API token with no budget limit, no scope restriction, no expiry.
+                      &ldquo;Just a quick test.&rdquo; The workflow gets an API token with no budget limit, no scope restriction, no expiry.
                     </p>
                   </div>
                 </div>
@@ -428,7 +425,7 @@ export default function GovernPage() {
                       <CheckCircle size={16} className="text-green-400" /> Audit Trail Complete
                     </h4>
                     <p className="text-gray-500 text-sm">
-                      Full timeline: who created the token, what it accessed, when it was revoked. Compliance-ready export.
+                      Full Evidence Pack: who authorized it, what it could do, what it spent, what was denied, when it was revoked, and the first denied call after revoke.
                     </p>
                   </div>
                 </div>
@@ -442,8 +439,8 @@ export default function GovernPage() {
 
           <div className="text-center mt-12">
             <div className="inline-block bg-gradient-to-r from-green-900/20 to-cyan-900/20 border border-green-800/30 rounded-xl px-6 py-4">
-              <p className="text-white font-semibold">Can turn a $47,000 weekend incident into a $50 policy event. 2 minutes to resolution.</p>
-              <p className="text-gray-500 text-sm mt-1">SatGate Observe mode would have caught this for free.</p>
+              <p className="text-white font-semibold">Turns a $47,000 weekend incident into a bounded policy event with an audit trail.</p>
+              <p className="text-gray-500 text-sm mt-1">Govern first. Enforce before execution. Prove every decision afterward.</p>
             </div>
           </div>
         </div>
@@ -452,8 +449,8 @@ export default function GovernPage() {
       {/* Dashboard Screenshots */}
       <section className="py-20 px-6 border-t border-gray-800">
         <div className="max-w-5xl mx-auto">
-          <h2 className="text-3xl font-bold text-center mb-4">60+ Dashboard Pages. Day One.</h2>
-          <p className="text-gray-500 text-center mb-12">Real-time visibility into every agent, every API call, every dollar.</p>
+          <h2 className="text-3xl font-bold text-center mb-4">Dashboards that end in evidence.</h2>
+          <p className="text-gray-500 text-center mb-12">Real-time visibility into every agent, API call, policy decision, revocation, and dollar — with exports when proof matters.</p>
 
           <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
             {[
@@ -465,7 +462,7 @@ export default function GovernPage() {
               },
               {
                 title: 'CFO Chargeback Report',
-                description: 'Automated cost attribution. See exactly which team spent what on which API. Export to CSV or push to your billing system.',
+                description: 'Automated spend attribution. See which agent, token, route, and policy created each dollar. Export to finance or the Evidence Pack.', 
                 gradient: 'from-green-600 to-emerald-600',
                 icon: <DollarSign size={24} className="text-green-400" />,
               },
@@ -506,9 +503,9 @@ export default function GovernPage() {
       {/* Token Delegation Hierarchy */}
       <section className="py-20 px-6 border-t border-gray-800 bg-gradient-to-b from-gray-900/30 to-black">
         <div className="max-w-5xl mx-auto">
-          <h2 className="text-3xl font-bold text-center mb-4">Hierarchical Token Delegation</h2>
+          <h2 className="text-3xl font-bold text-center mb-4">Delegation that leaves a trail</h2>
           <p className="text-gray-500 text-center mb-12">
-            Tokens flow down. Authority narrows. Every level is scoped, budgeted, and time-limited.
+            Tokens flow down. Authority narrows. Every level is scoped, budgeted, time-limited, and preserved for later proof.
           </p>
 
           {/* Tree Visualization */}
@@ -631,44 +628,43 @@ export default function GovernPage() {
         </div>
       </section>
 
-      {/* Tragedy of the Commons */}
+      {/* Authority Commons */}
       <section className="py-20 px-6 border-t border-gray-800 bg-gradient-to-b from-orange-950/10 to-black">
         <div className="max-w-4xl mx-auto">
           <div className="text-center mb-12">
             <div className="inline-flex items-center gap-2 px-3 py-1 rounded-full bg-orange-900/30 border border-orange-500/30 text-orange-300 text-xs font-mono mb-6">
               <AlertTriangle size={12} /> The Core Problem
             </div>
-            <h2 className="text-3xl font-bold mb-4">The Tragedy of the Commons — Inside Your Company</h2>
+            <h2 className="text-3xl font-bold mb-4">The authority commons — inside your company</h2>
             <p className="text-gray-400 max-w-2xl mx-auto">
-              Every shared internal API is a commons. When agents have unlimited access, they over-consume. 
-              The team that built the service pays the infrastructure bill. The team running the agent gets free compute. 
-              <span className="text-white font-medium"> Nobody optimizes because nobody pays.</span>
+              Every shared internal API is now an authority surface. When agents inherit broad credentials, nobody can prove which policy allowed the action, which team owned it, or where the limit should have stopped it. 
+              <span className="text-white font-medium"> Governance fails when authority is invisible.</span>
             </p>
           </div>
 
           <div className="grid grid-cols-1 md:grid-cols-2 gap-6 mb-8">
             <div className="p-6 rounded-xl bg-red-950/20 border border-red-900/30">
               <h3 className="font-bold text-red-300 mb-3 flex items-center gap-2">
-                <AlertTriangle size={18} className="text-red-400" /> Without EAC
+                <AlertTriangle size={18} className="text-red-400" /> Without SatGate
               </h3>
               <ul className="space-y-3 text-sm text-gray-400">
-                <li>• Agent team says &ldquo;we need unlimited access&rdquo;</li>
-                <li>• Platform team absorbs the cost</li>
-                <li>• No signal on which calls are valuable vs. wasteful</li>
-                <li>• Agents spam the most powerful tool because it&apos;s free</li>
-                <li className="text-red-400 font-medium">• IT remains a cost center forever</li>
+                <li>• Agents inherit broad API keys</li>
+                <li>• Delegation happens outside the control plane</li>
+                <li>• Spend and access are reconstructed after the fact</li>
+                <li>• Revocation requires rotating shared secrets</li>
+                <li className="text-red-400 font-medium">• Audit depends on screenshots and log joins</li>
               </ul>
             </div>
             <div className="p-6 rounded-xl bg-green-950/20 border border-green-900/30">
               <h3 className="font-bold text-green-300 mb-3 flex items-center gap-2">
-                <CheckCircle size={18} className="text-green-400" /> With EAC
+                <CheckCircle size={18} className="text-green-400" /> With SatGate
               </h3>
               <ul className="space-y-3 text-sm text-gray-400">
-                <li>• Every agent gets a budget — hard cap, no exceptions</li>
-                <li>• High-risk actions cost more, loops hit budget ceiling and stop</li>
-                <li>• Agents naturally optimize for efficiency</li>
-                <li>• Platform teams become measurable <span className="text-green-400">profit centers</span></li>
-                <li className="text-green-400 font-medium">• You can&apos;t out-smart an AI swarm, but you can hard-cap its wallet</li>
+                <li>• Every agent gets scoped, revocable authority</li>
+                <li>• Delegated workers inherit narrower limits</li>
+                <li>• Policy, budget, and scope denials stop requests before execution</li>
+                <li>• Revocation creates proof plus a post-revoke denial</li>
+                <li className="text-green-400 font-medium">• Evidence Pack exports answer who, what, why, spend, denial, and revoke</li>
               </ul>
             </div>
           </div>
@@ -682,37 +678,36 @@ export default function GovernPage() {
             <div className="inline-flex items-center gap-2 px-3 py-1 rounded-full bg-cyan-900/30 border border-cyan-500/30 text-cyan-300 text-xs font-mono mb-6">
               <Coins size={12} /> The Opportunity
             </div>
-            <h2 className="text-3xl font-bold mb-4">Your Internal APIs Are an Untapped Market</h2>
+            <h2 className="text-3xl font-bold mb-4">Your internal APIs are authority surfaces</h2>
             <p className="text-gray-400 max-w-2xl mx-auto">
-              Every internal service — databases, search indexes, ML models — has a real cost per call. 
-              EAC makes that cost visible and enforceable. Suddenly your internal tooling isn&apos;t overhead. 
-              It&apos;s a <span className="text-white font-medium">marketplace</span>.
+              Every internal service — databases, search indexes, ML models — now receives autonomous agent requests. SatGate makes the authority visible and enforceable before the call runs, then proves what happened afterward. 
+              It&apos;s not just usage tracking. It&apos;s <span className="text-white font-medium">policy-to-proof governance</span>.
             </p>
           </div>
 
           <div className="grid grid-cols-1 md:grid-cols-3 gap-6 mb-8">
             <div className="p-5 rounded-xl bg-gray-900 border border-gray-800 text-center">
               <div className="text-3xl mb-3">📊</div>
-              <h4 className="font-semibold text-white mb-2">Price Discovery</h4>
-              <p className="text-gray-500 text-sm">When every call has a cost, you learn which internal APIs are actually valuable vs. over-provisioned.</p>
+              <h4 className="font-semibold text-white mb-2">Authority discovery</h4>
+              <p className="text-gray-500 text-sm">See which agents, teams, tools, and workflows are asking for power before you enforce limits.</p>
             </div>
             <div className="p-5 rounded-xl bg-gray-900 border border-gray-800 text-center">
               <div className="text-3xl mb-3">⚖️</div>
-              <h4 className="font-semibold text-white mb-2">Natural Load Balancing</h4>
-              <p className="text-gray-500 text-sm">Expensive calls get used thoughtfully. Cheap calls get used freely. The market allocates resources better than any policy doc.</p>
+              <h4 className="font-semibold text-white mb-2">Runtime enforcement</h4>
+              <p className="text-gray-500 text-sm">Policy, caveats, budgets, and revocation run in the request path before the agent reaches the upstream service.</p>
             </div>
             <div className="p-5 rounded-xl bg-gray-900 border border-gray-800 text-center">
               <div className="text-3xl mb-3">💰</div>
-              <h4 className="font-semibold text-white mb-2">Profit Centers</h4>
-              <p className="text-gray-500 text-sm">Platform teams charge for what they provide. Agent teams budget for what they consume. IT finally has a P&amp;L.</p>
+              <h4 className="font-semibold text-white mb-2">Evidence export</h4>
+              <p className="text-gray-500 text-sm">Every mint, delegation, spend event, denial, and revocation can land in an Evidence Pack.</p>
             </div>
           </div>
 
           <div className="bg-gradient-to-r from-cyan-900/20 to-purple-900/20 border border-cyan-800/30 rounded-xl p-6 text-center">
             <p className="text-gray-300 text-sm">
-              <span className="text-white font-semibold">&ldquo;Stop giving AI agents an all-you-can-eat buffet pass.&rdquo;</span>
+              <span className="text-white font-semibold">&ldquo;Stop giving AI agents standing authority.&rdquo;</span>
               <br/>
-              <span className="text-gray-500 text-xs mt-2 block">Give them a budget. Let economics do what policy never could.</span>
+              <span className="text-gray-500 text-xs mt-2 block">Give them scoped capabilities. Enforce policy before execution. Export proof after.</span>
             </p>
           </div>
         </div>
@@ -727,7 +722,7 @@ export default function GovernPage() {
               Live Demo
             </div>
             <h2 className="text-3xl md:text-4xl font-bold mb-4">
-              See It Work — Right Now
+              See authority minted — then prove the lifecycle
             </h2>
             <p className="text-gray-400 text-lg max-w-2xl mx-auto">
               SatGate Mint exchanges workload identity tokens for capability-bearing macaroons.
@@ -773,8 +768,8 @@ export default function GovernPage() {
             </div>
             <div className="bg-[#12121a] border border-gray-800 rounded-xl p-6">
               <div className="text-2xl font-bold text-green-400 mb-2">3</div>
-              <h3 className="text-white font-semibold mb-2">Observe everything</h3>
-              <p className="text-gray-400 text-sm">Every tool call, every credit spent, every agent session — visible in real-time on your dashboard. When you&apos;re ready, flip to enforcement.</p>
+              <h3 className="text-white font-semibold mb-2">Export the evidence</h3>
+              <p className="text-gray-400 text-sm">Every grant, spend event, denial, delegation, and revocation becomes part of the evidence trail when you need to prove what happened.</p>
             </div>
           </div>
 
@@ -803,11 +798,11 @@ export SATGATE_TOKEN=$TOKEN
           <p className="mb-2 text-sm font-mono uppercase tracking-wide text-cyan-300">Governance rollout kit</p>
           <h2 className="mb-4 text-3xl font-bold text-white">Turn enterprise governance into request-path controls</h2>
           <p className="mb-8 max-w-3xl text-gray-400 leading-relaxed">
-            High-level AI governance only matters when it becomes enforceable policy: identity, budgets, scoped credentials, MCP tool limits, audit, and revocation before agents spend.
+            High-level AI governance only matters when it becomes enforceable policy: identity, budgets, scoped credentials, MCP tool limits, audit, revocation, and evidence before agents act.
           </p>
           <div className="grid gap-4 md:grid-cols-2">
             {[
-              ['/economic-firewall-readiness-grader', 'Economic firewall readiness grader', 'Score identity, budgets, MCP governance, revocation, delegation, audit, routing, and Charge readiness.'],
+              ['/economic-firewall-readiness-grader', 'Economic firewall readiness grader', 'Score identity, budgets, MCP governance, revocation, delegation, audit, routing, and rail-aware readiness.'],
               ['/agent-api-key-risk-assessment', 'Agent API key risk assessment', 'Find static-key blast radius before autonomous agents inherit unlimited API access.'],
               ['/agent-spend-policy-template', 'Agent spend policy template', 'Generate YAML/JSON policy for per-agent budgets, MCP caps, delegation, revocation, and audit.'],
               ['/mcp-cost-control', 'MCP cost control', 'Treat MCP tool calls as billable economic events with per-tool prices, caps, and deny decisions.'],
@@ -828,9 +823,9 @@ export SATGATE_TOKEN=$TOKEN
           <div className="space-y-6">
             {[
               ['What is AI agent governance?', 'AI agent governance is the set of controls that determines which agents can call which APIs, tools, and models; how much they can spend; what authority they can delegate; and when access must be revoked. For autonomous agents, governance needs request-path enforcement, not just logs and dashboards.'],
-              ['What is an economic control plane for AI agents?', 'An economic control plane for AI agents sits in the request path and applies budgets, prices, delegation rules, revocation, and audit before an agent reaches an upstream API, model, or MCP tool. It turns agent activity into observable, controllable, and chargeable economic events.'],
+              ['What is an economic control plane for AI agents?', 'An economic control plane for AI agents sits in the request path and applies scopes, budgets, delegation rules, revocation, and audit before an agent reaches an upstream API, model, or MCP tool. It turns agent activity into governed decisions with evidence.'],
               ['How should enterprises govern MCP tool usage?', 'Enterprises should govern MCP tools with per-tool budgets, scoped capability tokens, task and tenant attribution, audit trails, revocation, and hard request-path policy decisions. Rate limits and dashboards are useful, but they do not replace enforcement before tool calls execute.'],
-              ['What is the difference between AI governance and AI agent governance?', 'AI governance usually covers model risk, data policy, compliance, and human review. AI agent governance adds request-path controls for autonomous actions: budgets, tool scopes, delegated authority, revocation, cost attribution, and payment before APIs or MCP tools execute.'],
+              ['What is the difference between AI governance and AI agent governance?', 'AI governance usually covers model risk, data policy, compliance, and human review. AI agent governance adds request-path controls for autonomous actions: scopes, budgets, delegated authority, revocation, denial reasons, spend attribution, and proof before APIs or MCP tools execute.'],
             ].map(([question, answer]) => (
               <div key={question} className="border-t border-gray-800 pt-6 first:border-t-0 first:pt-0">
                 <h3 className="mb-2 text-xl font-bold text-white">{question}</h3>
@@ -848,16 +843,16 @@ export SATGATE_TOKEN=$TOKEN
             Ready to govern your AI agents?
           </h2>
           <p className="text-gray-400 text-lg mb-8">
-            We're working with 10 enterprises to build the governance layer for the agent economy.
-            Start with free Observe mode—no risk, full visibility.
+            We&apos;re working with enterprise teams that need scoped authority, runtime enforcement, and evidence before agents scale.
+            Start with Observe, then move to Control and Policy-to-Proof when you&apos;re ready.
           </p>
           <div className="flex flex-col sm:flex-row gap-4 justify-center">
             <Link href="/design-partners" className="bg-gradient-to-r from-purple-600 to-cyan-600 text-white px-10 py-4 rounded-full font-bold text-lg hover:opacity-90 transition shadow-lg shadow-purple-500/20 flex items-center justify-center gap-2">
-              Become a Design Partner <ArrowRight size={20} />
+              Book a governance walkthrough <ArrowRight size={20} />
             </Link>
           </div>
           <p className="text-gray-600 text-sm mt-6">
-            Free Observe mode • 5-minute setup • No credit card required
+            Observe first • Enforce next • Export proof when it matters
           </p>
         </div>
       </section>
@@ -871,7 +866,7 @@ export SATGATE_TOKEN=$TOKEN
                 <Image src="/logo_white_transparent.png" alt="SatGate" width={24} height={24} className="w-6 h-6" />
                 <h4 className="font-bold text-white">SatGate</h4>
               </div>
-              <p className="text-gray-500 text-sm">The Economic Firewall for AI agent requests.</p>
+              <p className="text-gray-500 text-sm">Govern what agents can do — and prove it.</p>
             </div>
             <div>
               <h4 className="font-bold text-white mb-4">Product</h4>

--- a/satgate-landing/app/govern/page.tsx
+++ b/satgate-landing/app/govern/page.tsx
@@ -2,34 +2,34 @@ import type { Metadata } from "next";
 import GovernClient from "../components/GovernClient";
 
 export const metadata: Metadata = {
-  title: "AI Agent Governance: Observe, Control, and Charge",
+  title: "AI Agent Governance: Govern, Enforce, Prove",
   description:
-    "Govern AI agents with SatGate: observe tool usage, control access and budgets, and charge for API or MCP consumption.",
+    "Govern enterprise AI agents with SatGate: scope authority, enforce request-path policy, and prove every mint, delegation, spend, denial, and revocation.",
   alternates: {
     canonical: "https://satgate.io/govern",
   },
   keywords: [
     "enterprise AI agent governance",
-    "AI agent cost governance",
+    "AI agent authority governance",
     "economic control plane for AI agents",
     "MCP governance for enterprises",
     "AI agent budget enforcement",
     "agent delegation controls",
-    "L402 robot customer payments",
-    "Observe Control Charge",
+    "Policy-to-Proof for AI agents",
+    "Govern Enforce Prove",
   ],
   openGraph: {
-    title: "AI Agent Governance: Observe, Control, and Charge",
+    title: "AI Agent Governance: Govern, Enforce, Prove",
     description:
-      "Govern AI agents with SatGate: observe tool usage, control access and budgets, and charge for API or MCP consumption.",
+      "Govern enterprise AI agents with scoped authority, request-path enforcement, and audit-ready proof for every agent lifecycle.",
     url: "https://satgate.io/govern",
     type: "website",
   },
   twitter: {
     card: "summary_large_image",
-    title: "AI Agent Governance: Observe, Control, and Charge",
+    title: "AI Agent Governance: Govern, Enforce, Prove",
     description:
-      "Observe tool usage, control access and budgets, and charge for API or MCP consumption with SatGate.",
+      "Scope authority, enforce policy, and export Policy-to-Proof evidence for enterprise AI agents with SatGate.",
   },
 };
 
@@ -46,7 +46,7 @@ const webPageSchema = {
     { "@type": "Thing", name: "economic control plane for AI agents" },
     { "@type": "Thing", name: "MCP governance for enterprises" },
     { "@type": "Thing", name: "agent delegation controls" },
-    { "@type": "Thing", name: "L402 robot customer payments" },
+    { "@type": "Thing", name: "Policy-to-Proof for AI agents" },
   ],
 };
 
@@ -67,7 +67,7 @@ const faqSchema = {
       name: "What is an economic control plane for AI agents?",
       acceptedAnswer: {
         "@type": "Answer",
-        text: "An economic control plane for AI agents sits in the request path and applies budgets, prices, delegation rules, revocation, and audit before an agent reaches an upstream API, model, or MCP tool. It turns agent activity into observable, controllable, and chargeable economic events.",
+        text: "An economic control plane for AI agents sits in the request path and applies scopes, budgets, delegation rules, revocation, and audit before an agent reaches an upstream API, model, or MCP tool. It turns agent activity into governed decisions with evidence.",
       },
     },
     {
@@ -83,7 +83,7 @@ const faqSchema = {
       name: "What is the difference between AI governance and AI agent governance?",
       acceptedAnswer: {
         "@type": "Answer",
-        text: "AI governance usually covers model risk, data policy, compliance, and human review. AI agent governance adds request-path controls for autonomous actions: budgets, tool scopes, delegated authority, revocation, cost attribution, and payment before APIs or MCP tools execute.",
+        text: "AI governance usually covers model risk, data policy, compliance, and human review. AI agent governance adds request-path controls for autonomous actions: scopes, budgets, delegated authority, revocation, denial reasons, spend attribution, and proof before APIs or MCP tools execute.",
       },
     },
   ],

--- a/satgate-landing/scripts/check_policy_to_proof_page.py
+++ b/satgate-landing/scripts/check_policy_to_proof_page.py
@@ -5,6 +5,7 @@ ROOT = Path(__file__).resolve().parents[1]
 PAGE = ROOT / "app" / "policy-to-proof" / "page.tsx"
 
 AGENT_CONTROL_PLANE = ROOT / "app" / "agent-control-plane" / "page.tsx"
+GOVERN_PAGE = ROOT / "app" / "components" / "GovernClient.tsx"
 
 required_phrases = [
     "Every agent action leaves a receipt",
@@ -64,6 +65,31 @@ required_phrases = [
     "Authority-chain entries preserve lineage",
 ]
 
+govern_required_phrases = [
+    "Govern what agents can do",
+    "Prove every decision",
+    "Govern internal agents. Preserve proof across external rails.",
+    "Payment proves value moved. SatGate proves the agent was allowed to move it",
+    "Govern, enforce, prove.",
+    "Evidence Pack exports",
+    "first denied call after revoke",
+    "Stop giving AI agents standing authority",
+    "Export proof after",
+    "Policy-to-Proof",
+]
+
+govern_forbidden_phrases = [
+    "Not &ldquo;Who Are You?&rdquo; — &ldquo;What Can You Afford?&rdquo;",
+    "Two Problems. One Token.",
+    "Built for the C-Suite",
+    "Three Modes. One Gateway.",
+    "Monetize your APIs with L402",
+    "Charge policy with Lightning settlement",
+    "The Rogue Intern Story",
+    "Your Internal APIs Are an Untapped Market",
+    "Stop giving AI agents an all-you-can-eat buffet pass",
+]
+
 
 def main() -> int:
     if not PAGE.exists():
@@ -75,6 +101,13 @@ def main() -> int:
     acp_text = AGENT_CONTROL_PLANE.read_text()
     if "/policy-to-proof" not in acp_text:
         raise SystemExit("agent-control-plane page must link to /policy-to-proof")
+    govern_text = GOVERN_PAGE.read_text()
+    govern_missing = [phrase for phrase in govern_required_phrases if phrase not in govern_text]
+    if govern_missing:
+        raise SystemExit("missing govern policy-to-proof phrases:\n" + "\n".join(govern_missing))
+    govern_stale = [phrase for phrase in govern_forbidden_phrases if phrase in govern_text]
+    if govern_stale:
+        raise SystemExit("stale govern spend/rail-first phrases remain:\n" + "\n".join(govern_stale))
     return 0
 
 


### PR DESCRIPTION
## Summary
- Reframe /govern hero around governing agent authority and proving decisions
- Replace spend/rail-first sections with govern → enforce → prove copy
- Add /govern anchors and stale-copy guards to the Policy-to-Proof regression script

## Verification
- python3 scripts/check_policy_to_proof_page.py
- npx eslint app/govern/page.tsx app/components/GovernClient.tsx
- npm run build
- Local render: http://127.0.0.1:3000/govern returned 200, required anchors present, stale phrases absent
- Browser visual check: hero H1/CTAs render cleanly