### PR TITLE
fix: remove external product conditional from economic firewall cta

### DIFF
--- a/satgate-landing/app/economic-firewall/page.tsx
+++ b/satgate-landing/app/economic-firewall/page.tsx
@@ -451,7 +451,7 @@ export default function EconomicFirewallPage() {
         <div className="rounded-3xl border border-cyan-900/60 bg-gradient-to-br from-cyan-950/30 to-purple-950/30 p-8 md:p-12">
           <h2 className="text-3xl font-bold text-white mb-4">SatGate governs agent authority before value moves</h2>
           <p className="text-gray-300 text-lg leading-relaxed max-w-3xl mb-8">
-            Put SatGate in the request path to observe every agent call, control what agents can access or spend, preserve Evidence Pack proof across mint, delegation, spend, denial, and revocation, and govern paid rails when APIs become products for external agents.
+            Put SatGate in the request path to observe every agent call, control what agents can access or spend, preserve Evidence Pack proof across mint, delegation, spend, denial, and revocation, and govern paid rails when value moves.
           </p>
           <div className="flex flex-col sm:flex-row gap-4">
             <Link href="/govern" className="inline-flex items-center justify-center gap-2 rounded-lg bg-white text-black px-6 py-3 font-bold hover:bg-gray-200 transition">

--- a/satgate-landing/scripts/check_policy_to_proof_page.py
+++ b/satgate-landing/scripts/check_policy_to_proof_page.py
@@ -159,6 +159,7 @@ economic_required_phrases = [
     "Preserve proof across paid rails",
     "Policy-to-Proof",
     "SatGate governs agent authority before value moves",
+    "govern paid rails when value moves",
 ]
 
 economic_forbidden_phrases = [
@@ -183,6 +184,7 @@ economic_forbidden_phrases = [
     "When an API becomes a product for external agents",
     "what evidence is captured",
     "evidence capture, and optional payment context",
+    "when APIs become products for external agents",
 ]
 
 


### PR DESCRIPTION
## Summary
- Removes the last external-product conditional from the /economic-firewall closing CTA.
- Changes paid-rail language to rail-neutral “govern paid rails when value moves.”
- Adds regression coverage for the new CTA phrase and stale conditional.

## Verification
- `python3 scripts/check_policy_to_proof_page.py`
- `npx eslint app/economic-firewall/page.tsx`
- `npm run build`
