### PR TITLE
fix: align readiness grader with authority proof framing

### DIFF
--- a/satgate-landing/app/economic-firewall-readiness-grader/layout.tsx
+++ b/satgate-landing/app/economic-firewall-readiness-grader/layout.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from 'next';
 
 export const metadata: Metadata = {
   title: 'Economic Firewall Readiness Grader',
-  description: 'Grade your AI agent economic governance readiness across identity, budgets, MCP tools, revocation, audit, routing, and payments.',
+  description: 'Grade AI agent authority readiness across identity, budgets, MCP tools, revocation, Evidence Pack capture, routing, and paid-rail context.',
   alternates: { canonical: 'https://satgate.io/economic-firewall-readiness-grader' },
   keywords: [
     'economic firewall readiness grader',
@@ -14,14 +14,14 @@ export const metadata: Metadata = {
   ],
   openGraph: {
     title: 'Economic Firewall Readiness Grader',
-    description: 'Assess whether your agent/API stack is ready for autonomous spend, delegated tools, budget enforcement, revocation, audit, and L402 payments.',
+    description: 'Assess whether your agent/API stack is ready for autonomous authority, delegated tools, budget enforcement, revocation, Evidence Pack capture, and paid-rail context.',
     url: 'https://satgate.io/economic-firewall-readiness-grader',
     type: 'website',
   },
   twitter: {
     card: 'summary_large_image',
     title: 'Economic Firewall Readiness Grader',
-    description: 'Grade your readiness for AI agent economic governance: identity, budgets, MCP tools, revocation, audit, routing, and payments.',
+    description: 'Grade AI agent authority readiness: identity, budgets, MCP tools, revocation, Evidence Pack capture, routing, and paid-rail context.',
   },
 };
 

--- a/satgate-landing/app/economic-firewall-readiness-grader/page.tsx
+++ b/satgate-landing/app/economic-firewall-readiness-grader/page.tsx
@@ -18,7 +18,7 @@ const questions: Question[] = [
     id: 'identity',
     category: 'Agent identity',
     prompt: 'Can you attribute every API/tool call to tenant, agent, workflow, delegated sub-agent, token, route, and model?',
-    fix: 'Start in Observe mode and require agent/workflow metadata on every request before optimizing spend.',
+    fix: 'Start in Observe mode and require agent/workflow metadata on every request before enforcing authority or optimizing spend.',
   },
   {
     id: 'budgets',
@@ -29,8 +29,8 @@ const questions: Question[] = [
   {
     id: 'mcp',
     category: 'MCP governance',
-    prompt: 'Do MCP tool calls have prices, spend caps, risk tiers, and audit trails before tools execute?',
-    fix: 'Proxy MCP traffic and assign explicit costs to search, browser, cloud, code, data, and premium API tools.',
+    prompt: 'Do MCP tool calls have prices, authority scope, risk tiers, denial reasons, and Evidence Pack trails before tools execute?',
+    fix: 'Proxy MCP traffic and assign explicit policy, price, risk, and Evidence Pack fields to search, browser, cloud, code, data, and premium API tools.',
   },
   {
     id: 'revocation',
@@ -47,8 +47,8 @@ const questions: Question[] = [
   {
     id: 'audit',
     category: 'Audit evidence',
-    prompt: 'Can finance/security/platform teams reconstruct who spent what, why it was allowed, and which policy decided?',
-    fix: 'Record policy decision, estimated cost, remaining budget, route, tool, credential, and upstream outcome.',
+    prompt: 'Can finance/security/platform teams reconstruct who had authority, what happened, why it was allowed or denied, and which policy decided?',
+    fix: 'Record the authority chain, policy decision, denial reason, estimated cost, remaining budget, route, tool, credential, and upstream outcome for Evidence Pack export.',
   },
   {
     id: 'routing',
@@ -57,10 +57,10 @@ const questions: Question[] = [
     fix: 'Add model/route policy that defaults to economical paths and reserves premium calls for justified work.',
   },
   {
-    id: 'charge',
-    category: 'Robot payments',
-    prompt: 'If external agents call your APIs, can you charge them per request with L402 before access is unlocked?',
-    fix: 'Use Charge/L402 for robot-customer APIs where payment and authorization should happen in the request path.',
+    id: 'paidRails',
+    category: 'Paid-rail context',
+    prompt: 'When value moves across paid rails, can you preserve payment context alongside authority, denial, delegation, and revocation evidence?',
+    fix: 'Govern paid calls across x402, L402, AgentCore Payments, Pay.sh, API-key billing, or enterprise ledgers without making payment the center of the control model.',
   },
 ];
 
@@ -71,11 +71,11 @@ const labels: Record<Answer, string> = {
 };
 
 function grade(score: number) {
-  if (score >= 85) return { label: 'A', title: 'Economically governable', color: 'text-green-400', summary: 'Your stack has the core controls for autonomous agent/API spend.' };
+  if (score >= 85) return { label: 'A', title: 'Economically governable', color: 'text-green-400', summary: 'Your stack has the core controls for autonomous agent authority, spend, and Evidence Pack proof.' };
   if (score >= 70) return { label: 'B', title: 'Close, with gaps', color: 'text-cyan-300', summary: 'You have real governance primitives, but a few request-path controls need tightening.' };
-  if (score >= 50) return { label: 'C', title: 'Observable but fragile', color: 'text-yellow-300', summary: 'You can probably explain spend after the fact, but agents can still outrun policy.' };
-  if (score >= 30) return { label: 'D', title: 'High runaway-spend risk', color: 'text-orange-400', summary: 'Agents can likely spend, delegate, or call tools faster than you can stop them.' };
-  return { label: 'F', title: 'Not ready for autonomous spend', color: 'text-red-400', summary: 'This is static-key/dashboard territory. Put governance in the request path before scaling agents.' };
+  if (score >= 50) return { label: 'C', title: 'Observable but fragile', color: 'text-yellow-300', summary: 'You can probably explain activity after the fact, but agents can still outrun authority policy.' };
+  if (score >= 30) return { label: 'D', title: 'High authority risk', color: 'text-orange-400', summary: 'Agents can likely access, spend, delegate, or call tools faster than you can stop them.' };
+  return { label: 'F', title: 'Not ready for autonomous authority', color: 'text-red-400', summary: 'This is static-key/dashboard territory. Put governance in the request path before scaling agents.' };
 }
 
 export default function EconomicFirewallReadinessGraderPage() {
@@ -94,7 +94,7 @@ export default function EconomicFirewallReadinessGraderPage() {
     '@type': 'WebPage',
     name: 'Economic Firewall Readiness Grader',
     url: 'https://satgate.io/economic-firewall-readiness-grader',
-    description: 'Grade AI agent economic governance readiness across identity, request-path budgets, MCP tools, revocation, delegation, audit, routing, and L402 robot payments.',
+    description: 'Grade AI agent economic governance readiness across identity, request-path budgets, MCP tools, revocation, delegation, audit, routing, and paid-rail context.',
     dateModified: '2026-05-05',
     isPartOf: { '@type': 'WebSite', name: 'SatGate', url: 'https://satgate.io' },
     about: [
@@ -102,7 +102,7 @@ export default function EconomicFirewallReadinessGraderPage() {
       { '@type': 'Thing', name: 'AI agent economic governance' },
       { '@type': 'Thing', name: 'request-path budget controls' },
       { '@type': 'Thing', name: 'MCP governance assessment' },
-      { '@type': 'Thing', name: 'L402 robot payment readiness' },
+      { '@type': 'Thing', name: 'paid-rail governance readiness' },
     ],
   };
 
@@ -117,7 +117,7 @@ export default function EconomicFirewallReadinessGraderPage() {
     publisher: { '@type': 'Organization', name: 'SatGate', url: 'https://satgate.io' },
     dateModified: '2026-05-05',
     about: webPageJsonLd.about,
-    featureList: ['Agent identity attribution scoring', 'Request-path budget readiness scoring', 'MCP tool cost governance checks', 'Revocation and delegation readiness checks', 'Audit, routing, and L402 payment readiness checks'],
+    featureList: ['Agent identity attribution scoring', 'Request-path budget readiness scoring', 'MCP tool cost governance checks', 'Revocation and delegation readiness checks', 'Audit, routing, and paid-rail context readiness checks'],
     offers: { '@type': 'Offer', price: '0', priceCurrency: 'USD' },
   };
 
@@ -125,11 +125,11 @@ export default function EconomicFirewallReadinessGraderPage() {
     '@context': 'https://schema.org',
     '@type': 'FAQPage',
     mainEntity: [
-      { '@type': 'Question', name: 'What is economic firewall readiness?', acceptedAnswer: { '@type': 'Answer', text: 'Economic firewall readiness measures whether an organization can observe, control, audit, revoke, route, budget, and optionally charge AI agent/API activity before requests execute.' } },
+      { '@type': 'Question', name: 'What is economic firewall readiness?', acceptedAnswer: { '@type': 'Answer', text: 'Economic firewall readiness measures whether an organization can observe, control, audit, revoke, route, budget, and preserve paid-rail context for AI agent/API activity before requests execute.' } },
       { '@type': 'Question', name: 'What score means we are ready for autonomous agents?', acceptedAnswer: { '@type': 'Answer', text: 'A score above 85 means most core request-path controls are in place. Lower scores indicate gaps in identity, budget enforcement, MCP governance, revocation, audit, routing, or payment.' } },
-      { '@type': 'Question', name: 'How does SatGate improve readiness?', acceptedAnswer: { '@type': 'Answer', text: 'SatGate sits in the request path to observe agent/API spend, enforce budget and access policy, revoke scoped capabilities, audit decisions, route economically, and use L402 Charge when agents become customers.' } },
-      { '@type': 'Question', name: 'Which gaps should teams fix first?', acceptedAnswer: { '@type': 'Answer', text: 'Teams should fix request attribution, hard budget enforcement, MCP tool cost policy, scoped revocable credentials, and audit evidence first because those controls stop spend before it becomes an invoice.' } },
-      { '@type': 'Question', name: 'Is a dashboard enough for economic firewall readiness?', acceptedAnswer: { '@type': 'Answer', text: 'No. Dashboards help explain spend after it happens, but economic firewall readiness requires request-path controls that can block, route, revoke, or charge before agents execute paid work.' } },
+      { '@type': 'Question', name: 'How does SatGate improve readiness?', acceptedAnswer: { '@type': 'Answer', text: 'SatGate sits in the request path to observe agent/API activity, enforce budget and access policy, revoke scoped capabilities, preserve Evidence Pack proof, route economically, and govern paid rails when value moves.' } },
+      { '@type': 'Question', name: 'Which gaps should teams fix first?', acceptedAnswer: { '@type': 'Answer', text: 'Teams should fix request attribution, hard budget enforcement, MCP tool policy, scoped revocable credentials, and Evidence Pack capture first because those controls stop unauthorized actions before execution.' } },
+      { '@type': 'Question', name: 'Is a dashboard enough for economic firewall readiness?', acceptedAnswer: { '@type': 'Answer', text: 'No. Dashboards help explain activity after it happens, but economic firewall readiness requires request-path controls that can allow, deny, route, revoke, delegate, or preserve paid-rail context before agents execute work.' } },
     ],
   };
 
@@ -137,7 +137,7 @@ export default function EconomicFirewallReadinessGraderPage() {
     '@context': 'https://schema.org',
     '@type': 'ItemList',
     name: 'Economic firewall readiness criteria',
-    description: 'Eight readiness checks for governing AI agent spend, MCP tools, scoped authority, audit, routing, and L402 robot payments before requests execute.',
+    description: 'Eight readiness checks for governing AI agent authority, spend, MCP tools, scoped authority, Evidence Pack capture, routing, and paid-rail context before requests execute.',
     itemListElement: questions.map((question, index) => ({
       '@type': 'ListItem',
       position: index + 1,
@@ -171,14 +171,14 @@ export default function EconomicFirewallReadinessGraderPage() {
           </div>
           <h1 className="mb-8 max-w-5xl text-5xl font-extrabold tracking-tight md:text-7xl">Economic Firewall Readiness Grader</h1>
           <p className="mb-10 max-w-4xl text-xl leading-relaxed text-gray-300 md:text-2xl">
-            Grade whether your agent/API stack can handle autonomous spend: identity, request-path budgets, MCP tool costs, revocation, delegation, audit, routing, and L402 robot payments.
+            Grade whether your agent/API stack can handle autonomous authority: identity, request-path budgets, MCP tool policy, revocation, delegation, Evidence Pack capture, routing, and paid-rail context.
           </p>
           <div className="flex flex-col gap-4 sm:flex-row">
             <Link href="/economic-firewall" className="inline-flex items-center justify-center gap-2 rounded-lg bg-white px-6 py-3 font-bold text-black transition hover:bg-gray-200">
               Learn economic firewalls <ArrowRight size={18} />
             </Link>
             <Link href="/ai-agent-cost-control" className="inline-flex items-center justify-center gap-2 rounded-lg border border-gray-700 px-6 py-3 font-bold text-white transition hover:border-cyan-500">
-              See agent cost control
+              See agent authority control
             </Link>
           </div>
         </div>
@@ -244,9 +244,9 @@ export default function EconomicFirewallReadinessGraderPage() {
           <div className="grid gap-5 md:grid-cols-2 lg:grid-cols-4">
             {[
               [KeyRound, 'Authority', 'Agent identity, scoped credentials, expiry, attenuation, and revocation.'],
-              [Gauge, 'Spend control', 'Request-path budgets, per-tool caps, model routing, and loop prevention.'],
-              [ReceiptText, 'Evidence', 'Audit trails that explain every cost, policy decision, route, and outcome.'],
-              [BadgeCheck, 'Commercial readiness', 'Observe, Control, and Charge paths for internal agents and robot customers.'],
+              [Gauge, 'Budget and authority limits', 'Request-path budgets, scoped authority, per-tool caps, model routing, and loop prevention.'],
+              [ReceiptText, 'Evidence', 'Evidence Pack trails that explain authority, cost, policy decision, denial reason, route, and outcome.'],
+              [BadgeCheck, 'Paid-rail context', 'Observe, Control, and Prove paths for internal agents and rail-aware paid calls.'],
             ].map(([Icon, title, body]) => {
               const TypedIcon = Icon as typeof KeyRound;
               return (
@@ -267,11 +267,11 @@ export default function EconomicFirewallReadinessGraderPage() {
           <h2 className="mb-8 text-3xl font-bold text-white">Economic firewall readiness questions</h2>
           <div className="grid gap-5 md:grid-cols-2">
             {[
-              ['What is economic firewall readiness?', 'Economic firewall readiness measures whether an organization can observe, control, audit, revoke, route, budget, and optionally charge AI agent/API activity before requests execute.'],
+              ['What is economic firewall readiness?', 'Economic firewall readiness measures whether an organization can observe, control, audit, revoke, route, budget, and preserve paid-rail context for AI agent/API activity before requests execute.'],
               ['What score means we are ready for autonomous agents?', 'A score above 85 means most core request-path controls are in place. Lower scores indicate gaps in identity, budget enforcement, MCP governance, revocation, audit, routing, or payment.'],
-              ['How does SatGate improve readiness?', 'SatGate sits in the request path to observe agent/API spend, enforce budget and access policy, revoke scoped capabilities, audit decisions, route economically, and use L402 Charge when agents become customers.'],
-              ['Which gaps should teams fix first?', 'Teams should fix request attribution, hard budget enforcement, MCP tool cost policy, scoped revocable credentials, and audit evidence first because those controls stop spend before it becomes an invoice.'],
-              ['Is a dashboard enough for economic firewall readiness?', 'No. Dashboards help explain spend after it happens, but economic firewall readiness requires request-path controls that can block, route, revoke, or charge before agents execute paid work.'],
+              ['How does SatGate improve readiness?', 'SatGate sits in the request path to observe agent/API activity, enforce budget and access policy, revoke scoped capabilities, preserve Evidence Pack proof, route economically, and govern paid rails when value moves.'],
+              ['Which gaps should teams fix first?', 'Teams should fix request attribution, hard budget enforcement, MCP tool policy, scoped revocable credentials, and Evidence Pack capture first because those controls stop unauthorized actions before execution.'],
+              ['Is a dashboard enough for economic firewall readiness?', 'No. Dashboards help explain activity after it happens, but economic firewall readiness requires request-path controls that can allow, deny, route, revoke, delegate, or preserve paid-rail context before agents execute work.'],
             ].map(([question, answer]) => (
               <div key={question} className="rounded-xl border border-gray-800 bg-gray-950 p-6">
                 <h3 className="mb-2 text-xl font-bold text-white">{question}</h3>
@@ -286,7 +286,7 @@ export default function EconomicFirewallReadinessGraderPage() {
         <div className="rounded-3xl border border-cyan-900/60 bg-gradient-to-br from-cyan-950/30 to-purple-950/30 p-8 md:p-12">
           <h2 className="mb-4 text-3xl font-bold text-white">Move weak areas into request-path control</h2>
           <p className="mb-8 max-w-3xl text-lg leading-relaxed text-gray-300">
-            SatGate is the economic control plane for AI agents: Observe what agents spend, Control risky requests before they execute, and Charge robot customers with L402 when APIs become products.
+            SatGate governs agent authority before execution: Observe every agent call, Control risky requests before they execute, and Prove allowed, denied, delegated, revoked, or paid decisions with an Evidence Pack.
           </p>
           <div className="flex flex-col gap-4 sm:flex-row">
             <Link href="/mcp-tool-cost-policy-generator" className="inline-flex items-center justify-center gap-2 rounded-lg bg-white px-6 py-3 font-bold text-black transition hover:bg-gray-200">

--- a/satgate-landing/scripts/check_policy_to_proof_page.py
+++ b/satgate-landing/scripts/check_policy_to_proof_page.py
@@ -7,6 +7,8 @@ PAGE = ROOT / "app" / "policy-to-proof" / "page.tsx"
 AGENT_CONTROL_PLANE = ROOT / "app" / "agent-control-plane" / "page.tsx"
 GOVERN_PAGE = ROOT / "app" / "components" / "GovernClient.tsx"
 ECONOMIC_FIREWALL_PAGE = ROOT / "app" / "economic-firewall" / "page.tsx"
+READINESS_GRADER_PAGE = ROOT / "app" / "economic-firewall-readiness-grader" / "page.tsx"
+READINESS_GRADER_LAYOUT = ROOT / "app" / "economic-firewall-readiness-grader" / "layout.tsx"
 
 required_phrases = [
     "Every agent action leaves a receipt",
@@ -187,6 +189,28 @@ economic_forbidden_phrases = [
     "when APIs become products for external agents",
 ]
 
+readiness_required_phrases = [
+    "Grade whether your agent/API stack can handle autonomous authority",
+    "Evidence Pack capture",
+    "Paid-rail context",
+    "govern paid rails when value moves",
+    "SatGate governs agent authority before execution",
+    "Prove allowed, denied, delegated, revoked, or paid decisions with an Evidence Pack",
+    "Assess whether your agent/API stack is ready for autonomous authority",
+]
+
+readiness_forbidden_phrases = [
+    "autonomous spend",
+    "L402 robot payments",
+    "L402 Charge",
+    "Robot payments",
+    "robot customers",
+    "when APIs become products",
+    "when agents become customers",
+    "Observe what agents spend",
+    "Charge robot customers",
+]
+
 
 def main() -> int:
     if not PAGE.exists():
@@ -218,6 +242,13 @@ def main() -> int:
     economic_stale = [phrase for phrase in economic_forbidden_phrases if phrase in economic_text]
     if economic_stale:
         raise SystemExit("stale economic-firewall Charge/spend-first phrases remain:\n" + "\n".join(economic_stale))
+    readiness_text = READINESS_GRADER_PAGE.read_text() + "\n" + READINESS_GRADER_LAYOUT.read_text()
+    readiness_missing = [phrase for phrase in readiness_required_phrases if phrase not in readiness_text]
+    if readiness_missing:
+        raise SystemExit("missing readiness-grader authority/proof phrases:\n" + "\n".join(readiness_missing))
+    readiness_stale = [phrase for phrase in readiness_forbidden_phrases if phrase in readiness_text]
+    if readiness_stale:
+        raise SystemExit("stale readiness-grader spend/Charge phrases remain:\n" + "\n".join(readiness_stale))
     return 0
 
 


### PR DESCRIPTION
## Summary
- Aligns `/economic-firewall-readiness-grader` with the authority/proof spine.
- Replaces old autonomous-spend, L402 Charge, robot-customer, and API-product conditional copy with authority, Evidence Pack, and paid-rail context language.
- Updates metadata, visible grader questions, score summaries, FAQ JSON-LD, visible FAQ, and CTA copy.
- Extends `check_policy_to_proof_page.py` to guard the grader against stale Charge/spend-first phrasing.

## Verification
- `python3 scripts/check_policy_to_proof_page.py`
- `npx eslint app/economic-firewall-readiness-grader/page.tsx app/economic-firewall-readiness-grader/layout.tsx`
- `npm run build`
- Local rendered `/economic-firewall-readiness-grader?v=local-tools3` verified for new authority/proof copy and stale phrase absence.
- Browser render checked: no console errors.
