### PR TITLE
fix: align public tool exits with Policy-to-Proof

### DIFF
--- a/satgate-landing/app/agent-spend-policy-template/layout.tsx
+++ b/satgate-landing/app/agent-spend-policy-template/layout.tsx
@@ -1,9 +1,9 @@
 import type { Metadata } from 'next';
 
 export const metadata: Metadata = {
-  title: 'Agent Spend Policy Template',
+  title: 'Agent Budget Policy Template: Policy-to-Proof Controls',
   description:
-    'Generate copyable YAML and JSON policy templates for AI agent budgets, MCP tool costs, delegation, revocation, and audit fields.',
+    'Generate YAML and JSON agent budget policy with authority, MCP tool caps, revocation, receipts, and Evidence Pack fields.',
   alternates: { canonical: 'https://satgate.io/agent-spend-policy-template' },
 };
 

--- a/satgate-landing/app/agent-spend-policy-template/page.tsx
+++ b/satgate-landing/app/agent-spend-policy-template/page.tsx
@@ -27,7 +27,7 @@ const tiers = {
     request: 5,
     tool: 25,
     delegate: true,
-    mode: 'control_and_charge',
+    mode: 'control_with_receipts',
   },
 };
 
@@ -50,9 +50,9 @@ export default function AgentSpendPolicyTemplatePage() {
     const t = tiers[tier];
     const w = workloads[workload];
     const slug = agentName.trim().toLowerCase().replace(/[^a-z0-9-]+/g, '-').replace(/^-|-$/g, '') || 'agent';
-    const yaml = `policy: ${slug}-spend-policy\nmode: ${t.mode}\nagent:\n  id: ${slug}\n  workload: ${workload}\n  risk_tier: ${w.risk}\nidentity:\n  require_agent_id: true\n  require_tenant_id: true\n  require_task_id: true\nbudgets:\n  daily_usd: ${t.daily}\n  session_usd: ${t.session}\n  per_request_usd: ${t.request}\n  on_exhausted: block\nroutes:\n  - path: ${w.route}\n    model: ${w.model}\n    max_request_usd: ${t.request}\nmcp_tools:\n  - name: ${w.tool}\n    max_call_usd: ${t.tool}\n    risk_tier: ${w.risk}\n    on_budget_exhausted: block\ndelegation:\n  allowed: ${t.delegate}\n  child_budget_pct: 20\n  child_expiry_minutes: 60\ncredentials:\n  type: revocable_capability\n  expiry_minutes: 240\n  revoke_on_loop: true\n  revoke_on_policy_violation: true\naudit:\n  include:\n    - tenant_id\n    - agent_id\n    - task_id\n    - route\n    - model\n    - mcp_tool\n    - estimated_cost_usd\n    - remaining_budget_usd\n    - policy_decision\n    - credential_id\n    - revocation_state`;
+    const yaml = `policy: ${slug}-budget-policy\nmode: ${t.mode}\nagent:\n  id: ${slug}\n  workload: ${workload}\n  risk_tier: ${w.risk}\nidentity:\n  require_agent_id: true\n  require_tenant_id: true\n  require_task_id: true\nbudgets:\n  daily_usd: ${t.daily}\n  session_usd: ${t.session}\n  per_request_usd: ${t.request}\n  on_exhausted: block\nroutes:\n  - path: ${w.route}\n    model: ${w.model}\n    max_request_usd: ${t.request}\nmcp_tools:\n  - name: ${w.tool}\n    max_call_usd: ${t.tool}\n    risk_tier: ${w.risk}\n    on_budget_exhausted: block\ndelegation:\n  allowed: ${t.delegate}\n  child_budget_pct: 20\n  child_expiry_minutes: 60\ncredentials:\n  type: revocable_capability\n  expiry_minutes: 240\n  revoke_on_loop: true\n  revoke_on_policy_violation: true\naudit:\n  include:\n    - tenant_id\n    - agent_id\n    - task_id\n    - route\n    - model\n    - mcp_tool\n    - estimated_cost_usd\n    - remaining_budget_usd\n    - policy_decision\n    - decision_reason\n    - policy_version\n    - receipt_id\n    - evidence_pack_id\n    - credential_id\n    - revocation_state`;
     const json = JSON.stringify({
-      policy: `${slug}-spend-policy`,
+      policy: `${slug}-budget-policy`,
       mode: t.mode,
       agent: { id: slug, workload, risk_tier: w.risk },
       identity: { require_agent_id: true, require_tenant_id: true, require_task_id: true },
@@ -61,7 +61,7 @@ export default function AgentSpendPolicyTemplatePage() {
       mcp_tools: [{ name: w.tool, max_call_usd: t.tool, risk_tier: w.risk, on_budget_exhausted: 'block' }],
       delegation: { allowed: t.delegate, child_budget_pct: 20, child_expiry_minutes: 60 },
       credentials: { type: 'revocable_capability', expiry_minutes: 240, revoke_on_loop: true, revoke_on_policy_violation: true },
-      audit: { include: ['tenant_id', 'agent_id', 'task_id', 'route', 'model', 'mcp_tool', 'estimated_cost_usd', 'remaining_budget_usd', 'policy_decision', 'credential_id', 'revocation_state'] },
+      audit: { include: ['tenant_id', 'agent_id', 'task_id', 'route', 'model', 'mcp_tool', 'estimated_cost_usd', 'remaining_budget_usd', 'policy_decision', 'decision_reason', 'policy_version', 'receipt_id', 'evidence_pack_id', 'credential_id', 'revocation_state'] },
     }, null, 2);
     return { yaml, json };
   }, [agentName, tier, workload]);
@@ -69,18 +69,18 @@ export default function AgentSpendPolicyTemplatePage() {
   const webPageJsonLd = {
     '@context': 'https://schema.org',
     '@type': 'WebPage',
-    name: 'Agent Spend Policy Template',
+    name: 'Agent Budget Policy Template',
     url: 'https://satgate.io/agent-spend-policy-template',
-    description: 'Generate copyable YAML and JSON policy templates for AI agent budgets, MCP tool costs, delegation, revocation, and audit fields.',
+    description: 'Generate copyable YAML and JSON policy templates for AI agent authority, budgets, MCP tool caps, revocation, receipts, and Evidence Pack fields.',
     datePublished: '2026-04-12',
     dateModified: '2026-05-03',
     isPartOf: { '@type': 'WebSite', name: 'SatGate', url: 'https://satgate.io' },
     about: [
-      { '@type': 'Thing', name: 'AI agent spend policy template' },
+      { '@type': 'Thing', name: 'AI agent budget policy template' },
       { '@type': 'Thing', name: 'request-path budget enforcement' },
       { '@type': 'Thing', name: 'MCP tool cost policy' },
       { '@type': 'Thing', name: 'agent delegation limits' },
-      { '@type': 'Thing', name: 'revocation and audit policy' },
+      { '@type': 'Thing', name: 'receipt and Evidence Pack policy' },
     ],
     audience: { '@type': 'Audience', audienceType: 'AI engineering, platform, API, security, and FinOps teams' },
   };
@@ -88,15 +88,15 @@ export default function AgentSpendPolicyTemplatePage() {
   const softwareJsonLd = {
     '@context': 'https://schema.org',
     '@type': 'SoftwareApplication',
-    name: 'Agent Spend Policy Template',
+    name: 'Agent Budget Policy Template',
     applicationCategory: 'DeveloperApplication',
     operatingSystem: 'Web',
     url: 'https://satgate.io/agent-spend-policy-template',
-    description: 'Generate copyable YAML and JSON policy templates for AI agent budgets, MCP tool costs, delegation, revocation, and audit fields.',
+    description: 'Generate copyable YAML and JSON policy templates for AI agent authority, budgets, MCP tool caps, revocation, receipts, and Evidence Pack fields.',
     publisher: { '@type': 'Organization', name: 'SatGate', url: 'https://satgate.io' },
     dateModified: '2026-05-03',
     audience: webPageJsonLd.audience,
-    featureList: ['YAML spend policy generation', 'JSON spend policy generation', 'MCP tool cost caps', 'Delegation limit templates', 'Revocation and audit field templates'],
+    featureList: ['YAML budget policy generation', 'JSON budget policy generation', 'MCP tool cost caps', 'Delegation limit templates', 'Receipt and Evidence Pack field templates'],
     offers: { '@type': 'Offer', price: '0', priceCurrency: 'USD' },
   };
 
@@ -106,7 +106,7 @@ export default function AgentSpendPolicyTemplatePage() {
     itemListElement: [
       { '@type': 'ListItem', position: 1, name: 'Home', item: 'https://satgate.io' },
       { '@type': 'ListItem', position: 2, name: 'AI Agent Cost Control', item: 'https://satgate.io/ai-agent-cost-control' },
-      { '@type': 'ListItem', position: 3, name: 'Agent Spend Policy Template', item: 'https://satgate.io/agent-spend-policy-template' },
+      { '@type': 'ListItem', position: 3, name: 'Agent Budget Policy Template', item: 'https://satgate.io/agent-spend-policy-template' },
     ],
   };
 
@@ -116,15 +116,15 @@ export default function AgentSpendPolicyTemplatePage() {
     mainEntity: [
       {
         '@type': 'Question',
-        name: 'What is an agent spend policy?',
+        name: 'What is an agent budget policy?',
         acceptedAnswer: {
           '@type': 'Answer',
-          text: 'An agent spend policy defines the budgets, per-request limits, route rules, MCP tool caps, delegation limits, revocation behavior, and audit fields that should be checked before autonomous agent requests execute.',
+          text: 'An agent budget policy defines the budgets, per-request limits, route rules, MCP tool caps, delegation limits, revocation behavior, receipts, and Evidence Pack fields that should be checked before autonomous agent requests execute.',
         },
       },
       {
         '@type': 'Question',
-        name: 'Why should spend policy be enforced in the request path?',
+        name: 'Why should budget policy be enforced in the request path?',
         acceptedAnswer: {
           '@type': 'Answer',
           text: 'Autonomous agents can loop, retry, delegate, and call expensive tools faster than dashboards or alerts can react. Request-path enforcement blocks over-budget activity before cost is created.',
@@ -135,20 +135,20 @@ export default function AgentSpendPolicyTemplatePage() {
         name: 'How does this template relate to SatGate?',
         acceptedAnswer: {
           '@type': 'Answer',
-          text: 'SatGate is the economic firewall that can enforce spend policy in the request path across model calls, APIs, MCP tools, revocable credentials, delegation, audit, and L402 payments.',
+          text: 'SatGate is the economic firewall that can enforce authority and budget policy in the request path across model calls, APIs, MCP tools, revocable credentials, delegation, audit receipts, and Evidence Pack exports.',
         },
       },
       {
         '@type': 'Question',
-        name: 'What fields should every AI agent spend policy include?',
+        name: 'What fields should every AI agent budget policy include?',
         acceptedAnswer: {
           '@type': 'Answer',
-          text: 'Every AI agent spend policy should include tenant, agent, task, route, model, tool, per-request cap, session budget, daily budget, delegation limits, credential expiry, revocation triggers, and audit fields.',
+          text: 'Every AI agent budget policy should include tenant, agent, task, route, model, tool, per-request cap, session budget, daily budget, delegation limits, credential expiry, revocation triggers, receipt ids, policy versions, and Evidence Pack fields.',
         },
       },
       {
         '@type': 'Question',
-        name: 'Should agent spend policy start in Observe or Control mode?',
+        name: 'Should agent budget policy start in Observe or Control mode?',
         acceptedAnswer: {
           '@type': 'Answer',
           text: 'Most teams should start in Observe to learn normal spend patterns, then move high-risk agents, expensive tools, and external-facing workflows into Control mode with hard caps and revocation.',
@@ -168,20 +168,20 @@ export default function AgentSpendPolicyTemplatePage() {
         <div className="absolute inset-0 bg-[radial-gradient(circle_at_20%_0%,rgba(34,211,238,0.18),transparent_32%),radial-gradient(circle_at_82%_10%,rgba(168,85,247,0.16),transparent_34%)]" />
         <div className="relative mx-auto max-w-6xl px-6 py-24">
           <div className="mb-8 inline-flex items-center gap-2 rounded-full border border-cyan-500/30 bg-cyan-950/30 px-4 py-2 text-sm text-cyan-200">
-            <ClipboardList size={16} /> Free agent spend policy template
+            <ClipboardList size={16} /> Free agent budget policy template
           </div>
           <h1 className="mb-8 max-w-5xl text-5xl font-extrabold tracking-tight md:text-7xl">
-            Agent Spend Policy Template
+            Agent Budget Policy Template
           </h1>
           <p className="mb-10 max-w-4xl text-xl leading-relaxed text-gray-300 md:text-2xl">
-            Generate a practical YAML or JSON policy for AI agent budgets, per-request caps, MCP tool costs, delegation limits, revocation, and audit fields.
+            Generate practical YAML or JSON policy for AI agent authority, budgets, per-request caps, MCP tool costs, delegation limits, revocation, receipts, and Evidence Pack fields.
           </p>
           <div className="flex flex-col gap-4 sm:flex-row">
             <a href="#template" className="inline-flex items-center justify-center gap-2 rounded-lg bg-white px-6 py-3 font-bold text-black transition hover:bg-gray-200">
               Generate template <ArrowRight size={18} />
             </a>
-            <Link href="/ai-api-budget-enforcement" className="inline-flex items-center justify-center gap-2 rounded-lg border border-gray-700 px-6 py-3 font-bold text-white transition hover:border-cyan-500">
-              AI API budget enforcement
+            <Link href="/policy-to-proof" className="inline-flex items-center justify-center gap-2 rounded-lg border border-gray-700 px-6 py-3 font-bold text-white transition hover:border-cyan-500">
+              See Policy-to-Proof
             </Link>
           </div>
         </div>
@@ -212,7 +212,7 @@ export default function AgentSpendPolicyTemplatePage() {
             </select>
           </label>
           <div className="rounded-xl border border-cyan-900/50 bg-cyan-950/10 p-5 text-sm leading-relaxed text-cyan-100">
-            This template is deliberately conservative. Start in Observe, then enforce Control once you know normal request and tool economics.
+            This template is deliberately conservative. Start in Observe, then enforce Control once you know normal request and tool economics, with receipts captured for every policy decision.
           </div>
         </div>
 
@@ -236,18 +236,18 @@ export default function AgentSpendPolicyTemplatePage() {
 
       <section className="border-y border-gray-900 bg-gray-950/60">
         <div className="mx-auto max-w-6xl px-6 py-20">
-          <h2 className="mb-4 text-3xl font-bold text-white">What a useful agent spend policy covers</h2>
+          <h2 className="mb-4 text-3xl font-bold text-white">What a useful agent budget policy covers</h2>
           <p className="mb-10 max-w-3xl text-lg leading-relaxed text-gray-400">
-            A policy is useful only if it can be enforced before the next model, API, or MCP tool call. These are the fields that make spend governable.
+            A policy is useful only if it can be enforced before the next model, API, or MCP tool call. These are the fields that make authority, budget, and proof governable.
           </p>
           <div className="grid gap-5 md:grid-cols-3">
             {[
               [Gauge, 'Budgets', 'Daily, session, per-request, route, model, and MCP tool caps.'],
-              [Wrench, 'Tools', 'Per-tool price, risk tier, deny behavior, and audit fields for MCP servers.'],
+              [Wrench, 'Tools', 'Per-tool price, risk tier, deny behavior, receipt fields, and Evidence Pack ids for MCP servers.'],
               [KeyRound, 'Credentials', 'Scoped capabilities with expiry, revocation, and loop-kill behavior.'],
               [ShieldCheck, 'Delegation', 'Sub-agent budget percentages, shorter expiry, and attenuated authority.'],
-              [ReceiptText, 'Audit', 'Tenant, agent, task, route, model, tool, cost, budget, and decision fields.'],
-              [ClipboardList, 'Mode', 'Observe first, Control when trusted thresholds are clear, Charge when robot customers pay.'],
+              [ReceiptText, 'Audit', 'Tenant, agent, task, route, model, tool, spend context, budget, decision, receipt id, and Evidence Pack id.'],
+              [ClipboardList, 'Mode', 'Observe first, Control when trusted thresholds are clear, and capture receipts for every policy decision.'],
             ].map(([Icon, title, body]) => {
               const CardIcon = Icon as typeof Gauge;
               return (
@@ -265,16 +265,16 @@ export default function AgentSpendPolicyTemplatePage() {
       <section className="border-t border-gray-900 bg-black">
         <div className="mx-auto max-w-6xl px-6 py-20">
           <p className="mb-2 text-sm font-mono uppercase tracking-wide text-cyan-300">FAQ</p>
-          <h2 className="mb-8 text-3xl font-bold text-white">Agent spend policy questions</h2>
+          <h2 className="mb-8 text-3xl font-bold text-white">Agent budget policy questions</h2>
           <div className="grid gap-5 md:grid-cols-2">
             <div className="rounded-xl border border-gray-800 bg-gray-950 p-6">
-              <h3 className="mb-2 text-xl font-bold text-white">What is an agent spend policy?</h3>
+              <h3 className="mb-2 text-xl font-bold text-white">What is an agent budget policy?</h3>
               <p className="text-gray-400 leading-relaxed">
-                An agent spend policy defines the budgets, per-request limits, route rules, MCP tool caps, delegation limits, revocation behavior, and audit fields that should be checked before autonomous agent requests execute.
+                An agent budget policy defines the budgets, per-request limits, route rules, MCP tool caps, delegation limits, revocation behavior, receipts, and Evidence Pack fields that should be checked before autonomous agent requests execute.
               </p>
             </div>
             <div className="rounded-xl border border-gray-800 bg-gray-950 p-6">
-              <h3 className="mb-2 text-xl font-bold text-white">Why should spend policy be enforced in the request path?</h3>
+              <h3 className="mb-2 text-xl font-bold text-white">Why should budget policy be enforced in the request path?</h3>
               <p className="text-gray-400 leading-relaxed">
                 Autonomous agents can loop, retry, delegate, and call expensive tools faster than dashboards or alerts can react. Request-path enforcement blocks over-budget activity before cost is created.
               </p>
@@ -282,17 +282,17 @@ export default function AgentSpendPolicyTemplatePage() {
             <div className="rounded-xl border border-gray-800 bg-gray-950 p-6">
               <h3 className="mb-2 text-xl font-bold text-white">How does this template relate to SatGate?</h3>
               <p className="text-gray-400 leading-relaxed">
-                SatGate is the economic firewall that can enforce spend policy in the request path across model calls, APIs, MCP tools, revocable credentials, delegation, audit, and L402 payments.
+                SatGate is the economic firewall that can enforce authority and budget policy in the request path across model calls, APIs, MCP tools, revocable credentials, delegation, audit receipts, and Evidence Pack exports.
               </p>
             </div>
             <div className="rounded-xl border border-gray-800 bg-gray-950 p-6">
-              <h3 className="mb-2 text-xl font-bold text-white">What fields should every AI agent spend policy include?</h3>
+              <h3 className="mb-2 text-xl font-bold text-white">What fields should every AI agent budget policy include?</h3>
               <p className="text-gray-400 leading-relaxed">
-                Every AI agent spend policy should include tenant, agent, task, route, model, tool, per-request cap, session budget, daily budget, delegation limits, credential expiry, revocation triggers, and audit fields.
+                Every AI agent budget policy should include tenant, agent, task, route, model, tool, per-request cap, session budget, daily budget, delegation limits, credential expiry, revocation triggers, receipt ids, policy versions, and Evidence Pack fields.
               </p>
             </div>
             <div className="rounded-xl border border-gray-800 bg-gray-950 p-6">
-              <h3 className="mb-2 text-xl font-bold text-white">Should agent spend policy start in Observe or Control mode?</h3>
+              <h3 className="mb-2 text-xl font-bold text-white">Should agent budget policy start in Observe or Control mode?</h3>
               <p className="text-gray-400 leading-relaxed">
                 Most teams should start in Observe to learn normal spend patterns, then move high-risk agents, expensive tools, and external-facing workflows into Control mode with hard caps and revocation.
               </p>
@@ -303,16 +303,16 @@ export default function AgentSpendPolicyTemplatePage() {
 
       <section className="mx-auto max-w-6xl px-6 py-20">
         <div className="rounded-3xl border border-purple-900/60 bg-gradient-to-br from-purple-950/30 to-cyan-950/25 p-8 md:p-12">
-          <h2 className="mb-4 text-3xl font-bold text-white">Turn templates into enforcement.</h2>
+          <h2 className="mb-4 text-3xl font-bold text-white">Turn this policy into proof.</h2>
           <p className="mb-8 max-w-3xl text-lg leading-relaxed text-gray-300">
-            SatGate sits in the request path and applies these policies before agents spend money, call MCP tools, delegate work, or unlock paid API access.
+            SatGate checks authority before execution, records every policy decision as a receipt, and packages evidence for review in an Evidence Pack.
           </p>
           <div className="flex flex-col gap-4 sm:flex-row">
-            <Link href="/agent-spending-limits" className="inline-flex items-center justify-center gap-2 rounded-lg bg-white px-6 py-3 font-bold text-black transition hover:bg-gray-200">
-              Agent spending limits <ArrowRight size={18} />
+            <Link href="/govern" className="inline-flex items-center justify-center gap-2 rounded-lg bg-white px-6 py-3 font-bold text-black transition hover:bg-gray-200">
+              Govern agent execution <ArrowRight size={18} />
             </Link>
-            <Link href="/mcp-cost-control" className="inline-flex items-center justify-center gap-2 rounded-lg border border-gray-700 px-6 py-3 font-bold text-white transition hover:border-cyan-500">
-              MCP cost control
+            <Link href="/policy-to-proof" className="inline-flex items-center justify-center gap-2 rounded-lg border border-gray-700 px-6 py-3 font-bold text-white transition hover:border-cyan-500">
+              Create Evidence Pack trail
             </Link>
           </div>
         </div>

--- a/satgate-landing/app/revocable-capability-token-policy-template/layout.tsx
+++ b/satgate-landing/app/revocable-capability-token-policy-template/layout.tsx
@@ -3,7 +3,7 @@ import type { Metadata } from 'next';
 export const metadata: Metadata = {
   title: 'Revocable Capability Token Policy Template',
   description:
-    'Generate scoped, expiring, revocable capability-token policy for AI agents, sub-agents, MCP tools, budgets, and audit trails.',
+    'Generate scoped, expiring, revocable capability-token policy for AI agents with budgets, receipts, and Evidence Pack fields.',
   alternates: { canonical: 'https://satgate.io/revocable-capability-token-policy-template' },
 };
 

--- a/satgate-landing/app/revocable-capability-token-policy-template/page.tsx
+++ b/satgate-landing/app/revocable-capability-token-policy-template/page.tsx
@@ -35,10 +35,10 @@ const profiles = {
     childBudgetPct: 15,
     risk: 'high',
   },
-  payments: {
-    subject: 'agent:robot-customer',
-    audience: 'paid-api-access',
-    scopes: ['api:metered:read', 'charge:l402:pay', 'receipt:audit:write'],
+  externalAccess: {
+    subject: 'agent:external-client',
+    audience: 'governed-api-access',
+    scopes: ['api:metered:read', 'policy:decision:read', 'receipt:audit:write'],
     maxBudgetUsd: 100,
     ttlMinutes: 60,
     delegation: false,
@@ -58,7 +58,7 @@ export default function RevocableCapabilityTokenPolicyTemplatePage() {
     const p = profiles[profile];
     const tenantSlug = tenant.trim().toLowerCase().replace(/[^a-z0-9-]+/g, '-').replace(/^-|-$/g, '') || 'tenant';
     const taskSlug = task.trim().toLowerCase().replace(/[^a-z0-9-]+/g, '-').replace(/^-|-$/g, '') || 'task';
-    const yaml = `capability_token_policy: ${tenantSlug}-${taskSlug}\nmode: enforce\nissuer: satgate-economic-firewall\nsubject: ${p.subject}\naudience: ${p.audience}\ntenant_id: ${tenantSlug}\ntask_id: ${taskSlug}\nrisk_tier: ${p.risk}\nvalidity:\n  ttl_minutes: ${p.ttlMinutes}\n  not_before: now\n  expires_at: now + ${p.ttlMinutes}m\nscopes:\n${p.scopes.map((scope) => `  - ${scope}`).join('\n')}\nbudgets:\n  token_lifetime_usd: ${p.maxBudgetUsd}\n  per_request_usd: ${Math.max(0.25, p.maxBudgetUsd / 50)}\n  on_exhausted: revoke_and_block\ndelegation:\n  allowed: ${p.delegation}\n  child_budget_pct: ${p.childBudgetPct}\n  child_ttl_minutes: ${Math.min(60, p.ttlMinutes)}\n  child_scopes_must_be_subset: true\nrevocation:\n  revoke_on_budget_exhausted: true\n  revoke_on_loop_detected: true\n  revoke_on_policy_violation: true\n  revoke_on_parent_revoked: true\n  kill_switch: tenant:${tenantSlug}:agents\naudit:\n  required_fields:\n    - token_id\n    - parent_token_id\n    - tenant_id\n    - agent_id\n    - task_id\n    - scope\n    - estimated_cost_usd\n    - remaining_budget_usd\n    - revocation_state\n    - policy_decision`;
+    const yaml = `capability_token_policy: ${tenantSlug}-${taskSlug}\nmode: enforce\nissuer: satgate-economic-firewall\nsubject: ${p.subject}\naudience: ${p.audience}\ntenant_id: ${tenantSlug}\ntask_id: ${taskSlug}\nrisk_tier: ${p.risk}\nvalidity:\n  ttl_minutes: ${p.ttlMinutes}\n  not_before: now\n  expires_at: now + ${p.ttlMinutes}m\nscopes:\n${p.scopes.map((scope) => `  - ${scope}`).join('\n')}\nbudgets:\n  token_lifetime_usd: ${p.maxBudgetUsd}\n  per_request_usd: ${Math.max(0.25, p.maxBudgetUsd / 50)}\n  on_exhausted: revoke_and_block\ndelegation:\n  allowed: ${p.delegation}\n  child_budget_pct: ${p.childBudgetPct}\n  child_ttl_minutes: ${Math.min(60, p.ttlMinutes)}\n  child_scopes_must_be_subset: true\nrevocation:\n  revoke_on_budget_exhausted: true\n  revoke_on_loop_detected: true\n  revoke_on_policy_violation: true\n  revoke_on_parent_revoked: true\n  kill_switch: tenant:${tenantSlug}:agents\naudit:\n  required_fields:\n    - token_id\n    - parent_token_id\n    - tenant_id\n    - agent_id\n    - task_id\n    - scope\n    - estimated_cost_usd\n    - remaining_budget_usd\n    - revocation_state\n    - policy_decision\n    - decision_reason\n    - policy_version\n    - receipt_id\n    - evidence_pack_id`;
     const json = JSON.stringify({
       capability_token_policy: `${tenantSlug}-${taskSlug}`,
       mode: 'enforce',
@@ -73,7 +73,7 @@ export default function RevocableCapabilityTokenPolicyTemplatePage() {
       budgets: { token_lifetime_usd: p.maxBudgetUsd, per_request_usd: Math.max(0.25, p.maxBudgetUsd / 50), on_exhausted: 'revoke_and_block' },
       delegation: { allowed: p.delegation, child_budget_pct: p.childBudgetPct, child_ttl_minutes: Math.min(60, p.ttlMinutes), child_scopes_must_be_subset: true },
       revocation: { revoke_on_budget_exhausted: true, revoke_on_loop_detected: true, revoke_on_policy_violation: true, revoke_on_parent_revoked: true, kill_switch: `tenant:${tenantSlug}:agents` },
-      audit: { required_fields: ['token_id', 'parent_token_id', 'tenant_id', 'agent_id', 'task_id', 'scope', 'estimated_cost_usd', 'remaining_budget_usd', 'revocation_state', 'policy_decision'] },
+      audit: { required_fields: ['token_id', 'parent_token_id', 'tenant_id', 'agent_id', 'task_id', 'scope', 'estimated_cost_usd', 'remaining_budget_usd', 'revocation_state', 'policy_decision', 'decision_reason', 'policy_version', 'receipt_id', 'evidence_pack_id'] },
     }, null, 2);
     return { yaml, json };
   }, [profile, task, tenant]);
@@ -83,7 +83,7 @@ export default function RevocableCapabilityTokenPolicyTemplatePage() {
     '@type': 'WebPage',
     name: 'Revocable Capability Token Policy Template',
     url: 'https://satgate.io/revocable-capability-token-policy-template',
-    description: 'Generate scoped, expiring, revocable capability-token policy for AI agents, sub-agents, MCP tools, budgets, and audit trails.',
+    description: 'Generate scoped, expiring, revocable capability-token policy for AI agents, sub-agents, MCP tools, budgets, receipts, and Evidence Pack evidence.',
     datePublished: '2026-04-12',
     dateModified: '2026-05-05',
     isPartOf: { '@type': 'WebSite', name: 'SatGate', url: 'https://satgate.io' },
@@ -104,11 +104,11 @@ export default function RevocableCapabilityTokenPolicyTemplatePage() {
     applicationCategory: 'DeveloperApplication',
     operatingSystem: 'Web',
     url: 'https://satgate.io/revocable-capability-token-policy-template',
-    description: 'Generate scoped, expiring, revocable capability-token policy for AI agents, sub-agents, MCP tools, budgets, and audit trails.',
+    description: 'Generate scoped, expiring, revocable capability-token policy for AI agents, sub-agents, MCP tools, budgets, receipts, and Evidence Pack evidence.',
     publisher: { '@type': 'Organization', name: 'SatGate', url: 'https://satgate.io' },
     dateModified: '2026-05-05',
     audience: webPageJsonLd.audience,
-    featureList: ['YAML capability-token policy generation', 'JSON capability-token policy generation', 'Delegation attenuation controls', 'Budget exhaustion revocation rules', 'Audit field templates'],
+    featureList: ['YAML capability-token policy generation', 'JSON capability-token policy generation', 'Delegation attenuation controls', 'Budget exhaustion revocation rules', 'Receipt field templates', 'Evidence Pack export fields'],
     offers: { '@type': 'Offer', price: '0', priceCurrency: 'USD' },
   };
 
@@ -116,14 +116,14 @@ export default function RevocableCapabilityTokenPolicyTemplatePage() {
     '@context': 'https://schema.org',
     '@type': 'ItemList',
     name: 'Capability-token policy checklist for AI agents',
-    description: 'Required fields for scoped, expiring, revocable, budget-aware AI agent capability tokens.',
+    description: 'Required fields for scoped, expiring, revocable, budget-aware AI agent capability tokens that produce receipts and Evidence Pack evidence.',
     itemListElement: [
       ['Scope', 'Bind authority to tenant, agent, task, audience, route, and MCP tool permissions.'],
       ['Expiry', 'Use short token lifetimes and shorter child-token TTLs for delegated sub-agents.'],
       ['Revocation', 'Revoke on budget exhaustion, loops, parent revocation, policy violation, or kill switch.'],
       ['Delegation', 'Require child capabilities to be strict subsets with attenuated budgets and scopes.'],
-      ['Audit', 'Log token id, parent id, cost, remaining budget, scope, revocation state, and decision.'],
-      ['Economic control', 'Pair identity with budgets so authentication and spend governance happen together.'],
+      ['Audit', 'Log token id, parent id, spend context, remaining budget, scope, revocation state, decision, receipt id, and Evidence Pack id.'],
+      ['Economic control', 'Pair identity with budgets so authentication, spend context, and proof capture happen together.'],
     ].map(([name, description], index) => ({
       '@type': 'ListItem',
       position: index + 1,
@@ -159,7 +159,7 @@ export default function RevocableCapabilityTokenPolicyTemplatePage() {
         name: 'Why are capability tokens better than shared API keys for agents?',
         acceptedAnswer: {
           '@type': 'Answer',
-          text: 'Shared API keys are broad, long-lived, and hard to revoke safely. Capability tokens bind authority to a specific agent task with spend limits, expiry, delegation rules, and audit fields.',
+          text: 'Shared API keys are broad, long-lived, and hard to revoke safely. Capability tokens bind authority to a specific agent task with budget limits, expiry, delegation rules, receipts, and Evidence Pack fields.',
         },
       },
       {
@@ -167,7 +167,7 @@ export default function RevocableCapabilityTokenPolicyTemplatePage() {
         name: 'How does SatGate enforce these token policies?',
         acceptedAnswer: {
           '@type': 'Answer',
-          text: 'SatGate sits in the request path as an economic firewall, checking token scope, budget, delegation, revocation state, and audit requirements before upstream model, API, MCP, or L402 Charge access.',
+          text: 'SatGate sits in the request path as an economic firewall, checking token scope, budget, delegation, revocation state, and receipt policy before upstream model, API, MCP, or externally exposed agent access.',
         },
       },
     ],
@@ -191,14 +191,14 @@ export default function RevocableCapabilityTokenPolicyTemplatePage() {
             Revocable Capability Token Policy Template
           </h1>
           <p className="mb-10 max-w-4xl text-xl leading-relaxed text-gray-300 md:text-2xl">
-            Generate scoped, expiring, revocable token policy for AI agents, sub-agents, MCP tools, request budgets, delegation, kill switches, and audit trails.
+            Generate scoped, expiring, revocable token policy for AI agents, sub-agents, MCP tools, request budgets, delegation, kill switches, receipts, and Evidence Pack evidence.
           </p>
           <div className="flex flex-col gap-4 sm:flex-row">
             <a href="#template" className="inline-flex items-center justify-center gap-2 rounded-lg bg-white px-6 py-3 font-bold text-black transition hover:bg-gray-200">
               Generate policy <ArrowRight size={18} />
             </a>
-            <Link href="/agent-capability-tokens" className="inline-flex items-center justify-center gap-2 rounded-lg border border-gray-700 px-6 py-3 font-bold text-white transition hover:border-cyan-500">
-              Learn capability tokens
+            <Link href="/policy-to-proof" className="inline-flex items-center justify-center gap-2 rounded-lg border border-gray-700 px-6 py-3 font-bold text-white transition hover:border-cyan-500">
+              See Policy-to-Proof
             </Link>
           </div>
         </div>
@@ -221,11 +221,11 @@ export default function RevocableCapabilityTokenPolicyTemplatePage() {
               <option value="coding">Coding agent</option>
               <option value="support">Support copilot</option>
               <option value="research">Research analyst</option>
-              <option value="payments">Robot customer / L402</option>
+              <option value="externalAccess">External agent access</option>
             </select>
           </label>
           <div className="rounded-xl border border-cyan-900/50 bg-cyan-950/10 p-5 text-sm leading-relaxed text-cyan-100">
-            Static API keys are wrong for autonomous agents. Capabilities should be narrow, priced, time-boxed, auditable, and revocable.
+            Static API keys are wrong for autonomous agents. Capabilities should be narrow, priced, time-boxed, receipt-producing, and revocable.
           </div>
         </div>
 
@@ -251,7 +251,7 @@ export default function RevocableCapabilityTokenPolicyTemplatePage() {
         <div className="mx-auto max-w-6xl px-6 py-20">
           <h2 className="mb-4 text-3xl font-bold text-white">Capability-token policy checklist</h2>
           <p className="mb-10 max-w-3xl text-lg leading-relaxed text-gray-400">
-            Agent tokens need economic constraints, not just authentication. These fields make authority governable before spend is created.
+            Agent tokens need economic constraints, not just authentication. These fields make authority governable before execution and proof exportable after the decision.
           </p>
           <div className="grid gap-5 md:grid-cols-3">
             {[
@@ -259,8 +259,8 @@ export default function RevocableCapabilityTokenPolicyTemplatePage() {
               [TimerReset, 'Expiry', 'Use short token lifetimes and shorter child-token TTLs for delegated sub-agents.'],
               [ShieldCheck, 'Revocation', 'Revoke on budget exhaustion, loops, parent revocation, policy violation, or kill switch.'],
               [ClipboardList, 'Delegation', 'Require child capabilities to be strict subsets with attenuated budgets and scopes.'],
-              [ReceiptText, 'Audit', 'Log token id, parent id, cost, remaining budget, scope, revocation state, and decision.'],
-              [KeyRound, 'Economic control', 'Pair identity with budgets so authentication and spend governance happen together.'],
+              [ReceiptText, 'Audit', 'Log token id, parent id, spend context, remaining budget, scope, revocation state, decision, receipt id, and Evidence Pack id.'],
+              [KeyRound, 'Economic control', 'Pair identity with budgets so authentication, spend context, and proof capture happen together.'],
             ].map(([Icon, title, body]) => {
               const CardIcon = Icon as typeof KeyRound;
               return (
@@ -286,11 +286,11 @@ export default function RevocableCapabilityTokenPolicyTemplatePage() {
             </div>
             <div className="rounded-xl border border-gray-800 bg-gray-950 p-6">
               <h3 className="mb-2 text-xl font-bold text-white">Why are capability tokens better than shared API keys for agents?</h3>
-              <p className="leading-relaxed text-gray-400">Shared API keys are broad, long-lived, and hard to revoke safely. Capability tokens bind authority to a specific agent task with spend limits, expiry, delegation rules, and audit fields.</p>
+              <p className="leading-relaxed text-gray-400">Shared API keys are broad, long-lived, and hard to revoke safely. Capability tokens bind authority to a specific agent task with budget limits, expiry, delegation rules, receipts, and Evidence Pack fields.</p>
             </div>
             <div className="rounded-xl border border-gray-800 bg-gray-950 p-6">
               <h3 className="mb-2 text-xl font-bold text-white">How does SatGate enforce these token policies?</h3>
-              <p className="leading-relaxed text-gray-400">SatGate sits in the request path as an economic firewall, checking token scope, budget, delegation, revocation state, and audit requirements before upstream model, API, MCP, or L402 Charge access.</p>
+              <p className="leading-relaxed text-gray-400">SatGate sits in the request path as an economic firewall, checking token scope, budget, delegation, revocation state, and receipt policy before upstream model, API, MCP, or externally exposed agent access.</p>
             </div>
           </div>
         </div>
@@ -298,19 +298,16 @@ export default function RevocableCapabilityTokenPolicyTemplatePage() {
 
       <section className="mx-auto max-w-6xl px-6 py-20">
         <div className="rounded-3xl border border-purple-900/60 bg-gradient-to-br from-purple-950/30 to-cyan-950/25 p-8 md:p-12">
-          <h2 className="mb-4 text-3xl font-bold text-white">Turn agent authority into an enforceable budget.</h2>
+          <h2 className="mb-4 text-3xl font-bold text-white">Turn agent authority into Policy-to-Proof evidence.</h2>
           <p className="mb-8 max-w-3xl text-lg leading-relaxed text-gray-300">
-            SatGate checks capability scope, budget, revocation, delegation, audit, and Charge/L402 payment policy in the request path before agents reach upstream APIs or MCP tools.
+            Every scoped token decision should produce a receipt that can be exported into an Evidence Pack.
           </p>
           <div className="flex flex-col gap-4 sm:flex-row">
-            <Link href="/revocable-agent-credentials" className="inline-flex items-center justify-center gap-2 rounded-lg bg-white px-6 py-3 font-bold text-black transition hover:bg-gray-200">
-              Revocable agent credentials <ArrowRight size={18} />
+            <Link href="/govern" className="inline-flex items-center justify-center gap-2 rounded-lg bg-white px-6 py-3 font-bold text-black transition hover:bg-gray-200">
+              Govern agent authority <ArrowRight size={18} />
             </Link>
-            <Link href="/agent-api-key-risk-assessment" className="inline-flex items-center justify-center gap-2 rounded-lg border border-gray-700 px-6 py-3 font-bold text-white transition hover:border-cyan-500">
-              Assess API key risk
-            </Link>
-            <Link href="/economic-firewall-readiness-grader" className="inline-flex items-center justify-center gap-2 rounded-lg border border-gray-700 px-6 py-3 font-bold text-white transition hover:border-cyan-500">
-              Grade economic firewall readiness
+            <Link href="/policy-to-proof" className="inline-flex items-center justify-center gap-2 rounded-lg border border-gray-700 px-6 py-3 font-bold text-white transition hover:border-cyan-500">
+              Create Evidence Pack trail
             </Link>
           </div>
         </div>

--- a/satgate-landing/app/roi-calculator/layout.tsx
+++ b/satgate-landing/app/roi-calculator/layout.tsx
@@ -4,7 +4,7 @@ export const metadata: Metadata = {
   title: "AI Agent ROI Calculator: Budget Enforcement Savings",
   alternates: { canonical: "https://satgate.io/roi-calculator" },
   description:
-    "Estimate AI agent ghost spend, loop waste, budget enforcement savings, payback period, and annual ROI with SatGate.",
+    "Estimate AI agent loop exposure and map budget controls to Policy-to-Proof receipts and Evidence Pack evidence with SatGate.",
   keywords: [
     "AI agent ROI calculator",
     "AI agent cost calculator",
@@ -16,7 +16,7 @@ export const metadata: Metadata = {
   openGraph: {
     title: "AI Agent ROI Calculator",
     description:
-      "Estimate ghost spend, runaway agent loop exposure, payback period, and savings from request-path budget enforcement.",
+      "Estimate runaway agent loop exposure, budget-control ROI, and Policy-to-Proof receipt coverage.",
     url: "https://satgate.io/roi-calculator",
     type: "website",
   },
@@ -24,7 +24,7 @@ export const metadata: Metadata = {
     card: "summary_large_image",
     title: "AI Agent ROI Calculator",
     description:
-      "Estimate AI agent ghost spend, runaway loop exposure, payback period, and SatGate budget-enforcement savings.",
+      "Estimate AI agent loop exposure, budget-control ROI, and SatGate Policy-to-Proof receipt coverage.",
   },
 };
 

--- a/satgate-landing/app/roi-calculator/page.tsx
+++ b/satgate-landing/app/roi-calculator/page.tsx
@@ -73,14 +73,15 @@ export default function ROICalculatorPage() {
     '@context': 'https://schema.org',
     '@type': 'WebPage',
     name: 'AI Agent ROI Calculator',
-    description: 'Estimate runaway AI agent spend exposure, request-path budget enforcement savings, payback period, and annual ROI for autonomous agents using paid APIs and MCP tools.',
+    description: 'Estimate runaway AI agent loop exposure, budget-control ROI, and the receipts needed for Policy-to-Proof evidence across paid APIs and MCP tools.',
     url: 'https://satgate.io/roi-calculator',
     dateModified: '2026-05-05',
     isPartOf: { '@type': 'WebSite', name: 'SatGate', url: 'https://satgate.io' },
     about: [
       { '@type': 'Thing', name: 'AI agent ROI calculator' },
-      { '@type': 'Thing', name: 'runaway AI agent spend exposure' },
+      { '@type': 'Thing', name: 'runaway AI agent loop exposure' },
       { '@type': 'Thing', name: 'request-path budget enforcement ROI' },
+      { '@type': 'Thing', name: 'Policy-to-Proof receipts' },
       { '@type': 'Thing', name: 'MCP tool spend risk' },
       { '@type': 'Thing', name: 'economic firewall payback period' },
     ],
@@ -93,14 +94,14 @@ export default function ROICalculatorPage() {
     applicationCategory: 'BusinessApplication',
     operatingSystem: 'Web',
     url: 'https://satgate.io/roi-calculator',
-    description: 'Estimate ghost spend, runaway agent loop exposure, payback period, and ROI from request-path AI agent budget enforcement.',
+    description: 'Estimate runaway agent loop exposure, budget-control ROI, and the receipts needed for Policy-to-Proof evidence.',
     featureList: [
       'Monthly AI agent tool spend estimate',
       'Runaway loop ghost spend exposure',
       'Annual AI agent cost-risk model',
       'Request-path budget enforcement savings estimate',
       'Payback period and annual ROI estimate',
-      'Links from ROI exposure to enforceable spend policy templates',
+      'Links from ROI exposure to Policy-to-Proof controls and Evidence Pack receipts',
     ],
     audience: [
       { '@type': 'Audience', audienceType: 'Platform engineering teams' },
@@ -155,7 +156,7 @@ export default function ROICalculatorPage() {
         name: 'What should I do after estimating runaway agent spend?',
         acceptedAnswer: {
           '@type': 'Answer',
-          text: 'Turn the exposure model into enforceable policy: generate budget limits, MCP tool caps, scoped capability-token policy, and request-path controls that block over-budget calls before cost is created.',
+          text: 'Turn the exposure model into Policy-to-Proof controls: define authority, budget limits, MCP tool caps, scoped capability-token policy, receipts, and Evidence Pack exports.',
         },
       },
       {
@@ -164,6 +165,14 @@ export default function ROICalculatorPage() {
         acceptedAnswer: {
           '@type': 'Answer',
           text: 'Yes. A token cost calculator estimates model usage. This ROI calculator estimates autonomous agent spend risk across paid tools, APIs, MCP calls, retries, delegation, and loops that may happen outside a single LLM invoice.',
+        },
+      },
+      {
+        '@type': 'Question',
+        name: 'How do ROI results become evidence?',
+        acceptedAnswer: {
+          '@type': 'Answer',
+          text: 'Use Policy-to-Proof to connect budget policy, request decisions, receipts, and Evidence Pack exports for audit-ready agent governance.',
         },
       },
       {
@@ -189,7 +198,7 @@ export default function ROICalculatorPage() {
     '@context': 'https://schema.org',
     '@type': 'HowTo',
     name: 'How to estimate AI agent budget enforcement ROI',
-    description: 'Use the SatGate ROI calculator to estimate unmanaged AI agent spend, runaway loop exposure, monthly savings, payback period, and annual ROI.',
+    description: 'Use the SatGate ROI calculator to estimate unmanaged AI agent loop exposure, budget-control ROI, and Policy-to-Proof receipt coverage.',
     totalTime: 'PT3M',
     tool: [{ '@type': 'HowToTool', name: 'SatGate AI Agent ROI Calculator' }],
     step: [
@@ -206,7 +215,7 @@ export default function ROICalculatorPage() {
       {
         '@type': 'HowToStep',
         name: 'Model loop exposure',
-        text: 'Estimate loop frequency and average calls wasted before discovery to calculate ghost spend and annual risk exposure.',
+        text: 'Estimate loop frequency and average calls wasted before enforcement to calculate avoidable spend and annual risk exposure.',
       },
       {
         '@type': 'HowToStep',
@@ -247,7 +256,7 @@ export default function ROICalculatorPage() {
     '@context': 'https://schema.org',
     '@type': 'ItemList',
     name: 'AI agent budget enforcement break-even examples',
-    description: 'Examples that show when request-path budget enforcement can pay for itself by preventing unmanaged autonomous agent spend.',
+    description: 'Examples that show when request-path budget enforcement can pay for itself by enforcing authority, budget, and receipt policy before agent execution.',
     itemListElement: [
       {
         '@type': 'ListItem',
@@ -264,8 +273,8 @@ export default function ROICalculatorPage() {
       {
         '@type': 'ListItem',
         position: 3,
-        name: 'External agent monetization',
-        description: 'APIs exposed to robot customers can offset governance cost by charging with L402 before access is granted.',
+        name: 'External agent access',
+        description: 'APIs exposed to external agents need authority, budget, and receipt policy before access is granted.',
       },
     ],
   };
@@ -297,10 +306,9 @@ export default function ROICalculatorPage() {
             <span className="text-lg sm:text-xl font-bold text-white whitespace-nowrap">SatGate<sup className="text-xs font-normal">™</sup></span>
           </Link>
           <div className="hidden md:flex gap-6 text-sm font-medium text-gray-400">
-            <Link href="/mint-demo" className="hover:text-white transition">Mint Demo</Link>
-            <Link href="/protect" className="hover:text-white transition">Control Demo</Link>
-            <Link href="/pay" className="hover:text-white transition">Charge Demo</Link>
-            <Link href="/govern" className="hover:text-white transition">Enterprise</Link>
+            <Link href="/govern" className="hover:text-white transition">Govern</Link>
+            <Link href="/policy-to-proof" className="hover:text-white transition">Policy-to-Proof</Link>
+            <Link href="/tools" className="hover:text-white transition">Tools</Link>
             <Link href="/pricing" className="hover:text-white transition">Pricing</Link>
             <Link href="/roi-calculator" className="text-white transition">ROI Calculator</Link>
             <a href="https://cloud.satgate.io/docs" target="_blank" rel="noopener noreferrer" className="hover:text-white transition">Docs</a>
@@ -317,10 +325,9 @@ export default function ROICalculatorPage() {
         <div className={`md:hidden overflow-hidden transition-all duration-300 ease-in-out ${mobileMenuOpen ? 'max-h-96 opacity-100' : 'max-h-0 opacity-0'}`}>
           <div className="bg-black/95 backdrop-blur-xl border-t border-gray-800 px-4 py-4 space-y-1">
             {[
-              { href: '/mint-demo', label: 'Mint Demo' },
-              { href: '/protect', label: 'Control Demo' },
-              { href: '/pay', label: 'Charge Demo' },
-              { href: '/govern', label: 'Enterprise' },
+              { href: '/govern', label: 'Govern' },
+              { href: '/policy-to-proof', label: 'Policy-to-Proof' },
+              { href: '/tools', label: 'Tools' },
               { href: '/pricing', label: 'Pricing' },
               { href: '/roi-calculator', label: 'ROI Calculator' },
             ].map((l) => (
@@ -444,20 +451,16 @@ export default function ROICalculatorPage() {
         <div className="max-w-5xl mx-auto rounded-2xl border border-gray-800 bg-gray-900/60 p-6 md:p-8">
           <div className="mb-6 max-w-3xl">
             <p className="mb-2 text-sm font-mono uppercase tracking-wide text-cyan-300">Go deeper</p>
-            <h2 className="mb-3 text-2xl md:text-3xl font-bold text-white">Turn the ROI model into enforceable policy</h2>
+            <h2 className="mb-3 text-2xl md:text-3xl font-bold text-white">Turn the ROI model into Policy-to-Proof</h2>
             <p className="text-gray-400">
-              The calculator shows the exposure. These guides show how to enforce budget limits before agents spend the money.
+              The calculator shows the exposure. SatGate maps it to enforceable authority checks, receipts, and an Evidence Pack before agents execute.
             </p>
           </div>
           <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
             {[
-              { href: '/ai-agent-cost-control', title: 'AI agent cost control', body: 'Control API spend before autonomous agents create runaway bills.' },
-              { href: '/economic-firewall', title: 'Economic firewall', body: 'The request-path control layer for Observe, Control, and Charge.' },
-              { href: '/mcp-governance', title: 'MCP budget enforcement', body: 'Assign per-tool costs and cap MCP tool spend in real time.' },
-              { href: '/agent-api-governance', title: 'Agent API governance', body: 'Replace unlimited API keys with scoped, revocable capabilities.' },
-              { href: '/revocable-capability-token-policy-template', title: 'Capability-token policy template', body: 'Generate scoped, expiring, revocable agent authority with budgets and audit fields.' },
-              { href: '/agent-spend-policy-template', title: 'Agent spend policy template', body: 'Convert ROI exposure into copyable YAML and JSON budget enforcement policy.' },
-              { href: '/runaway-agent-cost-calculator', title: 'Runaway agent cost calculator', body: 'Model loop, retry, fanout, and MCP tool-call exposure.' },
+              { href: '/policy-to-proof', title: 'Map ROI to Policy-to-Proof', body: 'Connect exposure to enforceable checks, receipts, and an Evidence Pack.' },
+              { href: '/govern', title: 'Govern agent execution', body: 'Put authority, budget, and audit policy in the request path before execution.' },
+              { href: '/agent-spend-policy-template', title: 'Generate budget policy', body: 'Convert ROI exposure into YAML and JSON budget policy with receipt fields.' },
             ].map((item) => (
               <Link key={item.href} href={item.href} className="block rounded-xl border border-gray-800 bg-black/40 p-5 transition hover:border-cyan-500/40 hover:bg-cyan-950/20">
                 <h3 className="mb-2 font-bold text-white">{item.title}</h3>
@@ -519,18 +522,18 @@ export default function ROICalculatorPage() {
           <p className="mb-2 text-sm font-mono uppercase tracking-wide text-green-300">Break-even examples</p>
           <h2 className="mb-4 text-2xl md:text-3xl font-bold text-white">When request-path budget enforcement pays for itself</h2>
           <p className="mb-8 max-w-3xl text-gray-400 leading-relaxed">
-            The calculator is most persuasive when it ties avoided waste to a specific operating model: internal agents, MCP tools, or external robot customers.
+            The calculator is most persuasive when it ties avoided waste to a specific operating model: internal agents, MCP tools, or externally exposed agent access.
           </p>
           <div className="grid gap-5 md:grid-cols-3">
             {[
-              ['Small team with one paid tool loop', 'A few dozen agents using a paid API can justify enforcement when one retry loop would exceed a monthly gateway subscription.', '/runaway-agent-cost-calculator'],
-              ['Enterprise MCP deployment', 'Hundreds of agents calling MCP tools need per-tool caps because provider dashboards miss spend outside LLM token invoices.', '/mcp-cost-control'],
-              ['External agent monetization', 'APIs exposed to robot customers can offset governance cost by charging with L402 before access is granted.', '/l402-api-pricing-calculator'],
+              ['Small team with one paid tool loop', 'A few dozen agents using a paid API can justify enforcement when one retry loop would exceed a monthly gateway subscription.', '/policy-to-proof'],
+              ['Enterprise MCP deployment', 'Hundreds of agents calling MCP tools need per-tool caps because provider dashboards miss spend outside LLM token invoices.', '/govern'],
+              ['External agent access', 'Externally exposed agent access needs scoped authority, budget checks, and receipts before execution.', '/policy-to-proof'],
             ].map(([title, body, href]) => (
               <Link key={title} href={href} className="rounded-xl border border-gray-800 bg-black/40 p-5 transition hover:border-green-500/50 hover:bg-green-950/20">
                 <h3 className="mb-2 font-bold text-white">{title}</h3>
                 <p className="mb-4 text-sm leading-relaxed text-gray-400">{body}</p>
-                <span className="text-sm font-semibold text-green-300">Model this scenario →</span>
+                <span className="text-sm font-semibold text-green-300">Map this to proof →</span>
               </Link>
             ))}
           </div>
@@ -594,7 +597,7 @@ export default function ROICalculatorPage() {
             <div>
               <h3 className="mb-2 text-xl font-bold text-white">What should I do after estimating runaway agent spend?</h3>
               <p className="text-gray-400 leading-relaxed">
-                Turn the exposure model into enforceable policy: generate budget limits, MCP tool caps, scoped capability-token policy, and request-path controls that block over-budget calls before cost is created.
+                Turn the exposure model into Policy-to-Proof controls: define authority, budget limits, MCP tool caps, scoped capability-token policy, receipts, and Evidence Pack exports.
               </p>
             </div>
             <div>
@@ -622,23 +625,23 @@ export default function ROICalculatorPage() {
       {/* CTA */}
       <section className="py-20 px-6 border-t border-gray-800">
         <div className="max-w-4xl mx-auto text-center">
-          <h2 className="text-2xl md:text-3xl font-bold mb-3">Start your free Shadow Audit</h2>
+          <h2 className="text-2xl md:text-3xl font-bold mb-3">Turn this ROI model into proof</h2>
           <p className="text-lg text-gray-400 mb-8 max-w-xl mx-auto">
-            See real numbers from your own infrastructure — not estimates.
+            SatGate checks authority before execution, records every policy decision as a receipt, and packages the evidence for review.
           </p>
           <div className="flex flex-col sm:flex-row items-center justify-center gap-4">
             <Link
-              href="/design-partners"
+              href="/govern"
               className="inline-block bg-gradient-to-r from-purple-600 to-cyan-600 text-white px-10 py-4 rounded-full font-bold text-lg hover:opacity-90 transition shadow-lg shadow-purple-500/20"
             >
-              Start Free Shadow Audit →
+              Govern agent actions →
             </Link>
-            <a
-              href="mailto:contact@satgate.io"
+            <Link
+              href="/policy-to-proof"
               className="inline-block border border-gray-700 text-gray-300 px-10 py-4 rounded-full font-bold text-lg hover:border-gray-500 hover:bg-gray-800 transition"
             >
-              Talk to Sales
-            </a>
+              See Policy-to-Proof
+            </Link>
           </div>
         </div>
       </section>

--- a/satgate-landing/scripts/check_policy_to_proof_page.py
+++ b/satgate-landing/scripts/check_policy_to_proof_page.py
@@ -9,6 +9,12 @@ GOVERN_PAGE = ROOT / "app" / "components" / "GovernClient.tsx"
 ECONOMIC_FIREWALL_PAGE = ROOT / "app" / "economic-firewall" / "page.tsx"
 READINESS_GRADER_PAGE = ROOT / "app" / "economic-firewall-readiness-grader" / "page.tsx"
 READINESS_GRADER_LAYOUT = ROOT / "app" / "economic-firewall-readiness-grader" / "layout.tsx"
+ROI_CALCULATOR_PAGE = ROOT / "app" / "roi-calculator" / "page.tsx"
+ROI_CALCULATOR_LAYOUT = ROOT / "app" / "roi-calculator" / "layout.tsx"
+AGENT_BUDGET_POLICY_PAGE = ROOT / "app" / "agent-spend-policy-template" / "page.tsx"
+AGENT_BUDGET_POLICY_LAYOUT = ROOT / "app" / "agent-spend-policy-template" / "layout.tsx"
+CAPABILITY_TOKEN_TEMPLATE_PAGE = ROOT / "app" / "revocable-capability-token-policy-template" / "page.tsx"
+CAPABILITY_TOKEN_TEMPLATE_LAYOUT = ROOT / "app" / "revocable-capability-token-policy-template" / "layout.tsx"
 
 required_phrases = [
     "Every agent action leaves a receipt",
@@ -219,6 +225,70 @@ readiness_forbidden_phrases = [
     "authority, cost, policy decision",
 ]
 
+tool_required_phrases = {
+    "roi-calculator": [
+        "Turn the ROI model into Policy-to-Proof",
+        "Evidence Pack",
+        "See Policy-to-Proof",
+        "Govern agent actions",
+        "Policy-to-Proof receipt coverage",
+        "Map ROI to Policy-to-Proof",
+    ],
+    "agent-budget-policy-template": [
+        "Agent Budget Policy Template",
+        "control_with_receipts",
+        "receipt_id",
+        "evidence_pack_id",
+        "Evidence Pack fields",
+        "See Policy-to-Proof",
+        "Govern agent execution",
+        "Create Evidence Pack trail",
+    ],
+    "revocable-capability-token-policy-template": [
+        "External agent access",
+        "policy:decision:read",
+        "receipt_id",
+        "evidence_pack_id",
+        "Evidence Pack evidence",
+        "See Policy-to-Proof",
+        "Govern agent authority",
+        "Create Evidence Pack trail",
+    ],
+}
+
+tool_forbidden_phrases = {
+    "roi-calculator": [
+        "robot customers",
+        "Charge Demo",
+        "L402 before access is granted",
+        "/pay",
+        "/l402-api-pricing-calculator",
+        "/runaway-agent-cost-calculator",
+        "Observe, Control, and Charge",
+    ],
+    "agent-budget-policy-template": [
+        "control_and_charge",
+        "Charge when robot customers pay",
+        "L402 payments",
+        "/ai-api-budget-enforcement",
+        "/agent-spending-limits",
+        "/mcp-cost-control",
+        "Agent Spend Policy Template",
+    ],
+    "revocable-capability-token-policy-template": [
+        "agent:robot-customer",
+        "paid-api-access",
+        "charge:l402:pay",
+        "Robot customer / L402",
+        "L402 Charge",
+        "Charge/L402",
+        "/agent-capability-tokens",
+        "/revocable-agent-credentials",
+        "/agent-api-key-risk-assessment",
+        "/economic-firewall-readiness-grader",
+    ],
+}
+
 
 def main() -> int:
     if not PAGE.exists():
@@ -257,6 +327,20 @@ def main() -> int:
     readiness_stale = [phrase for phrase in readiness_forbidden_phrases if phrase in readiness_text]
     if readiness_stale:
         raise SystemExit("stale readiness-grader spend/Charge phrases remain:\n" + "\n".join(readiness_stale))
+    tool_texts = {
+        "roi-calculator": ROI_CALCULATOR_PAGE.read_text() + "\n" + ROI_CALCULATOR_LAYOUT.read_text(),
+        "agent-budget-policy-template": AGENT_BUDGET_POLICY_PAGE.read_text() + "\n" + AGENT_BUDGET_POLICY_LAYOUT.read_text(),
+        "revocable-capability-token-policy-template": CAPABILITY_TOKEN_TEMPLATE_PAGE.read_text()
+        + "\n"
+        + CAPABILITY_TOKEN_TEMPLATE_LAYOUT.read_text(),
+    }
+    for name, tool_text in tool_texts.items():
+        tool_missing = [phrase for phrase in tool_required_phrases[name] if phrase not in tool_text]
+        if tool_missing:
+            raise SystemExit(f"missing {name} authority/proof phrases:\n" + "\n".join(tool_missing))
+        tool_stale = [phrase for phrase in tool_forbidden_phrases[name] if phrase in tool_text]
+        if tool_stale:
+            raise SystemExit(f"stale {name} spend/Charge/tool-exit phrases remain:\n" + "\n".join(tool_stale))
     return 0
 
 


### PR DESCRIPTION
## Summary
- aligns `/roi-calculator` exits around `/govern` and `/policy-to-proof` instead of legacy demo/tool chaining
- updates `/agent-spend-policy-template` into an agent budget policy template with receipt and Evidence Pack fields
- removes robot-customer/L402 Charge framing from the revocable capability-token template and routes high-intent exits to governance/proof pages
- extends the Policy-to-Proof regression guard to cover the three remaining public tools

## Verification
- `python3 scripts/check_policy_to_proof_page.py`
- `npx eslint app/roi-calculator/page.tsx app/roi-calculator/layout.tsx app/agent-spend-policy-template/page.tsx app/agent-spend-policy-template/layout.tsx app/revocable-capability-token-policy-template/page.tsx app/revocable-capability-token-policy-template/layout.tsx`
- `npm run build`
- local browser render verified for `/roi-calculator`, `/agent-spend-policy-template`, `/revocable-capability-token-policy-template`
- independent reviewer passed after follow-up UI card polish
