### PR TITLE
Align spend long-tail with Policy-to-Proof

### DIFF
--- a/satgate-landing/app/agent-payment-controls/page.tsx
+++ b/satgate-landing/app/agent-payment-controls/page.tsx
@@ -2,8 +2,8 @@ import Link from 'next/link';
 import { ArrowRight, BellRing, CheckCircle2, CreditCard, FileSearch, Gauge, KeyRound, ShieldCheck } from 'lucide-react';
 
 export const metadata = {
-  title: 'Agent Payment Controls for AI Agents',
-  description: 'Agent payment controls combine budgets, policy, metering, revocation, audit, HTTP 402, and L402 API monetization before requests execute.',
+  title: 'Agent Payment Controls | Policy Before Agent Payments',
+  description: 'Agent payment controls combine budgets, policy, scoped authority, revocation, metering, paid-rail context, and audit receipts before requests execute.',
   alternates: { canonical: 'https://satgate.io/agent-payment-controls' },
   keywords: [
     'agent payment controls',
@@ -13,17 +13,17 @@ export const metadata = {
     'agent payment policy',
     'agent spend control',
     'HTTP 402 agents',
-    'L402 API monetization',
+    'paid-rail agent governance',
   ],
   openGraph: {
-    title: 'Agent Payment Controls for AI Agents',
-    description: 'Wallet approval is necessary but not sufficient. SatGate adds request-path budgets, policy, audit, metering, and L402 Charge.',
+    title: 'Agent Payment Controls | Policy Before Agent Payments',
+    description: 'Wallet approval is necessary but not sufficient. SatGate adds request-path budgets, scoped authority, metering, revocation, and audit receipts.',
     url: 'https://satgate.io/agent-payment-controls',
     type: 'article',
   },
   twitter: {
     card: 'summary_large_image',
-    title: 'Agent Payment Controls for AI Agents',
+    title: 'Agent Payment Controls | Policy Before Agent Payments',
     description: 'Control agent payments before they become runaway API, MCP, and model spend.',
   },
 };
@@ -31,8 +31,8 @@ export const metadata = {
 const controls = [
   { icon: KeyRound, title: 'Agent identity', body: 'Know which tenant, agent, workflow, delegated sub-agent, route, and token caused the economic action.' },
   { icon: Gauge, title: 'Budgets', body: 'Enforce hard limits by agent, route, model, MCP tool, workflow, tenant, and time window before requests execute.' },
-  { icon: ShieldCheck, title: 'Policy', body: 'Allow, deny, meter, require approval, charge, or revoke based on risk, scope, price, and authority.' },
-  { icon: FileSearch, title: 'Audit', body: 'Record request, cost, payment challenge, policy decision, credential, proof, and upstream outcome.' },
+  { icon: ShieldCheck, title: 'Policy', body: 'Allow, deny, meter, require approval, preserve paid context, or revoke based on risk, scope, price, and authority.' },
+  { icon: FileSearch, title: 'Evidence Pack receipts', body: 'Record request, cost, payment challenge, policy decision, credential, proof, and upstream outcome.' },
   { icon: CreditCard, title: 'Payment rail awareness', body: 'Understand whether a flow uses card credentials, shared payment tokens, L402 Lightning, or another 402 challenge.' },
   { icon: BellRing, title: 'Human approval', body: 'Escalate only the decisions humans should make, instead of turning every agent request into a manual checkpoint.' },
 ];
@@ -41,7 +41,7 @@ export default function AgentPaymentControlsPage() {
   const articleJsonLd = {
     '@context': 'https://schema.org',
     '@type': 'TechArticle',
-    headline: 'Agent Payment Controls for AI Agents',
+    headline: 'Agent Payment Controls | Policy Before Agent Payments',
     description: metadata.description,
     author: { '@type': 'Organization', name: 'SatGate' },
     publisher: { '@type': 'Organization', name: 'SatGate', url: 'https://satgate.io' },
@@ -56,8 +56,8 @@ export default function AgentPaymentControlsPage() {
     mainEntity: [
       { '@type': 'Question', name: 'What are agent payment controls?', acceptedAnswer: { '@type': 'Answer', text: 'Agent payment controls are the policies, budgets, approvals, audit trails, and request-path enforcement that govern how AI agents spend money or unlock paid API access.' } },
       { '@type': 'Question', name: 'Is wallet approval enough for AI agent payments?', acceptedAnswer: { '@type': 'Answer', text: 'No. Wallet approval can authorize a purchase, but teams also need identity, budgets, scoped access, revocation, API metering, and audit before agent requests execute.' } },
-      { '@type': 'Question', name: 'How does SatGate help with agent payment controls?', acceptedAnswer: { '@type': 'Answer', text: 'SatGate sits in the request path to observe agent activity, control budgets and policy, and charge for API access with L402 Lightning when APIs become agent-native products.' } },
-      { '@type': 'Question', name: 'How are HTTP 402 and L402 related to agent payment controls?', acceptedAnswer: { '@type': 'Answer', text: 'HTTP 402 gives APIs a protocol-level way to request payment. L402 adds Lightning payment and proof. SatGate Charge uses L402 Lightning, while other 402 methods such as shared payment tokens are separate rails.' } },
+      { '@type': 'Question', name: 'How does SatGate help with agent payment controls?', acceptedAnswer: { '@type': 'Answer', text: 'SatGate sits in the request path to observe agent activity, enforce budgets and policy, preserve paid-rail context, and record receipts before requests execute.' } },
+      { '@type': 'Question', name: 'How are HTTP 402 and L402 related to agent payment controls?', acceptedAnswer: { '@type': 'Answer', text: 'HTTP 402 gives APIs a protocol-level way to request payment. L402, x402, shared payment tokens, cards, and enterprise billing are payment rails; agent payment controls decide whether the agent has authority before access is granted.' } },
     ],
   };
 
@@ -83,17 +83,17 @@ export default function AgentPaymentControlsPage() {
             <CreditCard size={16} /> Agent payment governance
           </div>
           <h1 className="text-5xl md:text-7xl font-extrabold tracking-tight max-w-5xl mb-8">
-            Agent Payment Controls Need More Than Wallet Approval
+            Agent Payment Controls Start With Policy Before Payment
           </h1>
           <p className="text-xl md:text-2xl text-gray-300 max-w-4xl leading-relaxed mb-10">
-            AI agents can use wallets, cards, shared payment tokens, HTTP 402 challenges, and L402 payments. The missing layer is policy: who may spend, how much, on what, and with what audit trail.
+            AI agents can use wallets, cards, shared payment tokens, HTTP 402 challenges, L402, x402, or enterprise billing rails. The control layer is policy: who may spend, how much, on what authority, and with what receipt.
           </p>
           <div className="flex flex-col sm:flex-row gap-4">
-            <Link href="/agent-spend-policy-template" className="inline-flex items-center justify-center gap-2 rounded-lg bg-white text-black px-6 py-3 font-bold hover:bg-gray-200 transition">
-              Generate a spend policy <ArrowRight size={18} />
+            <Link href="/govern" className="inline-flex items-center justify-center gap-2 rounded-lg bg-white text-black px-6 py-3 font-bold hover:bg-gray-200 transition">
+              Govern agent payments <ArrowRight size={18} />
             </Link>
-            <Link href="/stripe-link-agents-vs-satgate" className="inline-flex items-center justify-center gap-2 rounded-lg border border-gray-700 px-6 py-3 font-bold text-white hover:border-yellow-500 transition">
-              Compare Link and SatGate
+            <Link href="/policy-to-proof" className="inline-flex items-center justify-center gap-2 rounded-lg border border-gray-700 px-6 py-3 font-bold text-white hover:border-yellow-500 transition">
+              See Policy-to-Proof
             </Link>
           </div>
         </div>
@@ -103,19 +103,19 @@ export default function AgentPaymentControlsPage() {
         <div className="space-y-5 text-gray-300 text-lg leading-relaxed">
           <h2 className="text-3xl font-bold text-white mb-6">The payment credential is only one decision</h2>
           <p>
-            Agent wallets are useful. They can issue temporary credentials, request approval, and keep the user's raw payment method away from the agent. But payment approval does not answer whether the request should happen.
+            Agent wallets are useful. They can issue temporary credentials, request approval, and keep the user&apos;s raw payment method away from the agent. But payment approval does not answer whether the request should happen.
           </p>
           <p>
-            A company still needs to know which agent is acting, which route or MCP tool it is touching, what the action will cost, whether budget remains, whether scope is valid, and whether the outcome should be charged, blocked, or audited.
+            A company still needs to know which agent is acting, which route or MCP tool it is touching, what the action will cost, whether budget remains, whether scope is valid, and whether the outcome should be allowed, denied, paid, or recorded in the Evidence Pack.
           </p>
           <p>
-            SatGate adds that missing request-path layer: Observe the economic activity, Control policy and budgets, and Charge with L402 Lightning when API access itself becomes the product.
+            SatGate adds that missing request-path layer: observe economic activity, enforce policy and budgets, preserve paid-rail context, and record a receipt before access is granted.
           </p>
         </div>
         <div className="rounded-2xl border border-yellow-900/50 bg-yellow-950/10 p-6">
           <h3 className="text-xl font-bold text-white mb-4">Before an agent spends, ask</h3>
           <div className="space-y-3 text-sm">
-            {['Who is the agent?', 'What authority does it have?', 'What will this request cost?', 'Does budget remain?', 'Is the payment rail allowed?', 'Should a human approve, or should policy decide?'].map((item) => (
+            {['Who is the agent?', 'What authority does it have?', 'What scoped authority is it using?', 'Does budget remain?', 'Is the payment rail allowed?', 'Should the request be allowed, denied, paid, or recorded in the Evidence Pack?'].map((item) => (
               <div key={item} className="flex items-start gap-3 rounded-lg border border-gray-800 bg-black/50 p-3">
                 <CheckCircle2 className="text-yellow-300 mt-0.5" size={18} />
                 <span className="text-gray-300">{item}</span>
@@ -148,8 +148,8 @@ export default function AgentPaymentControlsPage() {
         <div className="grid md:grid-cols-2 gap-5">
           {[
             ['Cards and one-time credentials', 'Useful for merchant checkout. SatGate still governs API and tool access before downstream spend patterns become uncontrolled.'],
-            ['Shared payment tokens', 'Useful for some machine-payment 402 flows. Treat them as a separate rail from SatGate Charge/L402.'],
-            ['L402 Lightning payments', 'SatGate Charge uses L402 Lightning to let robot customers pay APIs in the request path.'],
+            ['Shared payment tokens', 'Useful for some machine-payment 402 flows. Treat them as one rail that still needs request-path policy, scope, and audit.'],
+            ['L402 and x402 payment rails', 'Useful payment contexts for agent-access flows. SatGate should preserve the rail, proof, policy decision, and receipt without making the rail the control layer.'],
             ['MCP priced tool calls', 'Agents need budget and policy on tool execution whether the tool charges directly or triggers paid upstream work.'],
           ].map(([title, body]) => (
             <div key={title} className="rounded-xl border border-gray-800 bg-gray-950 p-6">
@@ -171,7 +171,7 @@ export default function AgentPaymentControlsPage() {
               ['Purchase approval', 'Ask the user to approve a purchase', 'Decide whether policy allows the agent to attempt the spend'],
               ['Credential safety', 'Issue temporary credentials or tokens', 'Scope, revoke, and audit capability after authorization'],
               ['Budgeting', 'May cap specific approved transactions', 'Enforce budgets across routes, tools, models, tenants, and workflows'],
-              ['API monetization', 'Pay a merchant or endpoint', 'Quote, verify, and unlock paid API access with L402 Charge'],
+              ['Paid API access', 'Pay a merchant or endpoint', 'Preserve payment context, verify policy, and unlock access only when authority and budget allow it'],
             ].map(([control, wallet, firewall]) => (
               <div key={control} className="grid md:grid-cols-3 border-t border-gray-800 text-gray-300">
                 <div className="p-4 font-semibold text-white">{control}</div><div className="p-4">{wallet}</div><div className="p-4">{firewall}</div>
@@ -188,8 +188,8 @@ export default function AgentPaymentControlsPage() {
             {[
               ['What are agent payment controls?', 'Agent payment controls are the policies, budgets, approvals, audit trails, and request-path enforcement that govern how AI agents spend money or unlock paid API access.'],
               ['Is wallet approval enough for AI agent payments?', 'No. Wallet approval can authorize a purchase, but teams also need identity, budgets, scoped access, revocation, API metering, and audit before agent requests execute.'],
-              ['How does SatGate help with agent payment controls?', 'SatGate sits in the request path to observe agent activity, control budgets and policy, and charge for API access with L402 Lightning when APIs become agent-native products.'],
-              ['How are HTTP 402 and L402 related to agent payment controls?', 'HTTP 402 gives APIs a protocol-level way to request payment. L402 adds Lightning payment and proof. SatGate Charge uses L402 Lightning, while other 402 methods such as shared payment tokens are separate rails.'],
+              ['How does SatGate help with agent payment controls?', 'SatGate sits in the request path to observe agent activity, enforce budgets and policy, preserve paid-rail context, and record receipts before requests execute.'],
+              ['How are HTTP 402 and L402 related to agent payment controls?', 'HTTP 402 gives APIs a protocol-level way to request payment. L402, x402, shared payment tokens, cards, and enterprise billing are payment rails; agent payment controls decide whether the agent has authority before access is granted.'],
             ].map(([question, answer]) => (
               <div key={question} className="rounded-xl border border-gray-800 bg-black p-5">
                 <h3 className="mb-2 font-bold text-white">{question}</h3>
@@ -202,14 +202,14 @@ export default function AgentPaymentControlsPage() {
         <div className="rounded-3xl border border-yellow-900/60 bg-gradient-to-br from-yellow-950/20 to-cyan-950/30 p-8 md:p-12">
           <h2 className="text-3xl font-bold text-white mb-4">Put policy before payment</h2>
           <p className="text-gray-300 text-lg leading-relaxed max-w-3xl mb-8">
-            SatGate gives teams the economic control plane for agent payments: request-path metering, spend limits, revocation, audit, and L402 Charge when APIs become agent-native products.
+            SatGate gives teams the economic control plane for agent payments: request-path metering, spend limits, revocation, paid-rail context, audit receipts, and Policy-to-Proof evidence when access is granted.
           </p>
           <div className="flex flex-col sm:flex-row gap-4">
-            <Link href="/economic-firewall" className="inline-flex items-center justify-center gap-2 rounded-lg bg-white text-black px-6 py-3 font-bold hover:bg-gray-200 transition">
-              Learn the economic firewall <ArrowRight size={18} />
+            <Link href="/govern" className="inline-flex items-center justify-center gap-2 rounded-lg bg-white text-black px-6 py-3 font-bold hover:bg-gray-200 transition">
+              Govern agent payments <ArrowRight size={18} />
             </Link>
-            <Link href="/http-402-for-ai-agents" className="inline-flex items-center justify-center gap-2 rounded-lg border border-gray-700 px-6 py-3 font-bold text-white hover:border-yellow-500 transition">
-              Read HTTP 402 for agents
+            <Link href="/policy-to-proof" className="inline-flex items-center justify-center gap-2 rounded-lg border border-gray-700 px-6 py-3 font-bold text-white hover:border-yellow-500 transition">
+              Review Policy-to-Proof
             </Link>
           </div>
         </div>

--- a/satgate-landing/app/agent-spending-limits/page.tsx
+++ b/satgate-landing/app/agent-spending-limits/page.tsx
@@ -1,9 +1,9 @@
 import Link from 'next/link';
-import { ArrowRight, Ban, BarChart3, Bot, DollarSign, Gauge, KeyRound, ReceiptText, ShieldCheck } from 'lucide-react';
+import { ArrowRight, Ban, BarChart3, Bot, DollarSign, Gauge, KeyRound, ReceiptText } from 'lucide-react';
 
 export const metadata = {
   title: 'Agent Spending Limits | Spend Caps for Autonomous AI Agents',
-  description: 'Set AI agent spending limits by task, route, tool, model, tenant, workflow, session, and day. Block over-budget requests before spend occurs.',
+  description: 'Set AI agent spending limits by task, route, tool, model, tenant, workflow, session, and day. Enforce authority, revocation, and audit receipts before spend occurs.',
   alternates: { canonical: 'https://satgate.io/agent-spending-limits' },
   keywords: [
     'agent spending limits',
@@ -18,14 +18,14 @@ export const metadata = {
   ],
   openGraph: {
     title: 'Agent Spending Limits | Spend Caps for Autonomous AI Agents',
-    description: 'Set AI agent spending limits by task, route, tool, model, tenant, workflow, session, and day before spend occurs.',
+    description: 'Set AI agent spending limits by task, route, tool, model, tenant, workflow, session, and day with authority and audit receipts before spend occurs.',
     url: 'https://satgate.io/agent-spending-limits',
     type: 'website',
   },
   twitter: {
     card: 'summary_large_image',
     title: 'Agent Spending Limits | Spend Caps for Autonomous AI Agents',
-    description: 'Set AI agent spending limits by task, route, tool, model, tenant, workflow, session, and day before spend occurs.',
+    description: 'Set AI agent spending limits by task, route, tool, model, tenant, workflow, session, and day with authority and audit receipts before spend occurs.',
   },
 };
 
@@ -67,7 +67,7 @@ export default function Page() {
     url: 'https://satgate.io/agent-spending-limits',
     publisher: { '@type': 'Organization', name: 'SatGate', url: 'https://satgate.io' },
     dateModified: '2026-05-03',
-    featureList: ['Request-path budget enforcement', 'AI agent spend caps', 'MCP tool cost control', 'Revocable credentials', 'Audit trails'],
+    featureList: ['Request-path budget enforcement', 'AI agent spend caps', 'MCP tool cost control', 'Revocable credentials', 'Audit receipts', 'Policy-to-Proof evidence'],
     audience: { '@type': 'Audience', audienceType: 'AI platform, API, finance, and security teams' },
   };
 
@@ -105,10 +105,11 @@ export default function Page() {
         <div className="relative mx-auto max-w-6xl px-6 py-24">
           <div className="mb-8 inline-flex items-center gap-2 rounded-full border border-cyan-500/30 bg-cyan-950/30 px-4 py-2 text-sm text-cyan-200"><Gauge size={16} /> Spend caps for autonomous workers</div>
           <h1 className="mb-8 max-w-5xl text-5xl font-extrabold tracking-tight md:text-7xl">Agent spending limits should stop the next request, not explain the last bill</h1>
-          <p className="mb-10 max-w-4xl text-xl leading-relaxed text-gray-300 md:text-2xl">Autonomous agents need hard spending limits that apply per task, workflow, delegated sub-agent, model, tool, API route, and time window. SatGate enforces those limits before requests execute.</p>
+          <p className="mb-10 max-w-4xl text-xl leading-relaxed text-gray-300 md:text-2xl">Autonomous agents need hard spending limits that apply per task, workflow, delegated sub-agent, model, tool, API route, and time window. SatGate enforces authority before execution and records a receipt for every budget decision.</p>
           <div className="flex flex-col gap-4 sm:flex-row">
-            <Link href="/runaway-agent-cost-calculator" className="inline-flex items-center justify-center gap-2 rounded-lg bg-white px-6 py-3 font-bold text-black transition hover:bg-gray-200">Model runaway spend <ArrowRight size={18} /></Link>
-            <Link href="/ai-agent-runaway-spend-benchmark" className="inline-flex items-center justify-center gap-2 rounded-lg border border-gray-700 px-6 py-3 font-bold text-white transition hover:border-cyan-500">See benchmark data</Link>
+            <Link href="/govern" className="inline-flex items-center justify-center gap-2 rounded-lg bg-white px-6 py-3 font-bold text-black transition hover:bg-gray-200">Govern agent spending limits <ArrowRight size={18} /></Link>
+            <Link href="/runaway-agent-cost-calculator" className="inline-flex items-center justify-center gap-2 rounded-lg border border-gray-700 px-6 py-3 font-bold text-white transition hover:border-cyan-500">Model runaway spend</Link>
+            <Link href="/policy-to-proof" className="inline-flex items-center justify-center gap-2 rounded-lg border border-gray-700 px-6 py-3 font-bold text-white transition hover:border-cyan-500">See Policy-to-Proof</Link>
           </div>
         </div>
       </section>
@@ -118,7 +119,7 @@ export default function Page() {
           <h2 className="mb-6 text-3xl font-bold text-white">The control point is before the call</h2>
           <div className="space-y-5 text-lg leading-relaxed text-gray-300">
             <p>Autonomous agents can generate real costs through model calls, API requests, MCP tools, delegated sub-agents, retries, and background workflows. If the policy check happens after the request, the money is already spent.</p>
-            <p>SatGate enforces economic policy at the gateway boundary. Every important request can be evaluated against budget, scope, identity, revocation, route, tool, and audit rules before upstream access.</p>
+            <p>SatGate enforces economic policy at the gateway boundary. Every important request can be evaluated against budget, scope, identity, revocation, route, tool, receipt, and audit rules before upstream access.</p>
             <p>That is the difference between cost reporting and economic control.</p>
           </div>
         </div>
@@ -191,10 +192,10 @@ export default function Page() {
       <section className="mx-auto max-w-6xl px-6 py-20">
         <div className="rounded-3xl border border-purple-900/60 bg-gradient-to-br from-purple-950/35 to-cyan-950/20 p-8 md:p-12">
           <h2 className="mb-4 text-3xl font-bold text-white">Make agent economics enforceable.</h2>
-          <p className="mb-8 max-w-3xl text-lg leading-relaxed text-gray-300">SatGate is the economic firewall for AI agents: observe every request, control spend before execution, and charge robot customers when paid API access should unlock.</p>
+          <p className="mb-8 max-w-3xl text-lg leading-relaxed text-gray-300">SatGate is the economic firewall for AI agents: observe every request, enforce spending limits before execution, and preserve receipts for budget, revocation, and access decisions.</p>
           <div className="flex flex-col gap-4 sm:flex-row">
-            <Link href="/tools" className="inline-flex items-center justify-center gap-2 rounded-lg bg-white px-6 py-3 font-bold text-black transition hover:bg-gray-200">Open free tools <ArrowRight size={18} /></Link>
-            <Link href="/economic-firewall" className="inline-flex items-center justify-center gap-2 rounded-lg border border-gray-700 px-6 py-3 font-bold text-white transition hover:border-cyan-500">Economic firewall</Link>
+            <Link href="/govern" className="inline-flex items-center justify-center gap-2 rounded-lg bg-white px-6 py-3 font-bold text-black transition hover:bg-gray-200">Govern agent spending limits <ArrowRight size={18} /></Link>
+            <Link href="/policy-to-proof" className="inline-flex items-center justify-center gap-2 rounded-lg border border-gray-700 px-6 py-3 font-bold text-white transition hover:border-cyan-500">Review Policy-to-Proof</Link>
           </div>
         </div>
       </section>

--- a/satgate-landing/app/ai-agent-cost-control/page.tsx
+++ b/satgate-landing/app/ai-agent-cost-control/page.tsx
@@ -2,8 +2,8 @@ import Link from 'next/link';
 import { ArrowRight, Bot, DollarSign, Gauge, ShieldCheck, Workflow, BarChart3 } from 'lucide-react';
 
 export const metadata = {
-  title: 'AI Agent Cost Control Software',
-  description: 'Control AI agent API spend before it happens. SatGate enforces budgets, revocation, routing, and audit trails in the request path.',
+  title: 'AI Agent Cost Control | Request-Path Budget Enforcement',
+  description: 'Control AI agent API spend before it happens. SatGate enforces budgets, revocation, routing, and audit receipts in the request path.',
   alternates: { canonical: 'https://satgate.io/ai-agent-cost-control' },
   keywords: [
     'AI agent cost control',
@@ -16,15 +16,15 @@ export const metadata = {
     'AI cost governance',
   ],
   openGraph: {
-    title: 'AI Agent Cost Control Software',
-    description: 'Enforce per-agent budgets, spend caps, revocation, routing, and audit trails before autonomous API calls execute.',
+    title: 'AI Agent Cost Control | Request-Path Budget Enforcement',
+    description: 'Enforce per-agent budgets, spend caps, revocation, routing, and audit receipts before autonomous API calls execute.',
     url: 'https://satgate.io/ai-agent-cost-control',
     type: 'website',
   },
   twitter: {
     card: 'summary_large_image',
-    title: 'AI Agent Cost Control Software',
-    description: 'Stop runaway AI agent spend with request-path budget enforcement, revocation, routing, and audit trails.',
+    title: 'AI Agent Cost Control | Request-Path Budget Enforcement',
+    description: 'Stop runaway AI agent spend with request-path budget enforcement, revocation, routing, and audit receipts.',
   },
 };
 
@@ -65,7 +65,7 @@ export default function AiAgentCostControlPage() {
   const webPageJsonLd = {
     '@context': 'https://schema.org',
     '@type': 'WebPage',
-    name: 'AI Agent Cost Control Software',
+    name: 'AI Agent Cost Control | Request-Path Budget Enforcement',
     description: metadata.description,
     url: 'https://satgate.io/ai-agent-cost-control',
     dateModified: '2026-05-05',
@@ -96,8 +96,8 @@ export default function AiAgentCostControlPage() {
       'Per-tool cost attribution',
       'MCP budget enforcement',
       'Revocable agent credentials',
-      'Request-path audit trails',
-      'L402 API monetization',
+      'Request-path audit receipts',
+      'Policy-to-Proof Evidence Packs',
     ],
   };
 
@@ -110,7 +110,7 @@ export default function AiAgentCostControlPage() {
         name: 'What is AI agent cost control?',
         acceptedAnswer: {
           '@type': 'Answer',
-          text: 'AI agent cost control is the practice of attributing, budgeting, limiting, and auditing autonomous agent API and tool spend before requests execute.',
+          text: 'AI agent cost control is the practice of attributing, budgeting, limiting, and preserving receipts for autonomous agent API and tool spend before requests execute.',
         },
       },
       {
@@ -191,8 +191,8 @@ export default function AiAgentCostControlPage() {
       {
         '@type': 'ListItem',
         position: 4,
-        name: 'Economic audit trail',
-        description: 'Allowed, denied, charged, routed, and revoked requests leave evidence finance and security can review.',
+        name: 'Evidence Pack capture',
+        description: 'Allowed, denied, delegated, routed, paid, and revoked requests leave receipts finance and security can review.',
       },
     ],
   };
@@ -224,8 +224,8 @@ export default function AiAgentCostControlPage() {
       {
         '@type': 'ListItem',
         position: 4,
-        name: 'Add Charge for robot customers',
-        description: 'When external agents call high-value APIs, require L402 payment before granting access.',
+        name: 'Preserve proof for paid access',
+        description: 'When paid access is allowed, preserve the policy decision, payment context, and receipt before granting access.',
       },
     ],
   };
@@ -260,18 +260,18 @@ export default function AiAgentCostControlPage() {
           </h1>
 
           <p className="text-xl md:text-2xl text-gray-300 max-w-4xl leading-relaxed mb-10">
-            SatGate puts budget enforcement, revocation, routing, and audit trails in the request path so autonomous agents cannot silently burn through OpenAI, Claude, MCP, or paid API budgets.
+            SatGate puts authority before execution: budget enforcement, revocation, routing, and audit receipts run in the request path before autonomous agents can spend against OpenAI, Claude, MCP, or paid API budgets.
           </p>
 
           <div className="flex flex-col sm:flex-row gap-4">
-            <Link href="/roi-calculator" className="inline-flex items-center justify-center gap-2 rounded-lg bg-white text-black px-6 py-3 font-bold hover:bg-gray-200 transition">
-              Estimate avoided spend <ArrowRight size={18} />
+            <Link href="/govern" className="inline-flex items-center justify-center gap-2 rounded-lg bg-white text-black px-6 py-3 font-bold hover:bg-gray-200 transition">
+              Govern agent spend <ArrowRight size={18} />
             </Link>
-            <Link href="/economic-firewall" className="inline-flex items-center justify-center gap-2 rounded-lg border border-gray-700 px-6 py-3 font-bold text-white hover:border-cyan-500 transition">
-              Learn economic firewalls
+            <Link href="/policy-to-proof" className="inline-flex items-center justify-center gap-2 rounded-lg border border-gray-700 px-6 py-3 font-bold text-white hover:border-cyan-500 transition">
+              See Policy-to-Proof
             </Link>
-            <Link href="/llm-cost-dashboard" className="inline-flex items-center justify-center gap-2 rounded-lg border border-gray-700 px-6 py-3 font-bold text-white hover:border-cyan-500 transition">
-              LLM cost dashboard checklist
+            <Link href="/roi-calculator" className="inline-flex items-center justify-center gap-2 rounded-lg border border-gray-700 px-6 py-3 font-bold text-white hover:border-cyan-500 transition">
+              Estimate avoided spend
             </Link>
           </div>
         </div>
@@ -285,10 +285,10 @@ export default function AiAgentCostControlPage() {
               LLM dashboards, provider billing pages, and token reports are useful after the fact. They tell you what happened. They do not stop an autonomous agent from calling a premium model, retrying a failed tool, or delegating a task into a thousand-dollar loop.
             </p>
             <p>
-              AI agent cost control has to be inline. Every request needs an economic decision before it reaches the upstream provider: who is calling, what route is allowed, what the request costs, whether budget remains, and what should be recorded.
+              AI agent cost control has to be inline. Every request needs an economic decision before it reaches the upstream provider: who is calling, what authority applies, what route is allowed, what the request costs, whether budget remains, and which receipt should be recorded.
             </p>
             <p>
-              SatGate enforces those decisions at the gateway layer across internal agents, MCP tools, hosted APIs, model providers, and external robot customers.
+              SatGate enforces those decisions at the gateway layer across internal agents, MCP tools, hosted APIs, model providers, and paid external-access flows.
             </p>
           </div>
         </div>
@@ -325,7 +325,7 @@ export default function AiAgentCostControlPage() {
       </section>
 
       <section className="max-w-6xl mx-auto px-6 py-20">
-        <h2 className="text-3xl font-bold text-white mb-8">Start with Observe. Graduate to Control. Add Charge when agents become customers.</h2>
+        <h2 className="text-3xl font-bold text-white mb-8">Start with Observe. Graduate to Control. Preserve proof when value moves.</h2>
         <div className="grid lg:grid-cols-3 gap-6">
           <div className="rounded-2xl border border-gray-800 bg-gray-950 p-6">
             <div className="text-purple-300 font-mono text-sm mb-3">01 / OBSERVE</div>
@@ -338,9 +338,9 @@ export default function AiAgentCostControlPage() {
             <p className="text-gray-400 leading-relaxed">Apply hard caps, per-request ceilings, route policy, revocation, expiry, and kill switches before the expensive call happens.</p>
           </div>
           <div className="rounded-2xl border border-gray-800 bg-gray-950 p-6">
-            <div className="text-yellow-300 font-mono text-sm mb-3">03 / CHARGE</div>
-            <h3 className="text-xl font-bold text-white mb-3">Monetize agent access</h3>
-            <p className="text-gray-400 leading-relaxed">When APIs become products for external autonomous agents, collect payment with Charge/L402 before unlocking the protected resource.</p>
+            <div className="text-yellow-300 font-mono text-sm mb-3">03 / PROOF</div>
+            <h3 className="text-xl font-bold text-white mb-3">Preserve paid-access evidence</h3>
+            <p className="text-gray-400 leading-relaxed">When value moves, record the policy decision, payment context, route, authority, and receipt before unlocking the protected resource.</p>
           </div>
         </div>
       </section>
@@ -356,7 +356,7 @@ export default function AiAgentCostControlPage() {
               ['MCP tool spend control', 'Attach cost to tool calls and stop runaway Cursor, Claude Desktop, Claude Code, or OpenClaw workflows.', '/mcp-cost-control'],
               ['Revocable agent credentials', 'Replace broad static keys with scoped, expiring credentials and kill switches for autonomous workers.', '/revocable-agent-credentials'],
               ['Capability-token policy template', 'Generate scoped, expiring, revocable capability-token policy with budget, delegation, and audit caveats.', '/revocable-capability-token-policy-template'],
-              ['Robot customer payments', 'Let external agents pay for protected APIs through a governed request path.', '/robot-customer-payments'],
+              ['Agent payment controls', 'Govern wallet approval, payment context, budgets, and audit before protected API access.', '/agent-payment-controls'],
             ].map(([title, body, href]) => (
               <Link key={title} href={href} className="rounded-xl border border-gray-800 bg-black p-6 hover:border-cyan-800/70 transition block">
                 <h3 className="text-xl font-bold text-white mb-2">{title}</h3>
@@ -380,7 +380,7 @@ export default function AiAgentCostControlPage() {
               ['Inline enforcement', 'Budget policy runs before model, API, or MCP tool execution — not after a billing export.'],
               ['Agent-level attribution', 'Every request maps to tenant, workflow, agent, delegated sub-agent, token, route, and tool.'],
               ['Revocable authority', 'Credentials can expire, narrow, delegate safely, or be killed without rotating shared API keys.'],
-              ['Economic audit trail', 'Allowed, denied, charged, routed, and revoked requests leave evidence finance and security can review.'],
+              ['Evidence Pack capture', 'Allowed, denied, delegated, routed, paid, and revoked requests leave receipts finance and security can review.'],
             ].map(([title, body]) => (
               <div key={title} className="rounded-xl border border-gray-800 bg-gray-950 p-5">
                 <h3 className="mb-2 font-bold text-white">{title}</h3>
@@ -422,7 +422,7 @@ export default function AiAgentCostControlPage() {
               ['Inventory exposure', 'Map agents, shared API keys, MCP tools, paid APIs, premium models, and workflows that can create cost.', '/agent-api-key-risk-assessment'],
               ['Observe first', 'Route traffic through SatGate to attribute spend by tenant, agent, workflow, route, model, and tool before blocking.', '/llm-cost-monitoring'],
               ['Enforce budgets', 'Apply per-agent budgets, MCP caps, route ceilings, expiry, delegation limits, and revocation policy in the request path.', '/agent-spend-policy-template'],
-              ['Charge robot customers', 'When external agents call high-value APIs, require L402 payment before granting access.', '/robot-customer-payments'],
+              ['Preserve paid-access proof', 'Record policy decisions, payment context, and receipts before granting paid external access.', '/policy-to-proof'],
             ].map(([title, body, href]) => (
               <Link key={title} href={href} className="rounded-xl border border-gray-800 bg-gray-950 p-5 transition hover:border-cyan-500/50 hover:bg-cyan-950/20">
                 <h3 className="mb-2 font-bold text-white">{title}</h3>
@@ -433,7 +433,7 @@ export default function AiAgentCostControlPage() {
           </div>
           <div className="mt-8 rounded-2xl border border-purple-900/50 bg-purple-950/10 p-6">
             <h3 className="mb-2 text-xl font-bold text-white">Need a readiness score first?</h3>
-            <p className="mb-4 text-gray-400">Use the grader to see whether identity, budget policy, MCP governance, revocation, audit, routing, and Charge are ready for autonomous agents.</p>
+            <p className="mb-4 text-gray-400">Use the grader to see whether identity, budget policy, MCP governance, revocation, audit, routing, and paid-rail evidence are ready for autonomous agents.</p>
             <Link href="/economic-firewall-readiness-grader" className="inline-flex items-center gap-2 font-semibold text-purple-300 hover:text-purple-200">Run the economic firewall readiness grader <ArrowRight size={16} /></Link>
           </div>
         </div>
@@ -470,7 +470,7 @@ export default function AiAgentCostControlPage() {
             <div className="rounded-xl border border-gray-800 bg-gray-950 p-6">
               <h3 className="mb-2 text-xl font-bold text-white">What is AI agent cost control?</h3>
               <p className="text-gray-400 leading-relaxed">
-                AI agent cost control is the practice of attributing, budgeting, limiting, and auditing autonomous agent API and tool spend before requests execute.
+                AI agent cost control is the practice of attributing, budgeting, limiting, and preserving receipts for autonomous agent API and tool spend before requests execute.
               </p>
             </div>
             <div className="rounded-xl border border-gray-800 bg-gray-950 p-6">
@@ -517,7 +517,7 @@ export default function AiAgentCostControlPage() {
         <div className="rounded-3xl border border-purple-900/60 bg-gradient-to-br from-purple-950/30 to-cyan-950/30 p-8 md:p-12">
           <h2 className="text-3xl font-bold text-white mb-4">Find your avoidable agent spend</h2>
           <p className="text-gray-300 text-lg leading-relaxed max-w-3xl mb-8">
-            Use the SatGate ROI calculator to model ghost spend, runaway loops, wasted tool calls, and the payback period for request-path budget enforcement.
+            Use the SatGate ROI calculator to model ghost spend, runaway loops, wasted tool calls, and the payback period for request-path budget enforcement with Policy-to-Proof receipt coverage.
           </p>
           <Link href="/roi-calculator" className="inline-flex items-center justify-center gap-2 rounded-lg bg-white text-black px-6 py-3 font-bold hover:bg-gray-200 transition">
             Open the ROI calculator <ArrowRight size={18} />

--- a/satgate-landing/app/ai-api-budget-enforcement/page.tsx
+++ b/satgate-landing/app/ai-api-budget-enforcement/page.tsx
@@ -1,9 +1,9 @@
 import Link from 'next/link';
-import { ArrowRight, Ban, BarChart3, Bot, DollarSign, Gauge, KeyRound, ReceiptText, ShieldCheck } from 'lucide-react';
+import { ArrowRight, Ban, BarChart3, Bot, DollarSign, Gauge, KeyRound, ReceiptText } from 'lucide-react';
 
 export const metadata = {
   title: 'AI API Budget Enforcement | Hard Caps for Agent API Spend',
-  description: 'Enforce AI API budgets before agents call OpenAI, Claude, MCP tools, paid APIs, or internal services with request-path controls and audit.',
+  description: 'Enforce AI API budgets before agents call OpenAI, Claude, MCP tools, paid APIs, or internal services with request-path controls, revocation, and audit receipts.',
   alternates: { canonical: 'https://satgate.io/ai-api-budget-enforcement' },
   keywords: [
     'AI API budget enforcement',
@@ -18,14 +18,14 @@ export const metadata = {
   ],
   openGraph: {
     title: 'AI API Budget Enforcement | Hard Caps for Agent API Spend',
-    description: 'Enforce AI API budgets before agents call OpenAI, Claude, MCP tools, paid APIs, or internal services.',
+    description: 'Enforce AI API budgets before agents call OpenAI, Claude, MCP tools, paid APIs, or internal services with audit receipts.',
     url: 'https://satgate.io/ai-api-budget-enforcement',
     type: 'website',
   },
   twitter: {
     card: 'summary_large_image',
     title: 'AI API Budget Enforcement | Hard Caps for Agent API Spend',
-    description: 'Enforce AI API budgets before agents call OpenAI, Claude, MCP tools, paid APIs, or internal services.',
+    description: 'Enforce AI API budgets before agents call OpenAI, Claude, MCP tools, paid APIs, or internal services with audit receipts.',
   },
 };
 
@@ -67,7 +67,7 @@ export default function Page() {
     url: 'https://satgate.io/ai-api-budget-enforcement',
     publisher: { '@type': 'Organization', name: 'SatGate', url: 'https://satgate.io' },
     dateModified: '2026-05-03',
-    featureList: ['Request-path budget enforcement', 'AI agent spend caps', 'MCP tool cost control', 'Revocable credentials', 'Audit trails'],
+    featureList: ['Request-path budget enforcement', 'AI agent spend caps', 'MCP tool cost control', 'Revocable credentials', 'Audit receipts', 'Policy-to-Proof evidence'],
     audience: { '@type': 'Audience', audienceType: 'AI platform, API, finance, and security teams' },
   };
 
@@ -105,10 +105,10 @@ export default function Page() {
         <div className="relative mx-auto max-w-6xl px-6 py-24">
           <div className="mb-8 inline-flex items-center gap-2 rounded-full border border-cyan-500/30 bg-cyan-950/30 px-4 py-2 text-sm text-cyan-200"><Gauge size={16} /> Hard caps before API spend happens</div>
           <h1 className="mb-8 max-w-5xl text-5xl font-extrabold tracking-tight md:text-7xl">AI API budget enforcement belongs in the request path</h1>
-          <p className="mb-10 max-w-4xl text-xl leading-relaxed text-gray-300 md:text-2xl">AI agents can call APIs faster than finance, dashboards, or alerts can react. SatGate enforces budgets before upstream API, model, or MCP tool calls execute.</p>
+          <p className="mb-10 max-w-4xl text-xl leading-relaxed text-gray-300 md:text-2xl">AI agents can call APIs faster than finance, dashboards, or alerts can react. SatGate puts authority before execution by enforcing budget, route, scope, revocation, and audit policy before upstream API, model, or MCP tool calls execute.</p>
           <div className="flex flex-col gap-4 sm:flex-row">
-            <Link href="/ai-agent-cost-control" className="inline-flex items-center justify-center gap-2 rounded-lg bg-white px-6 py-3 font-bold text-black transition hover:bg-gray-200">AI agent cost control <ArrowRight size={18} /></Link>
-            <Link href="/openai-budget-policy-generator" className="inline-flex items-center justify-center gap-2 rounded-lg border border-gray-700 px-6 py-3 font-bold text-white transition hover:border-cyan-500">Generate OpenAI policy</Link>
+            <Link href="/govern" className="inline-flex items-center justify-center gap-2 rounded-lg bg-white px-6 py-3 font-bold text-black transition hover:bg-gray-200">Govern AI API budgets <ArrowRight size={18} /></Link>
+            <Link href="/policy-to-proof" className="inline-flex items-center justify-center gap-2 rounded-lg border border-gray-700 px-6 py-3 font-bold text-white transition hover:border-cyan-500">See Policy-to-Proof</Link>
           </div>
         </div>
       </section>
@@ -118,7 +118,7 @@ export default function Page() {
           <h2 className="mb-6 text-3xl font-bold text-white">The control point is before the call</h2>
           <div className="space-y-5 text-lg leading-relaxed text-gray-300">
             <p>Autonomous agents can generate real costs through model calls, API requests, MCP tools, delegated sub-agents, retries, and background workflows. If the policy check happens after the request, the money is already spent.</p>
-            <p>SatGate enforces economic policy at the gateway boundary. Every important request can be evaluated against budget, scope, identity, revocation, route, tool, and audit rules before upstream access.</p>
+            <p>SatGate enforces economic policy at the gateway boundary. Every important request can be evaluated against budget, scope, identity, revocation, route, tool, receipt, and audit rules before upstream access.</p>
             <p>That is the difference between cost reporting and economic control.</p>
           </div>
         </div>
@@ -191,10 +191,10 @@ export default function Page() {
       <section className="mx-auto max-w-6xl px-6 py-20">
         <div className="rounded-3xl border border-purple-900/60 bg-gradient-to-br from-purple-950/35 to-cyan-950/20 p-8 md:p-12">
           <h2 className="mb-4 text-3xl font-bold text-white">Make agent economics enforceable.</h2>
-          <p className="mb-8 max-w-3xl text-lg leading-relaxed text-gray-300">SatGate is the economic firewall for AI agents: observe every request, control spend before execution, and charge robot customers when paid API access should unlock.</p>
+          <p className="mb-8 max-w-3xl text-lg leading-relaxed text-gray-300">SatGate is the economic firewall for AI agents: observe every request, enforce spend before execution, and preserve Policy-to-Proof receipts when paid access or budget decisions occur.</p>
           <div className="flex flex-col gap-4 sm:flex-row">
-            <Link href="/tools" className="inline-flex items-center justify-center gap-2 rounded-lg bg-white px-6 py-3 font-bold text-black transition hover:bg-gray-200">Open free tools <ArrowRight size={18} /></Link>
-            <Link href="/economic-firewall" className="inline-flex items-center justify-center gap-2 rounded-lg border border-gray-700 px-6 py-3 font-bold text-white transition hover:border-cyan-500">Economic firewall</Link>
+            <Link href="/govern" className="inline-flex items-center justify-center gap-2 rounded-lg bg-white px-6 py-3 font-bold text-black transition hover:bg-gray-200">Govern AI API spend <ArrowRight size={18} /></Link>
+            <Link href="/policy-to-proof" className="inline-flex items-center justify-center gap-2 rounded-lg border border-gray-700 px-6 py-3 font-bold text-white transition hover:border-cyan-500">Review Policy-to-Proof</Link>
           </div>
         </div>
       </section>

--- a/satgate-landing/app/mcp-cost-control/page.tsx
+++ b/satgate-landing/app/mcp-cost-control/page.tsx
@@ -1,9 +1,9 @@
 import Link from 'next/link';
-import { ArrowRight, Ban, BarChart3, Bot, DollarSign, Gauge, KeyRound, ReceiptText, ShieldCheck } from 'lucide-react';
+import { ArrowRight, Ban, BarChart3, Bot, DollarSign, Gauge, KeyRound, ReceiptText } from 'lucide-react';
 
 export const metadata = {
   title: 'MCP Cost Control | Budget Enforcement for Tool-Calling Agents',
-  description: 'Control MCP tool costs with per-tool budgets, scoped credentials, revocation, audit trails, and request-path enforcement for Cursor, Claude, and OpenClaw.',
+  description: 'Control MCP tool costs with per-tool budgets, scoped credentials, revocation, audit receipts, and request-path enforcement for Cursor, Claude, and OpenClaw.',
   alternates: { canonical: 'https://satgate.io/mcp-cost-control' },
   keywords: [
     'MCP cost control',
@@ -18,14 +18,14 @@ export const metadata = {
   ],
   openGraph: {
     title: 'MCP Cost Control | Budget Enforcement for Tool-Calling Agents',
-    description: 'Control MCP tool costs with per-tool budgets, risk tiers, scoped credentials, revocation, audit trails, and request-path enforcement.',
+    description: 'Control MCP tool costs with per-tool budgets, risk tiers, scoped credentials, revocation, audit receipts, and request-path enforcement.',
     url: 'https://satgate.io/mcp-cost-control',
     type: 'website',
   },
   twitter: {
     card: 'summary_large_image',
     title: 'MCP Cost Control | Budget Enforcement for Tool-Calling Agents',
-    description: 'Control MCP tool costs with per-tool budgets, risk tiers, scoped credentials, revocation, audit trails, and request-path enforcement.',
+    description: 'Control MCP tool costs with per-tool budgets, risk tiers, scoped credentials, revocation, audit receipts, and request-path enforcement.',
   },
 };
 
@@ -79,7 +79,7 @@ export default function Page() {
       { '@type': 'Question', name: 'Why are dashboards not enough?', acceptedAnswer: { '@type': 'Answer', text: 'Dashboards and billing alerts report spend after requests complete. Autonomous agents can loop, retry, and delegate fast enough that budget policy must be enforced before upstream access.' } },
       { '@type': 'Question', name: 'How does SatGate help?', acceptedAnswer: { '@type': 'Answer', text: 'SatGate sits in the request path and checks identity, budget, route, tool scope, credential caveats, expiry, revocation, and audit policy before forwarding the request.' } },
       { '@type': 'Question', name: 'How is MCP cost control different from LLM cost control?', acceptedAnswer: { '@type': 'Answer', text: 'LLM cost control focuses on model and token usage. MCP cost control covers tool calls that can trigger paid search, browser automation, cloud actions, SaaS APIs, data lookups, code execution, or delegated workflows outside the LLM bill.' } },
-      { '@type': 'Question', name: 'Where should MCP tool cost policy be enforced?', acceptedAnswer: { '@type': 'Answer', text: 'MCP tool cost policy should be enforced in the request path before the MCP server executes the tool, so expensive calls can be blocked, downgraded, routed, approved, revoked, or charged before cost is created.' } },
+      { '@type': 'Question', name: 'Where should MCP tool cost policy be enforced?', acceptedAnswer: { '@type': 'Answer', text: 'MCP tool cost policy should be enforced in the request path before the MCP server executes the tool, so expensive calls can be blocked, downgraded, routed, approved, revoked, paid, or recorded before cost is created.' } },
     ],
   };
 
@@ -104,11 +104,12 @@ export default function Page() {
         <div className="absolute inset-0 bg-[radial-gradient(circle_at_24%_0%,rgba(34,211,238,0.18),transparent_34%),radial-gradient(circle_at_80%_10%,rgba(168,85,247,0.14),transparent_32%)]" />
         <div className="relative mx-auto max-w-6xl px-6 py-24">
           <div className="mb-8 inline-flex items-center gap-2 rounded-full border border-cyan-500/30 bg-cyan-950/30 px-4 py-2 text-sm text-cyan-200"><Gauge size={16} /> Cost controls for MCP tool calls</div>
-          <h1 className="mb-8 max-w-5xl text-5xl font-extrabold tracking-tight md:text-7xl">MCP cost control is the next budget problem for AI agents</h1>
-          <p className="mb-10 max-w-4xl text-xl leading-relaxed text-gray-300 md:text-2xl">MCP moves agent cost beyond LLM tokens. Tool calls can trigger search, data, cloud, code, SaaS, or premium API spend. SatGate attaches economic policy to the tool call before it executes.</p>
+          <h1 className="mb-8 max-w-5xl text-5xl font-extrabold tracking-tight md:text-7xl">MCP cost control belongs before tool execution</h1>
+          <p className="mb-10 max-w-4xl text-xl leading-relaxed text-gray-300 md:text-2xl">MCP moves agent cost beyond LLM tokens. Tool calls can trigger search, data, cloud, code, SaaS, or premium API spend. SatGate attaches authority, budget, revocation, and receipt policy to the tool call before it executes.</p>
           <div className="flex flex-col gap-4 sm:flex-row">
-            <Link href="/mcp-budget-enforcement" className="inline-flex items-center justify-center gap-2 rounded-lg bg-white px-6 py-3 font-bold text-black transition hover:bg-gray-200">MCP budget enforcement <ArrowRight size={18} /></Link>
+            <Link href="/govern" className="inline-flex items-center justify-center gap-2 rounded-lg bg-white px-6 py-3 font-bold text-black transition hover:bg-gray-200">Govern MCP tool spend <ArrowRight size={18} /></Link>
             <Link href="/mcp-tool-cost-policy-generator" className="inline-flex items-center justify-center gap-2 rounded-lg border border-gray-700 px-6 py-3 font-bold text-white transition hover:border-cyan-500">Generate MCP policy</Link>
+            <Link href="/policy-to-proof" className="inline-flex items-center justify-center gap-2 rounded-lg border border-gray-700 px-6 py-3 font-bold text-white transition hover:border-cyan-500">See Policy-to-Proof</Link>
           </div>
         </div>
       </section>
@@ -118,7 +119,7 @@ export default function Page() {
           <h2 className="mb-6 text-3xl font-bold text-white">The control point is before the call</h2>
           <div className="space-y-5 text-lg leading-relaxed text-gray-300">
             <p>Autonomous agents can generate real costs through model calls, API requests, MCP tools, delegated sub-agents, retries, and background workflows. If the policy check happens after the request, the money is already spent.</p>
-            <p>SatGate enforces economic policy at the gateway boundary. Every important request can be evaluated against budget, scope, identity, revocation, route, tool, and audit rules before upstream access.</p>
+            <p>SatGate enforces economic policy at the gateway boundary. Every important request can be evaluated against budget, scope, identity, revocation, route, tool, receipt, and audit rules before upstream access.</p>
             <p>That is the difference between cost reporting and economic control.</p>
           </div>
         </div>
@@ -181,7 +182,7 @@ export default function Page() {
             <div className="rounded-xl border border-gray-800 bg-gray-950 p-6">
               <h3 className="mb-2 text-xl font-bold text-white">Where should MCP tool cost policy be enforced?</h3>
               <p className="text-gray-400 leading-relaxed">
-                MCP tool cost policy should be enforced in the request path before the MCP server executes the tool, so expensive calls can be blocked, downgraded, routed, approved, revoked, or charged before cost is created.
+                MCP tool cost policy should be enforced in the request path before the MCP server executes the tool, so expensive calls can be blocked, downgraded, routed, approved, revoked, paid, or recorded before cost is created.
               </p>
             </div>
           </div>
@@ -191,10 +192,10 @@ export default function Page() {
       <section className="mx-auto max-w-6xl px-6 py-20">
         <div className="rounded-3xl border border-purple-900/60 bg-gradient-to-br from-purple-950/35 to-cyan-950/20 p-8 md:p-12">
           <h2 className="mb-4 text-3xl font-bold text-white">Make agent economics enforceable.</h2>
-          <p className="mb-8 max-w-3xl text-lg leading-relaxed text-gray-300">SatGate is the economic firewall for AI agents: observe every request, control spend before execution, and charge robot customers when paid API access should unlock.</p>
+          <p className="mb-8 max-w-3xl text-lg leading-relaxed text-gray-300">SatGate is the economic firewall for AI agents: observe every MCP tool call, enforce spend before execution, and preserve receipts for policy, revocation, and access decisions.</p>
           <div className="flex flex-col gap-4 sm:flex-row">
-            <Link href="/tools" className="inline-flex items-center justify-center gap-2 rounded-lg bg-white px-6 py-3 font-bold text-black transition hover:bg-gray-200">Open free tools <ArrowRight size={18} /></Link>
-            <Link href="/economic-firewall" className="inline-flex items-center justify-center gap-2 rounded-lg border border-gray-700 px-6 py-3 font-bold text-white transition hover:border-cyan-500">Economic firewall</Link>
+            <Link href="/govern" className="inline-flex items-center justify-center gap-2 rounded-lg bg-white px-6 py-3 font-bold text-black transition hover:bg-gray-200">Govern MCP tool spend <ArrowRight size={18} /></Link>
+            <Link href="/policy-to-proof" className="inline-flex items-center justify-center gap-2 rounded-lg border border-gray-700 px-6 py-3 font-bold text-white transition hover:border-cyan-500">Review Policy-to-Proof</Link>
           </div>
         </div>
       </section>

--- a/satgate-landing/scripts/check_policy_to_proof_page.py
+++ b/satgate-landing/scripts/check_policy_to_proof_page.py
@@ -16,6 +16,14 @@ AGENT_BUDGET_POLICY_LAYOUT = ROOT / "app" / "agent-spend-policy-template" / "lay
 CAPABILITY_TOKEN_TEMPLATE_PAGE = ROOT / "app" / "revocable-capability-token-policy-template" / "page.tsx"
 CAPABILITY_TOKEN_TEMPLATE_LAYOUT = ROOT / "app" / "revocable-capability-token-policy-template" / "layout.tsx"
 
+SPEND_LONGTAIL_PAGES = {
+    "ai-agent-cost-control": ROOT / "app" / "ai-agent-cost-control" / "page.tsx",
+    "ai-api-budget-enforcement": ROOT / "app" / "ai-api-budget-enforcement" / "page.tsx",
+    "agent-spending-limits": ROOT / "app" / "agent-spending-limits" / "page.tsx",
+    "mcp-cost-control": ROOT / "app" / "mcp-cost-control" / "page.tsx",
+    "agent-payment-controls": ROOT / "app" / "agent-payment-controls" / "page.tsx",
+}
+
 required_phrases = [
     "Every agent action leaves a receipt",
     "without permanent credentials, unlimited spend, or unobservable authority",
@@ -289,6 +297,108 @@ tool_forbidden_phrases = {
     ],
 }
 
+spend_longtail_required_phrases = {
+    "ai-agent-cost-control": [
+        "authority before execution",
+        "audit receipts",
+        "Policy-to-Proof",
+        "Evidence Pack capture",
+        "/govern",
+        "/policy-to-proof",
+        "paid-rail evidence",
+    ],
+    "ai-api-budget-enforcement": [
+        "authority before execution",
+        "audit receipts",
+        "Policy-to-Proof",
+        "Govern AI API budgets",
+        "/govern",
+        "/policy-to-proof",
+    ],
+    "agent-spending-limits": [
+        "authority before execution",
+        "receipt for every budget decision",
+        "Policy-to-Proof",
+        "Govern agent spending limits",
+        "/govern",
+        "/policy-to-proof",
+    ],
+    "mcp-cost-control": [
+        "MCP cost control belongs before tool execution",
+        "authority, budget, revocation, and receipt policy",
+        "Policy-to-Proof",
+        "Govern MCP tool spend",
+        "/govern",
+        "/policy-to-proof",
+    ],
+    "agent-payment-controls": [
+        "Policy Before Agent Payments",
+        "paid-rail context",
+        "Evidence Pack",
+        "Policy-to-Proof evidence",
+        "Govern agent payments",
+        "/govern",
+        "/policy-to-proof",
+    ],
+}
+
+spend_longtail_forbidden_phrases = {
+    "ai-agent-cost-control": [
+        "Charge robot customers",
+        "robot customers",
+        "external robot customers",
+        "Charge/L402",
+        "L402 Charge",
+        "L402 API monetization",
+        "when APIs become products",
+        "when agents become customers",
+        "03 / CHARGE",
+        "/robot-customer-payments",
+    ],
+    "ai-api-budget-enforcement": [
+        "Charge robot customers",
+        "robot customers",
+        "external robot customers",
+        "Charge/L402",
+        "L402 Charge",
+        "L402 API monetization",
+        "when APIs become products",
+        "Open free tools",
+    ],
+    "agent-spending-limits": [
+        "Charge robot customers",
+        "robot customers",
+        "external robot customers",
+        "Charge/L402",
+        "L402 Charge",
+        "L402 API monetization",
+        "when APIs become products",
+        "Open free tools",
+    ],
+    "mcp-cost-control": [
+        "Charge robot customers",
+        "robot customers",
+        "external robot customers",
+        "Charge/L402",
+        "L402 Charge",
+        "L402 API monetization",
+        "when APIs become products",
+        "Open free tools",
+    ],
+    "agent-payment-controls": [
+        "Charge robot customers",
+        "robot customers",
+        "external robot customers",
+        "L402 Charge",
+        "L402 API monetization",
+        "SatGate Charge",
+        "when APIs become agent-native products",
+        "Compare Link and SatGate",
+        "Learn the economic firewall",
+        "Read HTTP 402 for agents",
+    ],
+}
+
 
 def main() -> int:
     if not PAGE.exists():
@@ -341,6 +451,15 @@ def main() -> int:
         tool_stale = [phrase for phrase in tool_forbidden_phrases[name] if phrase in tool_text]
         if tool_stale:
             raise SystemExit(f"stale {name} spend/Charge/tool-exit phrases remain:\n" + "\n".join(tool_stale))
+
+    for name, path in SPEND_LONGTAIL_PAGES.items():
+        page_text = path.read_text()
+        missing_longtail = [phrase for phrase in spend_longtail_required_phrases[name] if phrase not in page_text]
+        if missing_longtail:
+            raise SystemExit(f"missing {name} spend-longtail authority/proof phrases:\n" + "\n".join(missing_longtail))
+        stale_longtail = [phrase for phrase in spend_longtail_forbidden_phrases[name] if phrase in page_text]
+        if stale_longtail:
+            raise SystemExit(f"stale {name} spend/Charge-first phrases remain:\n" + "\n".join(stale_longtail))
     return 0
 
 


### PR DESCRIPTION
## Summary
- Align five spend-cluster SEO pages around authority before execution, audit receipts, Evidence Pack/Policy-to-Proof language, and high-intent exits to /govern + /policy-to-proof
- Reframe agent payment controls so L402/x402/cards/shared tokens are paid-rail context, not the product center
- Extend policy-to-proof regression guard to cover the spend long-tail pages and stale Charge/robot-customer phrases

## Verification
- python scripts/check_policy_to_proof_page.py
- npx eslint app/ai-agent-cost-control/page.tsx app/ai-api-budget-enforcement/page.tsx app/agent-spending-limits/page.tsx app/mcp-cost-control/page.tsx app/agent-payment-controls/page.tsx --no-error-on-unmatched-pattern
- npm run build
- Local rendered verification for all five pages on 127.0.0.1:3008 with cache busters
- Independent reviewer pass