### PR TITLE
Align L402 rail pages with Policy-to-Proof

### DIFF
--- a/satgate-landing/app/http-402-for-ai-agents/page.tsx
+++ b/satgate-landing/app/http-402-for-ai-agents/page.tsx
@@ -12,7 +12,7 @@ export const metadata = {
     'shared payment token agents',
     'L402 agent payments',
     'HTTP 402 API monetization',
-    'robot customer payments',
+    'paid-rail agent governance',
     'agent payment controls',
   ],
   openGraph: {
@@ -24,14 +24,14 @@ export const metadata = {
   twitter: {
     card: 'summary_large_image',
     title: 'HTTP 402 for AI Agents',
-    description: 'HTTP 402 is becoming the payment handshake for robot customers. SatGate adds policy, budgets, audit, and L402 Charge.',
+    description: 'HTTP 402 can describe paid access for AI agents. SatGate adds authority checks, policy decisions, budgets, receipts, and Evidence Packs before execution.',
   },
 };
 
 const flows = [
   ['Card checkout', 'Agent receives a temporary card credential and fills a merchant checkout.', 'Good for web purchases, but not request-native API monetization.'],
-  ['Shared payment token', 'Agent receives a payment token for a supported 402 machine-payment flow.', 'Rail-specific; separate from SatGate Charge/L402.'],
-  ['L402 Lightning', 'API returns a Lightning-backed 402 challenge and verifies proof before access.', 'SatGate Charge uses this for robot-customer API monetization.'],
+  ['Shared payment token', 'Agent receives a payment token for a supported 402 machine-payment flow.', 'Rail-specific; L402 Lightning is one paid rail among several that still need governance.'],
+  ['L402 Lightning', 'API returns a Lightning-backed 402 challenge and verifies proof before access.', 'L402 Lightning can support request-native paid API access; SatGate governs the decision and receipt.'],
   ['Policy-only 402 observation', 'SatGate records and evaluates payment challenges even when another rail completes payment.', 'Useful for audit, deny/allow rules, and spend governance.'],
 ];
 
@@ -48,8 +48,8 @@ export default function Http402ForAiAgentsPage() {
     mainEntityOfPage: 'https://satgate.io/http-402-for-ai-agents',
     about: [
       { '@type': 'Thing', name: 'HTTP 402 for AI agents' },
-      { '@type': 'Thing', name: 'robot customer payments' },
-      { '@type': 'Thing', name: 'L402 Lightning API monetization' },
+      { '@type': 'Thing', name: 'paid-rail agent governance' },
+      { '@type': 'Thing', name: 'L402 Lightning paid rail' },
       { '@type': 'Thing', name: 'AI agent payment policy' },
     ],
   };
@@ -59,9 +59,9 @@ export default function Http402ForAiAgentsPage() {
     '@type': 'FAQPage',
     mainEntity: [
       { '@type': 'Question', name: 'What is HTTP 402 for AI agents?', acceptedAnswer: { '@type': 'Answer', text: 'HTTP 402 lets an API tell an AI agent that payment is required before access. The response can include a machine-readable challenge describing how to pay.' } },
-      { '@type': 'Question', name: 'Is HTTP 402 the same as L402?', acceptedAnswer: { '@type': 'Answer', text: 'No. HTTP 402 is the status code. L402 is a Lightning-based payment and access pattern that uses HTTP 402. SatGate Charge uses L402 Lightning.' } },
+      { '@type': 'Question', name: 'Is HTTP 402 the same as L402?', acceptedAnswer: { '@type': 'Answer', text: 'No. HTTP 402 is the status code. L402 is a Lightning-based payment and access pattern that uses HTTP 402. L402 Lightning is one rail SatGate can govern in the request path.' } },
       { '@type': 'Question', name: 'How are Stripe shared payment tokens different from L402?', acceptedAnswer: { '@type': 'Answer', text: 'Stripe-style shared payment tokens are a payment-credential method for supported 402 flows. L402 uses Lightning payment proof to unlock scoped API access. They are separate rails.' } },
-      { '@type': 'Question', name: 'Why do 402 payment challenges need policy?', acceptedAnswer: { '@type': 'Answer', text: 'A payment challenge tells the agent how to pay, but it does not decide whether the agent should be allowed to spend, which budget applies, whether the route is in scope, or how the event should be audited.' } },
+      { '@type': 'Question', name: 'Why do 402 payment challenges need policy?', acceptedAnswer: { '@type': 'Answer', text: 'A payment challenge tells the agent how to pay, but it does not decide whether the agent should be allowed to spend, which budget applies, whether the route is in scope, or how the event should feed the Evidence Pack.' } },
     ],
   };
 
@@ -84,20 +84,20 @@ export default function Http402ForAiAgentsPage() {
         <div className="absolute inset-0 bg-[radial-gradient(circle_at_20%_0%,rgba(250,204,21,0.18),transparent_30%),radial-gradient(circle_at_80%_10%,rgba(34,211,238,0.15),transparent_32%)]" />
         <div className="relative max-w-6xl mx-auto px-6 py-24">
           <div className="inline-flex items-center gap-2 rounded-full border border-yellow-500/30 bg-yellow-950/20 px-4 py-2 text-sm text-yellow-200 mb-8">
-            <BadgeDollarSign size={16} /> Payment Required for robot customers
+            <BadgeDollarSign size={16} /> Payment Required, governed before execution
           </div>
           <h1 className="text-5xl md:text-7xl font-extrabold tracking-tight max-w-5xl mb-8">
             HTTP 402 for AI Agents
           </h1>
           <p className="text-xl md:text-2xl text-gray-300 max-w-4xl leading-relaxed mb-10">
-            HTTP 402 is becoming the handshake between autonomous agents and paid APIs. The protocol can request payment; SatGate decides whether the agent should be allowed to pay, access, and continue.
+            HTTP 402 is becoming the handshake between autonomous agents and paid APIs. The protocol can request payment; SatGate decides whether the agent has authority to spend, access, and continue — then preserves proof of the decision.
           </p>
           <div className="flex flex-col sm:flex-row gap-4">
-            <Link href="/l402-agent-payments" className="inline-flex items-center justify-center gap-2 rounded-lg bg-white text-black px-6 py-3 font-bold hover:bg-gray-200 transition">
-              See L402 agent payments <ArrowRight size={18} />
+            <Link href="/govern" className="inline-flex items-center justify-center gap-2 rounded-lg bg-white text-black px-6 py-3 font-bold hover:bg-gray-200 transition">
+              Govern paid agent actions <ArrowRight size={18} />
             </Link>
-            <Link href="/agent-payment-controls" className="inline-flex items-center justify-center gap-2 rounded-lg border border-gray-700 px-6 py-3 font-bold text-white hover:border-yellow-500 transition">
-              Agent payment controls
+            <Link href="/policy-to-proof" className="inline-flex items-center justify-center gap-2 rounded-lg border border-gray-700 px-6 py-3 font-bold text-white hover:border-yellow-500 transition">
+              See Policy-to-Proof
             </Link>
           </div>
         </div>
@@ -113,13 +113,13 @@ export default function Http402ForAiAgentsPage() {
             That challenge may point to different rails: card-based credentials, shared payment tokens, L402 Lightning invoices, or future protocols. But the payment challenge is not the governance layer.
           </p>
           <p>
-            SatGate sits before upstream access and applies policy: identify the agent, estimate cost, enforce budgets, decide whether the rail is allowed, record the challenge, and unlock only scoped access after proof.
+            SatGate sits before upstream access and applies policy: identify the agent, confirm authority, estimate cost, enforce budgets, decide whether the rail is allowed, record the challenge, and unlock only scoped access after proof.
           </p>
         </div>
         <div className="rounded-2xl border border-yellow-900/50 bg-yellow-950/10 p-6">
           <h3 className="text-xl font-bold text-white mb-4">A 402-aware control plane asks</h3>
           <div className="space-y-3 text-sm">
-            {['Which payment method is being requested?', 'Is this route approved for agent payments?', 'Does the agent have budget?', 'Should policy require human approval?', 'Is this L402 Charge, shared payment token, or another rail?', 'What should be audited before forwarding?'].map((item) => (
+            {['Which payment method is being requested?', 'Is this route approved for agent payments?', 'Does the agent have authority and budget?', 'Should policy require human approval?', 'Which paid rail is being requested, and is it allowed by policy?', 'What Evidence Pack receipt should be recorded before forwarding?'].map((item) => (
               <div key={item} className="flex items-start gap-3 rounded-lg border border-gray-800 bg-black/50 p-3">
                 <CheckCircle2 className="text-yellow-300 mt-0.5" size={18} />
                 <span className="text-gray-300">{item}</span>
@@ -133,7 +133,7 @@ export default function Http402ForAiAgentsPage() {
         <div className="max-w-6xl mx-auto px-6 py-20">
           <h2 className="text-3xl font-bold text-white mb-4">HTTP 402 flow types</h2>
           <p className="text-gray-400 max-w-3xl mb-10 text-lg">
-            Treat 402 as a protocol surface, not a single payment system. SatGate Charge is L402 Lightning; other payment-token flows are separate rails that still need governance.
+            Treat 402 as a protocol surface, not a single payment system. L402 Lightning is one paid rail; other payment-token flows are separate rails that still need governance.
           </p>
           <div className="overflow-hidden rounded-2xl border border-gray-800">
             <div className="grid md:grid-cols-3 bg-gray-900/70 text-sm font-bold text-white">
@@ -170,16 +170,16 @@ export default function Http402ForAiAgentsPage() {
         <div className="max-w-6xl mx-auto px-6 py-20 grid lg:grid-cols-2 gap-8">
           <div className="rounded-2xl border border-yellow-900/50 bg-yellow-950/10 p-8">
             <Zap className="text-yellow-300 mb-5" size={34} />
-            <h2 className="text-2xl font-bold text-white mb-4">L402 is SatGate Charge</h2>
+            <h2 className="text-2xl font-bold text-white mb-4">L402 is a paid rail, not the governance layer</h2>
             <p className="text-gray-300 leading-relaxed">
-              SatGate Charge uses L402 Lightning: an API returns a 402 challenge, the agent pays a Lightning invoice, and payment proof unlocks scoped access. This is SatGate's robot-customer monetization rail.
+              L402 Lightning can carry payment proof: an API returns a 402 challenge, the agent or wallet client pays a Lightning invoice, and proof unlocks scoped access. SatGate evaluates the action before payment/access and records proof after the decision.
             </p>
           </div>
           <div className="rounded-2xl border border-cyan-900/60 bg-cyan-950/10 p-8">
             <ShieldCheck className="text-cyan-300 mb-5" size={34} />
             <h2 className="text-2xl font-bold text-white mb-4">Other 402 rails still need policy</h2>
             <p className="text-gray-300 leading-relaxed">
-              Stripe-style shared payment tokens, card credentials, and future payment protocols can help agents pay. They do not replace request-path controls for budget, scope, revocation, metering, or audit.
+              Stripe-style shared payment tokens, card credentials, and future payment protocols can help agents pay. They do not replace request-path controls for budget, scope, revocation, metering, receipts, or Evidence Pack proof.
             </p>
           </div>
         </div>
@@ -196,7 +196,7 @@ export default function Http402ForAiAgentsPage() {
             </div>
             <div className="rounded-xl border border-gray-800 bg-gray-950 p-6">
               <h3 className="text-xl font-bold text-white mb-2">Is HTTP 402 the same as L402?</h3>
-              <p className="text-gray-400 leading-relaxed">No. HTTP 402 is the status code. L402 is a Lightning-based payment and access pattern that uses HTTP 402. SatGate Charge uses L402 Lightning.</p>
+              <p className="text-gray-400 leading-relaxed">No. HTTP 402 is the status code. L402 is a Lightning-based payment and access pattern that uses HTTP 402. L402 Lightning is one rail SatGate can govern in the request path.</p>
             </div>
             <div className="rounded-xl border border-gray-800 bg-gray-950 p-6">
               <h3 className="text-xl font-bold text-white mb-2">How are Stripe shared payment tokens different from L402?</h3>
@@ -204,7 +204,7 @@ export default function Http402ForAiAgentsPage() {
             </div>
             <div className="rounded-xl border border-gray-800 bg-gray-950 p-6">
               <h3 className="text-xl font-bold text-white mb-2">Why do 402 payment challenges need policy?</h3>
-              <p className="text-gray-400 leading-relaxed">A payment challenge tells the agent how to pay, but it does not decide whether the agent should be allowed to spend, which budget applies, whether the route is in scope, or how the event should be audited.</p>
+              <p className="text-gray-400 leading-relaxed">A payment challenge tells the agent how to pay, but it does not decide whether the agent should be allowed to spend, which budget applies, whether the route is in scope, or how the event should feed the Evidence Pack.</p>
             </div>
           </div>
         </div>
@@ -214,12 +214,12 @@ export default function Http402ForAiAgentsPage() {
         <h2 className="text-3xl font-bold text-white mb-8">Related guides</h2>
         <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-4">
           {[
-            ['/stripe-link-agents-vs-satgate', 'Stripe Link for Agents vs SatGate', 'Compare wallet credentials with request-path economic governance.'],
-            ['/agent-payment-controls', 'Agent payment controls', 'Policy, budgets, approval, audit, and payment rails for AI agents.'],
-            ['/l402-agent-payments', 'L402 agent payments', 'Use SatGate Charge to monetize APIs with Lightning-native robot-customer payments.'],
-            ['/robot-customer-payments', 'Robot customer payments', 'Turn autonomous agents into paying API customers.'],
-            ['/economic-firewall', 'Economic firewall', 'Control agent access and spend before upstream API calls execute.'],
-            ['/l402-api-pricing-calculator', 'L402 API pricing calculator', 'Estimate request-native pricing for agent/API monetization.'],
+            ['/policy-to-proof', 'Policy-to-Proof', 'See how paid access decisions become Evidence Pack proof.'],
+            ['/govern', 'Govern AI agents', 'Govern paid agent actions before execution.'],
+            ['/l402-agent-payments', 'L402 agent payments', 'Understand L402 Lightning as one paid rail for governed agent/API access.'],
+            ['/agent-payment-controls', 'Agent payment controls', 'Policy, budgets, approval, receipts, and payment rails for AI agents.'],
+            ['/economic-firewall', 'Economic firewall', 'Control agent access, spend, and paid-rail context before upstream API calls execute.'],
+            ['/l402-api-pricing-calculator', 'L402 API pricing calculator', 'Estimate request-native pricing for agent/API paid-access scenarios.'],
           ].map(([href, title, body]) => (
             <Link key={href} href={href} className="rounded-xl border border-gray-800 bg-gray-950 p-5 transition hover:border-yellow-500/50 hover:bg-yellow-950/10">
               <h3 className="font-bold text-white mb-2">{title}</h3>
@@ -231,16 +231,16 @@ export default function Http402ForAiAgentsPage() {
 
       <section className="max-w-6xl mx-auto px-6 py-20">
         <div className="rounded-3xl border border-yellow-900/60 bg-gradient-to-br from-yellow-950/20 to-cyan-950/30 p-8 md:p-12">
-          <h2 className="text-3xl font-bold text-white mb-4">Make 402 programmable, governed, and auditable</h2>
+          <h2 className="text-3xl font-bold text-white mb-4">Govern paid agent access before execution</h2>
           <p className="text-gray-300 text-lg leading-relaxed max-w-3xl mb-8">
-            SatGate gives API teams the economic firewall for agent-native payments: Observe every 402 and paid request, Control who may spend, and Charge with L402 Lightning when APIs become robot-customer products.
+            HTTP 402 can carry payment context. SatGate turns that context into governed action: authority, policy, budget, proof, and an Evidence Pack receipt for every paid request.
           </p>
           <div className="flex flex-col sm:flex-row gap-4">
-            <Link href="/l402-api-pricing-calculator" className="inline-flex items-center justify-center gap-2 rounded-lg bg-white text-black px-6 py-3 font-bold hover:bg-gray-200 transition">
-              Price L402 API access <ArrowRight size={18} />
+            <Link href="/govern" className="inline-flex items-center justify-center gap-2 rounded-lg bg-white text-black px-6 py-3 font-bold hover:bg-gray-200 transition">
+              Govern agent actions <ArrowRight size={18} />
             </Link>
-            <Link href="/economic-firewall-readiness-grader" className="inline-flex items-center justify-center gap-2 rounded-lg border border-gray-700 px-6 py-3 font-bold text-white hover:border-yellow-500 transition">
-              Grade your readiness
+            <Link href="/policy-to-proof" className="inline-flex items-center justify-center gap-2 rounded-lg border border-gray-700 px-6 py-3 font-bold text-white hover:border-yellow-500 transition">
+              See Policy-to-Proof
             </Link>
           </div>
         </div>

--- a/satgate-landing/app/l402-agent-payments/page.tsx
+++ b/satgate-landing/app/l402-agent-payments/page.tsx
@@ -3,30 +3,30 @@ import { ArrowRight, Bot, Coins, KeyRound, LockKeyhole, ReceiptText, Zap } from 
 
 export const metadata = {
   title: 'L402 Agent Payments for APIs',
-  description: 'Let autonomous agents pay for APIs with L402 Lightning payments. SatGate verifies payment before access and keeps API monetization in the request path.',
+  description: 'Understand L402 Lightning as a paid rail for AI agent/API access. SatGate applies Policy-to-Proof before execution and preserves receipts after payment.',
   alternates: { canonical: 'https://satgate.io/l402-agent-payments' },
   keywords: [
     'L402 agent payments',
-    'robot customer payments',
+    'paid-rail agent governance',
     'AI agent payments',
     'Lightning API payments',
     'HTTP 402 agent payments',
     'API monetization for AI agents',
     'autonomous agent payments',
     'AI agents paying APIs',
-    'machine customer payments',
-    'L402 API monetization',
+    'machine payment rail governance',
+    'L402 paid rail governance',
   ],
   openGraph: {
     title: 'L402 Agent Payments for APIs',
-    description: 'Let robot customers pay for protected APIs with L402 Lightning challenges, proof verification, and request-path access control.',
+    description: 'Understand L402 Lightning as one paid rail for protected API access, governed by SatGate policy and Evidence Packs.',
     url: 'https://satgate.io/l402-agent-payments',
     type: 'article',
   },
   twitter: {
     card: 'summary_large_image',
     title: 'L402 Agent Payments for APIs',
-    description: 'Use SatGate Charge to let autonomous agents pay for APIs with L402 Lightning before access is unlocked.',
+    description: 'L402 can carry Lightning payment proof for agent/API access. SatGate governs the action, budget, rail, and receipt before upstream execution.',
   },
 };
 
@@ -44,7 +44,7 @@ const steps = [
   {
     icon: Zap,
     title: 'Agent pays with Lightning',
-    body: 'The robot customer pays the invoice through a wallet such as SaturnZap or another L402-capable client.',
+    body: 'The agent or wallet client pays the invoice through a wallet such as SaturnZap or another L402-capable client.',
   },
   {
     icon: KeyRound,
@@ -58,8 +58,8 @@ const steps = [
   },
   {
     icon: Coins,
-    title: 'API revenue becomes native',
-    body: 'APIs can charge autonomous agents per request, per tool, per dataset, or per premium capability.',
+    title: 'Proof becomes request-native',
+    body: 'Each paid request can carry identity, policy, price, payment proof, and access decision.',
   },
 ];
 
@@ -76,10 +76,10 @@ export default function L402AgentPaymentsPage() {
     mainEntityOfPage: 'https://satgate.io/l402-agent-payments',
     about: [
       { '@type': 'Thing', name: 'L402 agent payments' },
-      { '@type': 'Thing', name: 'robot customer payments' },
+      { '@type': 'Thing', name: 'paid-rail agent governance' },
       { '@type': 'Thing', name: 'Lightning API payments' },
       { '@type': 'Thing', name: 'HTTP 402 agent payments' },
-      { '@type': 'Thing', name: 'API monetization for AI agents' },
+      { '@type': 'Thing', name: 'Policy-to-Proof for paid agent access' },
     ],
   };
 
@@ -97,23 +97,23 @@ export default function L402AgentPaymentsPage() {
       },
       {
         '@type': 'Question',
-        name: 'Why use L402 for robot customers?',
+        name: 'Why use L402 for agent/API paid access?',
         acceptedAnswer: {
           '@type': 'Answer',
-          text: 'Robot customers need programmatic, low-friction payment. L402 combines HTTP 402, Lightning invoices, and access credentials so agents can pay for APIs without manual checkout.',
+          text: 'Agent/API paid access needs programmatic, low-friction payment. L402 combines HTTP 402, Lightning invoices, and access credentials so agents can pay for APIs without manual checkout.',
         },
       },
       {
         '@type': 'Question',
-        name: 'Is SatGate Charge the same as Fiat402?',
+        name: 'Is L402 enough to govern paid agent access?',
         acceptedAnswer: {
           '@type': 'Answer',
-          text: 'No. SatGate Charge is L402 Lightning for request-path agent/API payments. Fiat402 is a separate concept and should not be conflated with Charge.',
+          text: 'No. L402 is a payment/access rail. SatGate Policy-to-Proof governs authority, scope, budget, revocation, and Evidence Pack evidence.',
         },
       },
       {
         '@type': 'Question',
-        name: 'What APIs are good candidates for robot-customer payments?',
+        name: 'What APIs are good candidates for agent/API paid access?',
         acceptedAnswer: {
           '@type': 'Answer',
           text: 'Premium search, data enrichment, research APIs, MCP tools, datasets, model endpoints, and agent-native services are good L402 candidates when value is tied to each request.',
@@ -142,11 +142,11 @@ export default function L402AgentPaymentsPage() {
     '@context': 'https://schema.org',
     '@type': 'HowTo',
     name: 'How to monetize APIs with L402 agent payments',
-    description: 'Use SatGate Charge to issue an HTTP 402 payment challenge, verify Lightning payment proof, and unlock API access for autonomous agents.',
+    description: 'Use SatGate to govern an HTTP 402/L402 paid-access flow, verify Lightning payment proof, preserve receipts, and unlock scoped API access for autonomous agents.',
     totalTime: 'PT20M',
     step: [
       { '@type': 'HowToStep', name: 'Protect the API route', text: 'Put SatGate in front of the API, tool, dataset, or premium endpoint that autonomous agents should pay to access.' },
-      { '@type': 'HowToStep', name: 'Set a request price', text: 'Define per-request, per-tool, dataset, or premium capability pricing for robot customers.' },
+      { '@type': 'HowToStep', name: 'Set a request price', text: 'Define per-request, per-tool, dataset, or premium capability pricing for agent/API paid access.' },
       { '@type': 'HowToStep', name: 'Return an L402 challenge', text: 'When an unpaid agent requests the resource, return an HTTP 402 challenge with a Lightning invoice and access credential.' },
       { '@type': 'HowToStep', name: 'Verify payment proof', text: 'Accept the agent response only after SatGate validates the payment proof and request policy.' },
       { '@type': 'HowToStep', name: 'Forward and audit access', text: 'Unlock the approved request and record agent identity, route, price, proof, and policy outcome.' },
@@ -177,19 +177,19 @@ export default function L402AgentPaymentsPage() {
           </div>
 
           <h1 className="text-5xl md:text-7xl font-extrabold tracking-tight max-w-5xl mb-8">
-            Let AI Agents Pay for APIs Like Customers
+            L402 Agent Payments, Governed Before Access
           </h1>
 
           <p className="text-xl md:text-2xl text-gray-300 max-w-4xl leading-relaxed mb-10">
-            SatGate Charge uses L402 Lightning payments to let robot customers unlock protected APIs, tools, datasets, and premium capabilities at request time.
+            L402 Lightning can let agents satisfy HTTP 402 payment challenges. SatGate decides whether the agent is authorized to spend, unlocks only scoped access, and preserves proof for every paid action.
           </p>
 
           <div className="flex flex-col sm:flex-row gap-4">
-            <Link href="/blog/l402-protocol-explained" className="inline-flex items-center justify-center gap-2 rounded-lg bg-white text-black px-6 py-3 font-bold hover:bg-gray-200 transition">
-              Read the L402 guide <ArrowRight size={18} />
+            <Link href="/govern" className="inline-flex items-center justify-center gap-2 rounded-lg bg-white text-black px-6 py-3 font-bold hover:bg-gray-200 transition">
+              Govern L402 access <ArrowRight size={18} />
             </Link>
-            <Link href="/monetize" className="inline-flex items-center justify-center gap-2 rounded-lg border border-gray-700 px-6 py-3 font-bold text-white hover:border-yellow-500 transition">
-              Monetize APIs
+            <Link href="/policy-to-proof" className="inline-flex items-center justify-center gap-2 rounded-lg border border-gray-700 px-6 py-3 font-bold text-white hover:border-yellow-500 transition">
+              See Policy-to-Proof
             </Link>
           </div>
         </div>
@@ -197,16 +197,16 @@ export default function L402AgentPaymentsPage() {
 
       <section className="max-w-6xl mx-auto px-6 py-20 grid lg:grid-cols-[1fr_0.9fr] gap-12 items-start">
         <div>
-          <h2 className="text-3xl font-bold text-white mb-6">The next API customer is not always a human</h2>
+          <h2 className="text-3xl font-bold text-white mb-6">The next API call may be paid by an agent</h2>
           <div className="space-y-5 text-gray-300 text-lg leading-relaxed">
             <p>
               AI agents increasingly discover, evaluate, call, and combine APIs on behalf of people and companies. That creates a new customer type: software that can decide an API is worth paying for right now.
             </p>
             <p>
-              Traditional API monetization assumes a human signs up, enters a card, picks a plan, stores a key, and then integrates. Robot customers need a request-native flow: ask for resource, receive price, pay, unlock access, continue task.
+              Traditional API monetization assumes a human signs up, enters a card, picks a plan, stores a key, and then integrates. Agent/API paid access needs a request-native flow: ask for resource, receive price, pay, unlock scoped access, continue task.
             </p>
             <p>
-              L402 gives that flow an internet-native shape. SatGate puts it in front of APIs as the Charge mode of the economic control plane.
+              L402 gives that flow an internet-native shape. SatGate treats it as paid-rail context governed by request-path policy and proof.
             </p>
           </div>
         </div>
@@ -249,7 +249,7 @@ export default function L402AgentPaymentsPage() {
             <h2 className="text-3xl font-bold text-white mb-5">L402, shared payment tokens, and agent wallets are different layers</h2>
             <div className="space-y-4 text-gray-300 text-lg leading-relaxed">
               <p>
-                HTTP 402 can carry different payment challenges. Some flows use card credentials or shared payment tokens. SatGate Charge uses L402 Lightning for request-native API monetization.
+                HTTP 402 can carry different payment challenges. Some flows use card credentials or shared payment tokens. L402 Lightning is one paid rail for request-native API access.
               </p>
               <p>
                 The important control-plane question is broader than payment: whether the agent has authority, budget, scope, and policy approval before paid access is unlocked.
@@ -274,13 +274,13 @@ export default function L402AgentPaymentsPage() {
       </section>
 
       <section className="max-w-6xl mx-auto px-6 py-20">
-        <h2 className="text-3xl font-bold text-white mb-8">Robot-customer payment requirements</h2>
+        <h2 className="text-3xl font-bold text-white mb-8">Governed L402 payment requirements</h2>
         <div className="grid md:grid-cols-2 gap-5 mb-16">
           {[
             ['Machine-readable price', 'Agents need a price and payment challenge in the protocol flow, not a human checkout page or sales form.'],
             ['Payment before access', 'SatGate verifies L402 Lightning payment proof before forwarding the protected API request upstream.'],
             ['Scoped unlocks', 'Payment should unlock the requested route, tool, dataset, or capability — not a broad reusable API key.'],
-            ['Revenue audit trail', 'Every paid request should record agent identity, route, price, proof, settlement evidence, and access decision.'],
+            ['Evidence Pack receipts', 'Every paid request should record agent identity, route, price, payment proof, policy decision, and Evidence Pack receipt.'],
           ].map(([title, body]) => (
             <div key={title} className="rounded-xl border border-gray-800 bg-gray-950 p-6">
               <h3 className="text-xl font-bold text-white mb-2">{title}</h3>
@@ -289,7 +289,7 @@ export default function L402AgentPaymentsPage() {
           ))}
         </div>
 
-        <h2 className="text-3xl font-bold text-white mb-8">A robot-customer request flow</h2>
+        <h2 className="text-3xl font-bold text-white mb-8">A governed L402 request flow</h2>
         <div className="rounded-2xl border border-gray-800 bg-gray-950 p-6 overflow-x-auto">
           <pre className="text-sm text-gray-300"><code>{`# Agent attempts a protected API call
 sz fetch https://api.example.com/premium-research --max-sats 25
@@ -303,7 +303,7 @@ HTTP/1.1 200 OK
 { "answer": "paid premium result" }`}</code></pre>
         </div>
         <p className="text-gray-400 mt-5 leading-relaxed">
-          In this pattern, the merchant runs SatGate. The robot customer runs a wallet/client. Payment, authorization, and audit happen before upstream access.
+          In this pattern, the merchant runs SatGate. The agent or wallet client presents payment proof. Payment, authorization, receipt capture, and audit happen before upstream access.
         </p>
       </section>
 
@@ -320,9 +320,9 @@ HTTP/1.1 200 OK
             <p className="text-gray-400 leading-relaxed">Limit which agents, routes, prices, budgets, and proofs are accepted before unlocking protected resources.</p>
           </div>
           <div className="rounded-2xl border border-gray-800 bg-black p-6">
-            <div className="text-yellow-300 font-mono text-sm mb-3">CHARGE</div>
-            <h3 className="text-xl font-bold text-white mb-3">Collect per request</h3>
-            <p className="text-gray-400 leading-relaxed">Use L402 Lightning payments to charge autonomous agents for API access at the moment of demand.</p>
+            <div className="text-yellow-300 font-mono text-sm mb-3">PROVE</div>
+            <h3 className="text-xl font-bold text-white mb-3">Preserve the receipt</h3>
+            <p className="text-gray-400 leading-relaxed">Use L402 payment proof as one input to a Policy-to-Proof receipt that records authority, rail, price, and decision.</p>
           </div>
         </div>
       </section>
@@ -339,19 +339,19 @@ HTTP/1.1 200 OK
               </p>
             </div>
             <div className="rounded-xl border border-gray-800 bg-gray-950 p-6">
-              <h3 className="mb-2 text-xl font-bold text-white">Why use L402 for robot customers?</h3>
+              <h3 className="mb-2 text-xl font-bold text-white">Why use L402 for agent/API paid access?</h3>
               <p className="text-gray-400 leading-relaxed">
-                Robot customers need programmatic, low-friction payment. L402 combines HTTP 402, Lightning invoices, and access credentials so agents can pay for APIs without manual checkout.
+                Agent/API paid access needs programmatic, low-friction payment. L402 combines HTTP 402, Lightning invoices, and access credentials so agents can pay for APIs without manual checkout.
               </p>
             </div>
             <div className="rounded-xl border border-gray-800 bg-gray-950 p-6">
-              <h3 className="mb-2 text-xl font-bold text-white">Is SatGate Charge the same as Fiat402?</h3>
+              <h3 className="mb-2 text-xl font-bold text-white">Is L402 enough to govern paid agent access?</h3>
               <p className="text-gray-400 leading-relaxed">
-                No. SatGate Charge is L402 Lightning for request-path agent/API payments. Fiat402 is a separate concept and should not be conflated with Charge.
+                No. L402 is a payment/access rail. SatGate Policy-to-Proof governs authority, scope, budget, revocation, and Evidence Pack evidence.
               </p>
             </div>
             <div className="rounded-xl border border-gray-800 bg-gray-950 p-6">
-              <h3 className="mb-2 text-xl font-bold text-white">What APIs are good candidates for robot-customer payments?</h3>
+              <h3 className="mb-2 text-xl font-bold text-white">What APIs are good candidates for agent/API paid access?</h3>
               <p className="text-gray-400 leading-relaxed">
                 Premium search, data enrichment, research APIs, MCP tools, datasets, model endpoints, and agent-native services are good L402 candidates when value is tied to each request.
               </p>
@@ -370,18 +370,18 @@ HTTP/1.1 200 OK
             </div>
           </div>
 
-          <h2 className="text-3xl font-bold text-white mb-8">Related robot-payment guides</h2>
+          <h2 className="text-3xl font-bold text-white mb-8">Related paid-agent-access guides</h2>
           <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-4">
             {[
               ['/http-402-for-ai-agents', 'HTTP 402 for AI agents', 'Compare payment challenges, shared payment tokens, and L402 for autonomous agents.'],
               ['/agent-payment-controls', 'Agent payment controls', 'Govern budgets, approval, payment rails, audit, and access policy.'],
               ['/stripe-link-agents-vs-satgate', 'Stripe Link for Agents vs SatGate', 'See how agent wallets differ from SatGate economic governance.'],
-              ['/l402-api-pricing-calculator', 'L402 API pricing calculator', 'Estimate per-request robot-customer pricing, gross margin, and Lightning sats per API request.'],
-              ['/robot-customer-payments', 'Robot customer payments', 'How autonomous agents become paying API customers in the request path.'],
+              ['/policy-to-proof', 'Policy-to-Proof', 'See how paid access becomes Evidence Pack proof.'],
+              ['/govern', 'Govern AI agents', 'Govern paid agent actions before execution.'],
               ['/agent-capability-tokens', 'Agent capability tokens', 'Scope paid access with route, budget, expiry, delegation, and revocation caveats.'],
               ['/blog/l402-protocol-explained', 'L402 protocol explained', 'How HTTP 402, Lightning, and macaroons enable API payments.'],
-              ['/blog/api-monetization-ai', 'API monetization for AI', 'How to price, meter, and collect from machine consumers.'],
-              ['/economic-firewall', 'Economic firewall', 'Observe, Control, and Charge in one request-path control plane.'],
+              ['/l402-api-pricing-calculator', 'L402 API pricing calculator', 'Estimate per-request agent/API paid-access pricing.'],
+              ['/economic-firewall', 'Economic firewall', 'Observe, Control, and Prove in one request-path control plane.'],
             ].map(([href, title, body]) => (
               <Link key={href} href={href} className="rounded-xl border border-gray-800 bg-gray-950 p-5 transition hover:border-yellow-500/50 hover:bg-yellow-950/10">
                 <h3 className="font-bold text-white mb-2">{title}</h3>
@@ -394,16 +394,16 @@ HTTP/1.1 200 OK
 
       <section className="max-w-6xl mx-auto px-6 py-20">
         <div className="rounded-3xl border border-yellow-900/60 bg-gradient-to-br from-yellow-950/20 to-cyan-950/30 p-8 md:p-12">
-          <h2 className="text-3xl font-bold text-white mb-4">Turn protected APIs into robot-customer products</h2>
+          <h2 className="text-3xl font-bold text-white mb-4">Govern L402-paid access with Policy-to-Proof</h2>
           <p className="text-gray-300 text-lg leading-relaxed max-w-3xl mb-8">
-            SatGate gives API teams a request-path control plane for observing, controlling, and charging AI agents. Charge is L402 Lightning: simple, programmatic, and built for autonomous access.
+            L402 can prove payment. SatGate proves the action was authorized: who acted, what policy applied, which rail was used, what was paid, and why access was allowed or denied.
           </p>
           <div className="flex flex-col sm:flex-row gap-4">
-            <Link href="/pay" className="inline-flex items-center justify-center gap-2 rounded-lg bg-white text-black px-6 py-3 font-bold hover:bg-gray-200 transition">
-              Try the payment demo <ArrowRight size={18} />
+            <Link href="/govern" className="inline-flex items-center justify-center gap-2 rounded-lg bg-white text-black px-6 py-3 font-bold hover:bg-gray-200 transition">
+              Govern paid agent actions <ArrowRight size={18} />
             </Link>
-            <Link href="/blog/http-402-payment-required-use-cases" className="inline-flex items-center justify-center gap-2 rounded-lg border border-gray-700 px-6 py-3 font-bold text-white hover:border-yellow-500 transition">
-              HTTP 402 use cases
+            <Link href="/policy-to-proof" className="inline-flex items-center justify-center gap-2 rounded-lg border border-gray-700 px-6 py-3 font-bold text-white hover:border-yellow-500 transition">
+              View Policy-to-Proof
             </Link>
           </div>
         </div>

--- a/satgate-landing/scripts/check_policy_to_proof_page.py
+++ b/satgate-landing/scripts/check_policy_to_proof_page.py
@@ -24,6 +24,11 @@ SPEND_LONGTAIL_PAGES = {
     "agent-payment-controls": ROOT / "app" / "agent-payment-controls" / "page.tsx",
 }
 
+L402_RAIL_PAGES = {
+    "http-402-for-ai-agents": ROOT / "app" / "http-402-for-ai-agents" / "page.tsx",
+    "l402-agent-payments": ROOT / "app" / "l402-agent-payments" / "page.tsx",
+}
+
 required_phrases = [
     "Every agent action leaves a receipt",
     "without permanent credentials, unlimited spend, or unobservable authority",
@@ -399,6 +404,49 @@ spend_longtail_forbidden_phrases = {
     ],
 }
 
+l402_rail_required_phrases = {
+    "http-402-for-ai-agents": [
+        "Payment Required, governed before execution",
+        "authority to spend",
+        "Evidence Pack receipt",
+        "Govern paid agent actions",
+        "See Policy-to-Proof",
+        "L402 Lightning is one paid rail",
+        "/govern",
+        "/policy-to-proof",
+        "/l402-agent-payments",
+    ],
+    "l402-agent-payments": [
+        "L402 Agent Payments, Governed Before Access",
+        "SatGate applies Policy-to-Proof before execution",
+        "preserves proof for every paid action",
+        "Evidence Pack receipt",
+        "Govern L402 access",
+        "Govern paid agent actions",
+        "View Policy-to-Proof",
+        "/govern",
+        "/policy-to-proof",
+        "/http-402-for-ai-agents",
+    ],
+}
+
+l402_rail_forbidden_phrases = [
+    "robot customers",
+    "robot-customer",
+    "SatGate Charge",
+    "Charge/L402",
+    "L402 Charge",
+    "Charge is L402",
+    "L402 is SatGate Charge",
+    "when APIs become products",
+    "when APIs become robot-customer products",
+    "Turn protected APIs into robot-customer products",
+    "Try the payment demo",
+    "Monetize APIs",
+    "Price L402 API access",
+    "Grade your readiness",
+]
+
 
 def main() -> int:
     if not PAGE.exists():
@@ -460,6 +508,15 @@ def main() -> int:
         stale_longtail = [phrase for phrase in spend_longtail_forbidden_phrases[name] if phrase in page_text]
         if stale_longtail:
             raise SystemExit(f"stale {name} spend/Charge-first phrases remain:\n" + "\n".join(stale_longtail))
+
+    for name, path in L402_RAIL_PAGES.items():
+        page_text = path.read_text()
+        missing_l402 = [phrase for phrase in l402_rail_required_phrases[name] if phrase not in page_text]
+        if missing_l402:
+            raise SystemExit(f"missing {name} paid-rail authority/proof phrases:\n" + "\n".join(missing_l402))
+        stale_l402 = [phrase for phrase in l402_rail_forbidden_phrases if phrase in page_text]
+        if stale_l402:
+            raise SystemExit(f"stale {name} Charge/robot-customer phrases remain:\n" + "\n".join(stale_l402))
     return 0
 
 


### PR DESCRIPTION
## Summary
- Reframe `/http-402-for-ai-agents` and `/l402-agent-payments` as paid-rail context governed by SatGate Policy-to-Proof
- Preserve HTTP 402/L402 SEO intent while removing robot-customer / SatGate Charge product-center framing
- Route high-intent exits to `/govern` and `/policy-to-proof`
- Extend regression guard coverage to the L402 rail cluster

## Verification
- python scripts/check_policy_to_proof_page.py
- npx eslint app/http-402-for-ai-agents/page.tsx app/l402-agent-payments/page.tsx --no-error-on-unmatched-pattern
- npm run build
- local rendered verification for both pages on 127.0.0.1:3008
- independent reviewer pass
