### PR TITLE
Align MCP cluster with Policy-to-Proof

### DIFF
--- a/satgate-landing/app/agent-api-governance/page.tsx
+++ b/satgate-landing/app/agent-api-governance/page.tsx
@@ -3,7 +3,7 @@ import { ArrowRight, BadgeCheck, Ban, Clock, Fingerprint, GitBranch, KeyRound, S
 
 export const metadata = {
   title: 'Agent API Governance | Identity, Revocation, Budgets, Audit',
-  description: 'Govern AI agent API access with scoped capabilities, revocation, delegated budgets, and audit trails. Replace unlimited API keys with request-path policy.',
+  description: 'Govern AI agent API access with scoped capabilities, delegation limits, revocation, policy checks, and audit receipts. Replace unlimited API keys with authority enforced before execution.',
   alternates: { canonical: 'https://satgate.io/agent-api-governance' },
   keywords: [
     'agent API governance',
@@ -25,7 +25,7 @@ export const metadata = {
   twitter: {
     card: 'summary_large_image',
     title: 'Agent API Governance',
-    description: 'Govern AI agent identity, delegated access, revocation, budgets, and audit trails before API calls execute.',
+    description: 'Govern AI agent identity, delegated access, revocation, policy checks, and audit receipts before API calls execute.',
   },
 };
 
@@ -58,7 +58,7 @@ const principles = [
   {
     icon: BadgeCheck,
     title: 'Audit should explain decisions',
-    body: 'A governance trail must show identity, capability, policy, budget, route, decision, and outcome for every important call.',
+    body: 'A governance trail must show identity, capability, policy, budget, route, decision, outcome, and Evidence Pack receipt for every important call.',
   },
 ];
 
@@ -91,7 +91,7 @@ export default function AgentApiGovernancePage() {
         name: 'What is agent API governance?',
         acceptedAnswer: {
           '@type': 'Answer',
-          text: 'Agent API governance is the request-path policy layer for AI agent identity, delegated authority, budgets, revocation, routing, and audit trails.',
+          text: 'Agent API governance is the request-path policy layer for AI agent identity, delegated authority, budgets, revocation, routing, and audit receipts.',
         },
       },
       {
@@ -133,7 +133,7 @@ export default function AgentApiGovernancePage() {
     '@context': 'https://schema.org',
     '@type': 'ItemList',
     name: 'Agent API governance requirements',
-    description: 'Core request-path controls required to govern AI agent API access without broad static keys.',
+    description: 'Core request-path controls required to govern AI agent API access without broad static keys, then preserve audit receipts for Evidence Pack proof.',
     itemListElement: [
       {
         '@type': 'ListItem',
@@ -190,15 +190,15 @@ export default function AgentApiGovernancePage() {
           </h1>
 
           <p className="text-xl md:text-2xl text-gray-300 max-w-4xl leading-relaxed mb-10">
-            AI agents need more than static API keys. They need scoped capabilities, delegated budgets, expiry, revocation, and audit trails enforced before every API request.
+            AI agents need more than static API keys. They need scoped capabilities, delegation limits, expiry, revocation, and policy checks before every API request — with a receipt proving each decision.
           </p>
 
           <div className="flex flex-col sm:flex-row gap-4">
-            <Link href="/blog/macaroon-tokens-vs-api-keys" className="inline-flex items-center justify-center gap-2 rounded-lg bg-white text-black px-6 py-3 font-bold hover:bg-gray-200 transition">
-              Macaroons vs API keys <ArrowRight size={18} />
+            <Link href="/govern" className="inline-flex items-center justify-center gap-2 rounded-lg bg-white text-black px-6 py-3 font-bold hover:bg-gray-200 transition">
+              See SatGate governance <ArrowRight size={18} />
             </Link>
-            <Link href="/economic-firewall" className="inline-flex items-center justify-center gap-2 rounded-lg border border-gray-700 px-6 py-3 font-bold text-white hover:border-cyan-500 transition">
-              Economic firewall overview
+            <Link href="/policy-to-proof" className="inline-flex items-center justify-center gap-2 rounded-lg border border-gray-700 px-6 py-3 font-bold text-white hover:border-cyan-500 transition">
+              See Policy-to-Proof
             </Link>
           </div>
         </div>
@@ -228,7 +228,7 @@ export default function AgentApiGovernancePage() {
             <li className="rounded-lg border border-gray-800 bg-black/50 p-3">What spend budget remains?</li>
             <li className="rounded-lg border border-gray-800 bg-black/50 p-3">Can authority be delegated, and how far?</li>
             <li className="rounded-lg border border-gray-800 bg-black/50 p-3">When does it expire or become invalid?</li>
-            <li className="rounded-lg border border-gray-800 bg-black/50 p-3">What audit event proves the decision?</li>
+            <li className="rounded-lg border border-gray-800 bg-black/50 p-3">What audit receipt proves the decision and feeds the Evidence Pack?</li>
           </ul>
         </div>
       </section>
@@ -237,7 +237,7 @@ export default function AgentApiGovernancePage() {
         <div className="max-w-6xl mx-auto px-6 py-20">
           <h2 className="text-3xl font-bold text-white mb-4">Agent API governance principles</h2>
           <p className="text-gray-400 max-w-3xl mb-10 text-lg">
-            Governance is not a login screen. It is a request-path policy system for agent identity, authority, spend, and evidence.
+            Governance is not a login screen. It is a request-path policy system that checks authority before execution and turns every decision into evidence.
           </p>
 
           <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-5">
@@ -284,7 +284,7 @@ export default function AgentApiGovernancePage() {
             ['Budget', 'External or manual', 'Embedded or enforced inline'],
             ['Delegation', 'Copied or shared', 'Attenuated: sub-agents get less authority'],
             ['Revocation', 'Rotate key or change config', 'Revoke/expire capability before next request'],
-            ['Audit', 'Often aggregate usage only', 'Decision trail per agent/tool/request'],
+            ['Audit', 'Often aggregate usage only', 'Evidence Pack receipt per agent/tool/request'],
           ].map(([a, b, c]) => (
             <div key={a} className="grid md:grid-cols-3 border-t border-gray-800 text-gray-300">
               <div className="p-4 font-semibold text-white">{a}</div>
@@ -305,7 +305,7 @@ export default function AgentApiGovernancePage() {
                 ['Observe', 'Attribute calls and learn real access/spend patterns.'],
                 ['Control', 'Enforce budgets, route policy, tool limits, and revocation.'],
                 ['Delegate', 'Allow sub-agents to receive narrower authority than the parent.'],
-                ['Audit', 'Record policy decisions, spend, outcomes, and revocation events.'],
+                ['Prove', 'Record policy decisions, spend, outcomes, revocation events, and Evidence Pack receipts.'],
               ].map(([title, body]) => (
                 <div key={title} className="rounded-xl border border-gray-800 bg-black p-5">
                   <h3 className="text-lg font-bold text-white mb-2">{title}</h3>
@@ -317,19 +317,26 @@ export default function AgentApiGovernancePage() {
 
           <div className="rounded-2xl border border-cyan-900/50 bg-cyan-950/10 p-6">
             <h2 className="text-2xl font-bold text-white mb-4">Example capability policy</h2>
-            <pre className="bg-black border border-gray-800 rounded-lg p-4 overflow-x-auto text-sm text-gray-300"><code>{`agent: research-bot
+            <pre className="bg-black border border-gray-800 rounded-lg p-4 overflow-x-auto text-sm text-gray-300"><code>{`parent_agent: finance-automation
+worker_agent: invoice-reconciler
 scope:
-  routes: [/v1/responses, /tools/search]
-  models: [gpt-5.5, venice/deepseek]
+  routes: [/invoices/read, /vendors/match, /payments/schedule]
+  denied_routes: [/payments/release]
+authority:
+  tenant: acme-finance
+  workflow: monthly-close
 budget:
-  daily: 25.00 USD
+  workflow: 25.00 USD
   per_request: 0.50 USD
 delegation:
   allowed: true
+  max_depth: 1
   child_budget_max: 5.00 USD
 expiry: 2026-04-26T00:00:00Z
-revocation: immediate
-audit: required`}</code></pre>
+revocation: before_next_request
+evidence:
+  receipt: required
+  include: [parent_agent, worker_agent, route, policy, decision, outcome]`}</code></pre>
           </div>
         </div>
       </section>
@@ -342,7 +349,7 @@ audit: required`}</code></pre>
             <div className="rounded-xl border border-gray-800 bg-gray-950 p-6">
               <h3 className="mb-2 text-xl font-bold text-white">What is agent API governance?</h3>
               <p className="text-gray-400 leading-relaxed">
-                Agent API governance is the request-path policy layer for AI agent identity, delegated authority, budgets, revocation, routing, and audit trails.
+                Agent API governance is the request-path policy layer for AI agent identity, delegated authority, budgets, revocation, routing, and audit receipts.
               </p>
             </div>
             <div className="rounded-xl border border-gray-800 bg-gray-950 p-6">
@@ -377,11 +384,11 @@ audit: required`}</code></pre>
               ['/agent-api-key-risk-assessment', 'Agent API key risk assessment', 'Score static key risk across scope, budget, expiry, revocation, delegation, and audit gaps.'],
               ['/revocable-agent-credentials', 'Revocable agent credentials', 'Scoped credentials, expiry, and kill switches for autonomous access.'],
               ['/agent-capability-tokens', 'Agent capability tokens', 'Encode scope, budget, route, delegation, and revocation into agent authority.'],
-              ['/blog/zero-trust-for-ai-agents', 'Zero trust for AI agents', 'How agent credentials break human-centric identity assumptions.'],
-              ['/agent-control-plane', 'Agent control plane', 'Govern local agent authority, delegation lineage, spend, audit, and revocation.'],
-              ['/economic-firewall', 'Economic firewall', 'The request-path control layer for agent access and spend.'],
-              ['/economic-firewall-readiness-grader', 'Economic firewall readiness grader', 'Score identity, budgets, revocation, audit, routing, MCP, and Charge readiness.'],
-              ['/mcp-governance', 'MCP governance', 'Apply budgets, revocation, and audit to agent tool calls.'],
+              ['/policy-to-proof', 'Policy-to-Proof', 'See how agent API decisions become Evidence Pack proof.'],
+              ['/blog/macaroon-tokens-vs-api-keys', 'Macaroons vs API keys', 'Why attenuated capabilities beat static API keys for agents.'],
+              ['/agent-control-plane', 'Agent control plane', 'Govern enterprise agent authority, delegation lineage, spend, audit, and revocation.'],
+              ['/economic-firewall', 'Economic firewall', 'The request-path control layer for agent access, spend, and proof.'],
+              ['/mcp-governance', 'MCP governance', 'Apply authority, budgets, revocation, and audit receipts to agent tool calls.'],
             ].map(([href, title, body]) => (
               <Link key={href} href={href} className="rounded-xl border border-gray-800 bg-gray-950 p-5 transition hover:border-yellow-500/50 hover:bg-yellow-950/10">
                 <h3 className="font-bold text-white mb-2">{title}</h3>
@@ -396,14 +403,14 @@ audit: required`}</code></pre>
         <div className="rounded-3xl border border-yellow-900/60 bg-gradient-to-br from-yellow-950/20 to-cyan-950/30 p-8 md:p-12">
           <h2 className="text-3xl font-bold text-white mb-4">SatGate makes agent API access governable</h2>
           <p className="text-gray-300 text-lg leading-relaxed max-w-3xl mb-8">
-            Put SatGate in the request path to move from unlimited API keys to scoped, revocable, budget-aware agent capabilities with audit trails.
+            Put SatGate in the request path to move from unlimited API keys to scoped, revocable agent capabilities. Check authority before execution and produce audit receipts for the Evidence Pack.
           </p>
           <div className="flex flex-col sm:flex-row gap-4">
             <Link href="/govern" className="inline-flex items-center justify-center gap-2 rounded-lg bg-white text-black px-6 py-3 font-bold hover:bg-gray-200 transition">
               See SatGate governance <ArrowRight size={18} />
             </Link>
-            <Link href="/blog/zero-trust-for-ai-agents" className="inline-flex items-center justify-center gap-2 rounded-lg border border-gray-700 px-6 py-3 font-bold text-white hover:border-cyan-500 transition">
-              Zero trust for AI agents
+            <Link href="/policy-to-proof" className="inline-flex items-center justify-center gap-2 rounded-lg border border-gray-700 px-6 py-3 font-bold text-white hover:border-cyan-500 transition">
+              See Policy-to-Proof
             </Link>
           </div>
         </div>

--- a/satgate-landing/app/mcp-gateway/page.tsx
+++ b/satgate-landing/app/mcp-gateway/page.tsx
@@ -1,14 +1,14 @@
 import Link from 'next/link';
-import { ArrowRight, Cable, DollarSign, Eye, Gauge, LockKeyhole, ServerCog } from 'lucide-react';
+import { ArrowRight, Cable, Eye, Gauge, LockKeyhole, ReceiptText, ServerCog } from 'lucide-react';
 
 export const metadata = {
   title: 'MCP Gateway for Governed Agent Tool Access',
-  description: 'Use SatGate as an MCP gateway to observe, control, and charge for agent tool access across SaaS and hybrid deployments.',
+  description: 'Use SatGate as an MCP gateway to check agent authority before tool execution, enforce policy across SaaS and Hybrid MCP deployments, and record audit receipts for every decision.',
   alternates: { canonical: 'https://satgate.io/mcp-gateway' },
   keywords: ['MCP gateway', 'Model Context Protocol gateway', 'MCP access control', 'MCP budget enforcement', 'MCP tool metering', 'hosted MCP gateway', 'hybrid MCP gateway'],
   openGraph: {
     title: 'MCP Gateway for Governed Agent Tool Access',
-    description: 'Observe, control, and charge for agent tool access across SaaS MCP and Hybrid MCP deployments with SatGate.',
+    description: 'Check authority before tool execution, enforce policy across SaaS MCP and Hybrid MCP deployments, and preserve Evidence Pack receipts with SatGate.',
     url: 'https://satgate.io/mcp-gateway',
     type: 'website',
   },
@@ -20,18 +20,18 @@ export const metadata = {
 };
 
 const controls = [
-  { icon: Eye, title: 'Observe MCP tool usage', body: 'Attribute each MCP call to tenant, agent, token, server, tool, customer, and workflow before finance or security asks for proof.' },
+  { icon: Eye, title: 'Observe MCP tool usage', body: 'Attribute each MCP call to tenant, agent, token, server, tool, customer, and workflow before finance or security asks for Evidence Pack proof.' },
   { icon: LockKeyhole, title: 'Control access and budgets', body: 'Enforce scoped capabilities, tool allowlists, per-tool prices, spend caps, delegation depth, expiry, and instant revocation.' },
-  { icon: DollarSign, title: 'Charge for tool access', body: 'Turn governed MCP usage into meterable events for chargeback, enterprise billing, or robot-customer monetization.' },
+  { icon: ReceiptText, title: 'Produce audit receipts', body: 'Record the agent, tool, policy, decision, budget state, outcome, and receipt ID so MCP activity can be reviewed in an Evidence Pack.' },
   { icon: ServerCog, title: 'Run SaaS or Hybrid MCP', body: 'Use Fly-hosted SaaS MCP for fast onboarding or Hetzner-hosted Hybrid MCP when buyers need dedicated runtime control.' },
 ];
 
 const faqs = [
-  ['What is an MCP gateway?', 'An MCP gateway sits between AI agents and Model Context Protocol servers. It observes tool calls, applies access policy and budgets, records audit trails, and can turn usage into chargeable events before tools execute.'],
+  ['What is an MCP gateway?', 'An MCP gateway sits between AI agents and Model Context Protocol servers. It observes tool calls, applies access policy and budgets, records audit receipts, and proves decisions before tools execute.'],
   ['Why do MCP tools need access control?', 'MCP makes tools easy for agents to reach, which also makes expensive or sensitive tools easy to overuse. Access control limits which agents can call which tools, for how long, under which budget, and with what delegation.'],
   ['Can SatGate host MCP servers?', 'Yes. SatGate supports SaaS MCP for fast hosted deployment and Hybrid MCP for dedicated enterprise runtime control. The critical split is simple: SaaS MCP is Fly-hosted; Hybrid MCP is Hetzner-hosted.'],
   ['How is an MCP gateway different from an API gateway?', 'A traditional API gateway mostly routes HTTP traffic and checks identity. An MCP gateway also understands agent tool calls, capability scope, per-tool cost, budget policy, delegation lineage, and audit outcomes.'],
-  ['Can MCP usage be monetized?', 'Yes. Once tool usage is identified, priced, and metered, SatGate can support chargeback, invoiceable usage, or Charge-mode payment flows where appropriate.'],
+  ['Can MCP usage produce audit evidence?', 'Yes. Once tool usage is identified, governed, and metered, SatGate can support chargeback or invoiceable usage while preserving policy decisions in the Evidence Pack.'],
 ];
 
 export default function McpGatewayPage() {
@@ -77,14 +77,14 @@ export default function McpGatewayPage() {
             MCP Gateway for Governed Agent Tool Access
           </h1>
           <p className="text-xl md:text-2xl text-gray-300 max-w-4xl leading-relaxed mb-8">
-            SatGate is an MCP gateway for teams that need to observe, control, and charge for how agents use tools. Put policy in the request path before MCP calls execute.
+            SatGate is an MCP gateway for teams that need authority before execution. Put policy in the request path so every MCP call is allowed or denied before it reaches a tool, then recorded as proof.
           </p>
           <div className="flex flex-col sm:flex-row gap-4">
             <Link href="/govern" className="inline-flex items-center justify-center gap-2 rounded-lg bg-white text-black px-6 py-3 font-bold hover:bg-gray-200 transition">
               See SatGate governance <ArrowRight size={18} />
             </Link>
-            <Link href="/mcp-tool-cost-policy-generator" className="inline-flex items-center justify-center gap-2 rounded-lg border border-gray-700 px-6 py-3 font-bold text-white hover:border-cyan-500 transition">
-              Generate MCP tool policy
+            <Link href="/policy-to-proof" className="inline-flex items-center justify-center gap-2 rounded-lg border border-gray-700 px-6 py-3 font-bold text-white hover:border-cyan-500 transition">
+              See Policy-to-Proof
             </Link>
           </div>
         </div>
@@ -95,16 +95,16 @@ export default function McpGatewayPage() {
           <h2 className="text-3xl font-bold text-white mb-6">What is an MCP gateway?</h2>
           <div className="space-y-5 text-gray-300 text-lg leading-relaxed">
             <p>
-              An MCP gateway is the control point between agent runtimes and Model Context Protocol servers. Instead of letting agents call tools directly, traffic flows through a policy layer that can identify the agent, price the tool, check budget, enforce scope, and record the decision.
+              An MCP gateway is the control point between agent runtimes and Model Context Protocol servers. Instead of letting agents call tools directly, traffic flows through a policy layer that can identify the agent, check authority, price the tool when needed, enforce scope, and record the decision.
             </p>
             <p>
-              That matters because MCP connections are not governance. Agents can trigger searches, code execution, paid APIs, database calls, browser sessions, and cloud tasks. SatGate makes those calls observable, controllable, and chargeable.
+              That matters because MCP connections are not governance. Agents can trigger searches, code execution, paid APIs, database calls, browser sessions, and cloud tasks. SatGate makes those calls observable, governable, and provable.
             </p>
           </div>
         </div>
         <div className="rounded-2xl border border-cyan-900/50 bg-cyan-950/10 p-6">
           <h3 className="text-xl font-bold text-white mb-4">The request path</h3>
-          {['Agent asks for a tool', 'SatGate checks capability, policy, and budget', 'Allowed calls execute; denied calls stop cleanly', 'Usage is attributed to agent, customer, tool, and tenant', 'Billing, chargeback, or audit events are recorded'].map((step, index) => (
+          {['Agent asks for a tool', 'SatGate checks capability, policy, and budget', 'Allowed calls execute; denied calls stop cleanly', 'Usage is attributed to agent, customer, tool, and tenant', 'An audit receipt is recorded for the Evidence Pack'].map((step, index) => (
             <div key={step} className="flex gap-3 border-b border-gray-800 py-3 last:border-b-0">
               <span className="text-cyan-300 font-bold">{index + 1}</span>
               <span className="text-gray-300">{step}</span>
@@ -115,9 +115,9 @@ export default function McpGatewayPage() {
 
       <section className="border-y border-gray-900 bg-gray-950/60">
         <div className="max-w-6xl mx-auto px-6 py-20">
-          <h2 className="text-3xl font-bold text-white mb-4">Observe, Control, Charge for MCP tools</h2>
+          <h2 className="text-3xl font-bold text-white mb-4">Check, Govern, Prove MCP tool use</h2>
           <p className="text-gray-400 max-w-3xl mb-10 text-lg">
-            SatGate turns MCP tool calls into governed economic events. The point is not just to connect agents to tools. The point is to prove what happened, stop what should not happen, and meter what should be paid for.
+            SatGate turns MCP tool calls into governed authority decisions. The point is not just to connect agents to tools. The point is to prove what happened, stop what should not happen, and preserve receipts for what was allowed or denied.
           </p>
           <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-5">
             {controls.map(({ icon: Icon, title, body }) => (
@@ -166,7 +166,7 @@ export default function McpGatewayPage() {
             ['/capability-auth', 'Capability auth', 'Scope agent authority before tools run.'],
             ['/blog/api-gateway-for-ai-agents', 'API gateway for agents', 'Compare routing with governance.'],
             ['/blog/mcp-budget-enforcement-guide', 'MCP budget enforcement', 'Hard-cap per-tool spend.'],
-            ['/blog/http-402-payment-required-use-cases', 'HTTP 402 use cases', 'Turn access into chargeable events.'],
+            ['/policy-to-proof', 'Policy-to-Proof', 'Turn MCP decisions into Evidence Pack proof.'],
           ].map(([href, title, body]) => (
             <Link key={href} href={href} className="rounded-xl border border-gray-800 bg-gray-950 p-5 hover:border-cyan-700 transition">
               <h3 className="text-lg font-bold text-white mb-2">{title}</h3>
@@ -180,9 +180,9 @@ export default function McpGatewayPage() {
         <div className="max-w-4xl mx-auto px-6 py-20 text-center">
           <Gauge className="mx-auto mb-6 text-cyan-300" size={36} />
           <h2 className="text-3xl font-bold text-white mb-4">Launch an MCP gateway agents can safely use.</h2>
-          <p className="text-gray-300 mb-8">Start with visibility, add budget and capability controls, then charge or bill for usage when tool access becomes economic activity.</p>
-          <Link href="/design-partners" className="inline-flex items-center justify-center gap-2 rounded-lg bg-white px-6 py-3 font-bold text-black hover:bg-gray-200 transition">
-            Work with SatGate <ArrowRight size={18} />
+          <p className="text-gray-300 mb-8">Start with authority checks, enforce policy before execution, and produce audit receipts that prove what each agent was allowed or denied to do.</p>
+          <Link href="/govern" className="inline-flex items-center justify-center gap-2 rounded-lg bg-white px-6 py-3 font-bold text-black hover:bg-gray-200 transition">
+            Govern MCP tool access <ArrowRight size={18} />
           </Link>
         </div>
       </section>

--- a/satgate-landing/app/mcp-governance/page.tsx
+++ b/satgate-landing/app/mcp-governance/page.tsx
@@ -2,8 +2,8 @@ import Link from 'next/link';
 import { ArrowRight, Cable, Eye, Gauge, KeyRound, ShieldAlert, Wrench } from 'lucide-react';
 
 export const metadata = {
-  title: 'MCP Governance: Budget Enforcement, Audit, and Policy',
-  description: 'Govern Model Context Protocol tools with SatGate. Enforce MCP budgets, audit tool calls, revoke agent access, and control spend before tools execute.',
+  title: 'MCP Governance: Authority, Policy, and Audit Receipts',
+  description: 'Govern Model Context Protocol tools with SatGate. Check agent authority before MCP calls execute, enforce policy, revoke access, and produce audit receipts for every decision.',
   alternates: { canonical: 'https://satgate.io/mcp-governance' },
   keywords: [
     'MCP governance',
@@ -17,15 +17,15 @@ export const metadata = {
     'MCP tool spend limits',
   ],
   openGraph: {
-    title: 'MCP Governance: Budget Enforcement, Audit, and Policy',
-    description: 'Control Model Context Protocol tool calls with per-agent budgets, access policy, revocation, audit trails, and spend attribution.',
+    title: 'MCP Governance: Authority, Policy, and Audit Receipts',
+    description: 'Control Model Context Protocol tool calls with authority policy, scoped budgets, revocation, audit receipts, and Evidence Pack proof.',
     url: 'https://satgate.io/mcp-governance',
     type: 'article',
   },
   twitter: {
     card: 'summary_large_image',
     title: 'MCP Governance for AI Agents',
-    description: 'Enforce budgets, policy, revocation, and audit around MCP tool calls before agents execute expensive work.',
+    description: 'Check authority, policy, revocation, and audit receipts around MCP tool calls before agents execute work.',
   },
 };
 
@@ -37,8 +37,8 @@ const controls = [
   },
   {
     icon: Gauge,
-    title: 'Enforce per-tool budgets',
-    body: 'Assign cost to expensive tools, cap spend per session or agent, and block calls before they run.',
+    title: 'Enforce authority and budgets',
+    body: 'Check scope, allowed tools, delegation depth, and budget before forwarding each MCP call.',
   },
   {
     icon: KeyRound,
@@ -52,8 +52,8 @@ const controls = [
   },
   {
     icon: Eye,
-    title: 'Audit every decision',
-    body: 'Record who called which tool, why it was allowed or denied, what it cost, and which policy applied.',
+    title: 'Create audit receipts',
+    body: 'Record who called which tool, why it was allowed or denied, what policy applied, and how the decision feeds the Evidence Pack.',
   },
   {
     icon: Wrench,
@@ -66,7 +66,7 @@ export default function McpGovernancePage() {
   const jsonLd = {
     '@context': 'https://schema.org',
     '@type': 'TechArticle',
-    headline: 'MCP Governance: Budget Enforcement, Audit, and Policy',
+    headline: 'MCP Governance: Authority, Policy, and Audit Receipts',
     description: metadata.description,
     author: { '@type': 'Organization', name: 'SatGate' },
     publisher: { '@type': 'Organization', name: 'SatGate', url: 'https://satgate.io' },
@@ -76,7 +76,7 @@ export default function McpGovernancePage() {
     about: [
       { '@type': 'Thing', name: 'MCP governance' },
       { '@type': 'Thing', name: 'MCP budget enforcement' },
-      { '@type': 'Thing', name: 'Model Context Protocol audit trails' },
+      { '@type': 'Thing', name: 'Model Context Protocol audit receipts' },
       { '@type': 'Thing', name: 'MCP proxy policy' },
       { '@type': 'Thing', name: 'agent tool spend limits' },
     ],
@@ -91,7 +91,7 @@ export default function McpGovernancePage() {
         name: 'What is MCP governance?',
         acceptedAnswer: {
           '@type': 'Answer',
-          text: 'MCP governance is the policy, budget, access-control, revocation, and audit layer around Model Context Protocol tool calls made by AI agents.',
+          text: 'MCP governance is the authority, policy, budget, access-control, revocation, and audit receipt layer around Model Context Protocol tool calls made by AI agents.',
         },
       },
       {
@@ -99,7 +99,7 @@ export default function McpGovernancePage() {
         name: 'Why do MCP tools need budget enforcement?',
         acceptedAnswer: {
           '@type': 'Answer',
-          text: 'Agents can call MCP tools repeatedly, delegate work, and trigger paid APIs or compute-heavy operations. Budget enforcement stops expensive tool calls before they execute.',
+          text: 'Agents can call MCP tools repeatedly, delegate work, and trigger paid APIs or compute-heavy operations. Authority and budget enforcement stop unauthorized tool calls before they execute.',
         },
       },
       {
@@ -123,7 +123,7 @@ export default function McpGovernancePage() {
         name: 'How is MCP governance different from MCP security?',
         acceptedAnswer: {
           '@type': 'Answer',
-          text: 'MCP security focuses on safe tool access, secrets, permissions, and malicious behavior. MCP governance adds economics: who can call which tool, what each call costs, what budget remains, and whether policy allows the request before execution.',
+          text: 'MCP security focuses on safe tool access, secrets, permissions, and malicious behavior. MCP governance adds authority proof: who can call which tool, what budget applies, what policy allows or denies the request, and which receipt proves the decision.',
         },
       },
       {
@@ -141,14 +141,14 @@ export default function McpGovernancePage() {
     '@context': 'https://schema.org',
     '@type': 'HowTo',
     name: 'How to add MCP budget enforcement',
-    description: 'Route MCP tool calls through SatGate so each call can be identified, priced, checked against policy, executed or blocked, and audited.',
+    description: 'Route MCP tool calls through SatGate so each call can be identified, checked against authority policy, allowed or denied before execution, and recorded as an audit receipt.',
     totalTime: 'PT15M',
     step: [
-      { '@type': 'HowToStep', name: 'Proxy MCP traffic', text: 'Place SatGate between the agent runtime and MCP servers so tool calls pass through the economic control plane.' },
+      { '@type': 'HowToStep', name: 'Proxy MCP traffic', text: 'Place SatGate between the agent runtime and MCP servers so tool calls pass through the request-path governance layer.' },
       { '@type': 'HowToStep', name: 'Identify agents and tools', text: 'Attach tenant, agent, session, token, server, and tool metadata to each MCP call.' },
-      { '@type': 'HowToStep', name: 'Assign tool costs', text: 'Set cost and risk values for expensive MCP tools, paid APIs, searches, browser sessions, code agents, or cloud tasks.' },
-      { '@type': 'HowToStep', name: 'Enforce budget policy', text: 'Block, route, allow, or revoke MCP calls based on remaining budget, per-tool limits, and capability policy.' },
-      { '@type': 'HowToStep', name: 'Audit outcomes', text: 'Record the decision, estimated cost, tool, route, policy, and outcome for finance, security, and platform teams.' },
+      { '@type': 'HowToStep', name: 'Map authority and risk', text: 'Set scope, budget, risk, and approval rules for MCP tools, paid APIs, searches, browser sessions, code agents, or cloud tasks.' },
+      { '@type': 'HowToStep', name: 'Enforce authority policy', text: 'Block, route, allow, or revoke MCP calls based on scope, budget, per-tool limits, delegation depth, and capability policy.' },
+      { '@type': 'HowToStep', name: 'Create audit receipts', text: 'Record the decision, estimated cost, tool, route, policy, outcome, and receipt ID for finance, security, and platform teams.' },
     ],
   };
 
@@ -176,19 +176,19 @@ export default function McpGovernancePage() {
           </div>
 
           <h1 className="text-5xl md:text-7xl font-extrabold tracking-tight max-w-5xl mb-8">
-            MCP Governance for Agents That Can Actually Spend Money
+            MCP Governance for Agents That Need Authority Before Execution
           </h1>
 
           <p className="text-xl md:text-2xl text-gray-300 max-w-4xl leading-relaxed mb-10">
-            MCP makes tools easy for agents to use. SatGate makes them governable: budgets, access policy, revocation, audit trails, and spend attribution before tools execute.
+            MCP makes tools easy for agents to use. SatGate makes tool use governable: every MCP call is identified, checked against policy, allowed or denied before execution, and recorded as proof.
           </p>
 
           <div className="flex flex-col sm:flex-row gap-4">
-            <Link href="/mcp-budget-enforcement" className="inline-flex items-center justify-center gap-2 rounded-lg bg-white text-black px-6 py-3 font-bold hover:bg-gray-200 transition">
-              See MCP budget enforcement <ArrowRight size={18} />
+            <Link href="/govern" className="inline-flex items-center justify-center gap-2 rounded-lg bg-white text-black px-6 py-3 font-bold hover:bg-gray-200 transition">
+              See SatGate governance <ArrowRight size={18} />
             </Link>
-            <Link href="/mcp-tool-cost-policy-generator" className="inline-flex items-center justify-center gap-2 rounded-lg border border-gray-700 px-6 py-3 font-bold text-white hover:border-cyan-500 transition">
-              Generate MCP tool policy
+            <Link href="/policy-to-proof" className="inline-flex items-center justify-center gap-2 rounded-lg border border-gray-700 px-6 py-3 font-bold text-white hover:border-cyan-500 transition">
+              See Policy-to-Proof
             </Link>
           </div>
         </div>
@@ -196,7 +196,7 @@ export default function McpGovernancePage() {
 
       <section className="max-w-6xl mx-auto px-6 py-20 grid lg:grid-cols-[1fr_0.9fr] gap-12 items-start">
         <div>
-          <h2 className="text-3xl font-bold text-white mb-6">MCP connects agents to tools. It does not govern the economics.</h2>
+          <h2 className="text-3xl font-bold text-white mb-6">MCP connects agents to tools. It does not govern authority.</h2>
           <div className="space-y-5 text-gray-300 text-lg leading-relaxed">
             <p>
               Model Context Protocol is becoming the common tool interface for agents. Cursor, Claude Desktop, Claude Code, OpenClaw, and other runtimes can connect to tools without every integration being custom-built.
@@ -205,13 +205,13 @@ export default function McpGovernancePage() {
               That is powerful, but it creates a new control problem. An agent with tool access can trigger searches, database calls, code execution, paid APIs, browser sessions, cloud tasks, and expensive workflows. A tool connection is not the same thing as a policy boundary.
             </p>
             <p>
-              MCP governance means every tool call is identified, priced, checked, routed, and audited before it runs.
+              MCP governance means every tool call is identified, checked against authority and budget policy, routed or denied, and recorded as an audit receipt before it runs.
             </p>
           </div>
         </div>
 
         <div className="rounded-2xl border border-cyan-900/50 bg-cyan-950/10 p-6">
-          <h3 className="text-xl font-bold text-white mb-4">Without MCP governance</h3>
+          <h3 className="text-xl font-bold text-white mb-4">Without MCP authority governance</h3>
           <ul className="space-y-3 text-gray-300">
             <li className="rounded-lg border border-gray-800 bg-black/50 p-3">Agents call tools without per-tool spend caps.</li>
             <li className="rounded-lg border border-gray-800 bg-black/50 p-3">Expensive tools look identical to cheap tools.</li>
@@ -226,7 +226,7 @@ export default function McpGovernancePage() {
         <div className="max-w-6xl mx-auto px-6 py-20">
           <h2 className="text-3xl font-bold text-white mb-4">What SatGate adds around MCP</h2>
           <p className="text-gray-400 max-w-3xl mb-10 text-lg">
-            SatGate acts as the economic control plane around MCP tool traffic, so agent access becomes measurable and enforceable without rewriting every tool.
+            SatGate acts as the request-path governance layer around MCP tool traffic, so agent authority becomes measurable, enforceable, and provable without rewriting every tool.
           </p>
 
           <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-5">
@@ -246,10 +246,10 @@ export default function McpGovernancePage() {
         <div className="grid lg:grid-cols-5 gap-4">
           {[
             ['1', 'Identify', 'Which agent, tenant, token, session, and tool?'],
-            ['2', 'Price', 'What does this tool call cost or risk?'],
-            ['3', 'Check', 'Does policy and budget allow it?'],
+            ['2', 'Authorize', 'What scope, budget, and risk policy applies?'],
+            ['3', 'Check', 'Does policy allow this action before execution?'],
             ['4', 'Execute', 'Forward only approved tool calls.'],
-            ['5', 'Audit', 'Record decision, spend, and outcome.'],
+            ['5', 'Prove', 'Record the receipt, decision, spend, and outcome.'],
           ].map(([n, title, body]) => (
             <div key={n} className="rounded-xl border border-gray-800 bg-gray-950 p-5">
               <div className="text-cyan-300 font-mono text-sm mb-3">{n}</div>
@@ -299,20 +299,26 @@ export default function McpGovernancePage() {
           </div>
 
           <div className="rounded-2xl border border-purple-900/50 bg-purple-950/10 p-6">
-            <h2 className="text-2xl font-bold text-white mb-4">MCP budget policy example</h2>
-            <pre className="bg-black border border-gray-800 rounded-lg p-4 overflow-x-auto text-sm text-gray-300"><code>{`agent: cursor-coder
-mcp_server: github-tools
-mode: control
+            <h2 className="text-2xl font-bold text-white mb-4">MCP authority policy example</h2>
+            <pre className="bg-black border border-gray-800 rounded-lg p-4 overflow-x-auto text-sm text-gray-300"><code>{`parent_agent: finance-automation
+worker_agent: invoice-reconciler
+mcp_server: accounts-payable-tools
+authority:
+  tools:
+    invoice_lookup: allow
+    vendor_match: allow
+    payment_schedule: require_approval
+    erp_write: deny
 budget:
-  session: 5.00 USD
-  per_tool_call: 0.25 USD
-tools:
-  repo_search: allow
-  issue_create: allow
-  deploy_prod: deny
-on_budget_exhausted: block
-audit:
-  include: [agent, tool, route, estimated_cost, decision]`}</code></pre>
+  workflow: 25.00 USD
+  per_tool_call: 0.50 USD
+delegation:
+  max_depth: 1
+  child_budget_max: 5.00 USD
+decision:
+  enforce_before_execution: true
+evidence:
+  include: [parent_agent, worker_agent, tool, policy, decision, outcome, receipt_id]`}</code></pre>
           </div>
         </div>
       </section>
@@ -325,13 +331,13 @@ audit:
             <div className="rounded-xl border border-gray-800 bg-gray-950 p-6">
               <h3 className="mb-2 text-xl font-bold text-white">What is MCP governance?</h3>
               <p className="text-gray-400 leading-relaxed">
-                MCP governance is the policy, budget, access-control, revocation, and audit layer around Model Context Protocol tool calls made by AI agents.
+                MCP governance is the authority, policy, budget, access-control, revocation, and audit receipt layer around Model Context Protocol tool calls made by AI agents.
               </p>
             </div>
             <div className="rounded-xl border border-gray-800 bg-gray-950 p-6">
               <h3 className="mb-2 text-xl font-bold text-white">Why do MCP tools need budget enforcement?</h3>
               <p className="text-gray-400 leading-relaxed">
-                Agents can call MCP tools repeatedly, delegate work, and trigger paid APIs or compute-heavy operations. Budget enforcement stops expensive tool calls before they execute.
+                Agents can call MCP tools repeatedly, delegate work, and trigger paid APIs or compute-heavy operations. Authority and budget enforcement stop unauthorized tool calls before they execute.
               </p>
             </div>
             <div className="rounded-xl border border-gray-800 bg-gray-950 p-6">
@@ -349,7 +355,7 @@ audit:
             <div className="rounded-xl border border-gray-800 bg-gray-950 p-6">
               <h3 className="mb-2 text-xl font-bold text-white">How is MCP governance different from MCP security?</h3>
               <p className="text-gray-400 leading-relaxed">
-                MCP security focuses on safe tool access, secrets, permissions, and malicious behavior. MCP governance adds economics: who can call which tool, what each call costs, what budget remains, and whether policy allows the request before execution.
+                MCP security focuses on safe tool access, secrets, permissions, and malicious behavior. MCP governance adds authority proof: who can call which tool, what budget applies, what policy allows or denies the request, and which receipt proves the decision.
               </p>
             </div>
             <div className="rounded-xl border border-gray-800 bg-gray-950 p-6">
@@ -363,11 +369,11 @@ audit:
           <h2 className="text-3xl font-bold text-white mb-8">Related MCP governance topics</h2>
           <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-4">
             {[
+              ['/policy-to-proof', 'Policy-to-Proof', 'See how MCP allow, deny, delegate, and revoke decisions become Evidence Pack proof.'],
+              ['/govern', 'Govern AI agents', 'Govern MCP authority before tool execution.'],
               ['/mcp-budget-enforcement', 'MCP budget enforcement', 'Hard caps, per-tool prices, and request-path budget decisions for MCP servers.'],
               ['/mcp-cost-control', 'MCP cost control', 'Control paid tool calls, retries, SaaS actions, cloud tasks, and data lookups before MCP tools execute.'],
               ['/mcp-tool-cost-policy-generator', 'MCP tool cost policy generator', 'Generate practical policy for Cursor, Claude Desktop, Claude Code, OpenClaw, and custom clients.'],
-              ['/mcp-proxy-config-generator', 'MCP proxy config generator', 'Generate proxy config for Cursor, Claude Desktop, Claude Code, OpenClaw, and custom clients.'],
-              ['/agent-capability-tokens', 'Agent capability tokens', 'Constrain MCP authority with scope, budget, expiry, delegation, and revocation.'],
               ['/satgate-for-cursor', 'SatGate for Cursor', 'Govern Cursor MCP/tool workflows with budgets and audit.'],
               ['/satgate-for-openclaw', 'SatGate for OpenClaw', 'Apply economic policy to proactive agents, sub-agents, and tools.'],
             ].map(([href, title, body]) => (
@@ -384,14 +390,14 @@ audit:
         <div className="rounded-3xl border border-cyan-900/60 bg-gradient-to-br from-cyan-950/30 to-purple-950/30 p-8 md:p-12">
           <h2 className="text-3xl font-bold text-white mb-4">Make MCP tools safe enough for autonomous agents</h2>
           <p className="text-gray-300 text-lg leading-relaxed max-w-3xl mb-8">
-            Connect tools quickly with MCP. Govern them with SatGate. Observe every call, control spend and access, revoke risky capabilities, and charge when tools become products for external agents.
+            Connect tools quickly with MCP. Govern them with SatGate. Check authority before execution, revoke risky capabilities, and turn every allow/deny decision into audit evidence for the Evidence Pack.
           </p>
           <div className="flex flex-col sm:flex-row gap-4">
-            <Link href="/mcp-budget-enforcement" className="inline-flex items-center justify-center gap-2 rounded-lg bg-white text-black px-6 py-3 font-bold hover:bg-gray-200 transition">
-              MCP budget enforcement <ArrowRight size={18} />
+            <Link href="/govern" className="inline-flex items-center justify-center gap-2 rounded-lg bg-white text-black px-6 py-3 font-bold hover:bg-gray-200 transition">
+              Govern MCP tool calls <ArrowRight size={18} />
             </Link>
-            <Link href="/economic-firewall" className="inline-flex items-center justify-center gap-2 rounded-lg border border-gray-700 px-6 py-3 font-bold text-white hover:border-cyan-500 transition">
-              Economic firewall category
+            <Link href="/policy-to-proof" className="inline-flex items-center justify-center gap-2 rounded-lg border border-gray-700 px-6 py-3 font-bold text-white hover:border-cyan-500 transition">
+              See Policy-to-Proof
             </Link>
           </div>
         </div>

--- a/satgate-landing/scripts/check_policy_to_proof_page.py
+++ b/satgate-landing/scripts/check_policy_to_proof_page.py
@@ -29,6 +29,12 @@ L402_RAIL_PAGES = {
     "l402-agent-payments": ROOT / "app" / "l402-agent-payments" / "page.tsx",
 }
 
+MCP_AUTHORITY_PAGES = {
+    "mcp-governance": ROOT / "app" / "mcp-governance" / "page.tsx",
+    "mcp-gateway": ROOT / "app" / "mcp-gateway" / "page.tsx",
+    "agent-api-governance": ROOT / "app" / "agent-api-governance" / "page.tsx",
+}
+
 required_phrases = [
     "Every agent action leaves a receipt",
     "without permanent credentials, unlimited spend, or unobservable authority",
@@ -447,6 +453,78 @@ l402_rail_forbidden_phrases = [
     "Grade your readiness",
 ]
 
+mcp_authority_required_phrases = {
+    "mcp-governance": [
+        "MCP Governance for Agents That Need Authority Before Execution",
+        "before execution",
+        "audit receipt",
+        "Evidence Pack",
+        "finance-automation",
+        "invoice-reconciler",
+        "Govern MCP tool calls",
+        "See Policy-to-Proof",
+        "/govern",
+        "/policy-to-proof",
+    ],
+    "mcp-gateway": [
+        "MCP Gateway for Governed Agent Tool Access",
+        "authority before execution",
+        "audit receipt",
+        "Evidence Pack",
+        "SaaS MCP is Fly-hosted",
+        "Hybrid MCP is Hetzner-hosted",
+        "Govern MCP tool access",
+        "See Policy-to-Proof",
+        "/govern",
+        "/policy-to-proof",
+    ],
+    "agent-api-governance": [
+        "Agent API Governance",
+        "static API keys",
+        "scoped capabilities",
+        "before every API request",
+        "audit receipt",
+        "Evidence Pack",
+        "finance-automation",
+        "invoice-reconciler",
+        "See SatGate governance",
+        "See Policy-to-Proof",
+        "/govern",
+        "/policy-to-proof",
+    ],
+}
+
+mcp_authority_forbidden_phrases = {
+    "mcp-governance": [
+        "Agents That Can Actually Spend Money",
+        "charge when tools become products",
+        "robot-customer",
+        "Charge-mode",
+        "Economic firewall category",
+        "Generate MCP tool policy",
+        "control spend and access",
+        "economic control plane",
+    ],
+    "mcp-gateway": [
+        "observe, control, and charge",
+        "Observe, Control, Charge",
+        "Charge for tool access",
+        "robot-customer",
+        "Charge-mode",
+        "chargeable events",
+        "economic activity",
+        "Generate MCP tool policy",
+        "/blog/http-402-payment-required-use-cases",
+    ],
+    "agent-api-governance": [
+        "research-bot",
+        "local agent authority",
+        "Charge readiness",
+        "Economic firewall overview",
+        "Macaroons vs API keys <ArrowRight",
+    ],
+}
+
 
 def main() -> int:
     if not PAGE.exists():
@@ -517,6 +595,16 @@ def main() -> int:
         stale_l402 = [phrase for phrase in l402_rail_forbidden_phrases if phrase in page_text]
         if stale_l402:
             raise SystemExit(f"stale {name} Charge/robot-customer phrases remain:\n" + "\n".join(stale_l402))
+
+
+    for name, path in MCP_AUTHORITY_PAGES.items():
+        page_text = path.read_text()
+        missing_mcp = [phrase for phrase in mcp_authority_required_phrases[name] if phrase not in page_text]
+        if missing_mcp:
+            raise SystemExit(f"missing {name} MCP authority/proof phrases:\n" + "\n".join(missing_mcp))
+        stale_mcp = [phrase for phrase in mcp_authority_forbidden_phrases[name] if phrase in page_text]
+        if stale_mcp:
+            raise SystemExit(f"stale {name} MCP spend/Charge/local-first phrases remain:\n" + "\n".join(stale_mcp))
     return 0
 
 


### PR DESCRIPTION
## Summary
- Reframe `/mcp-governance`, `/mcp-gateway`, and `/agent-api-governance` around authority before execution, audit receipts, and Evidence Pack proof
- Preserve MCP SEO/category intent while demoting spend/Charge/local-agent residue
- Route decision/proof exits to `/govern` and `/policy-to-proof`
- Add finance-automation → invoice-reconciler examples for cross-page scenario consistency
- Extend Policy-to-Proof regression guards to the MCP authority cluster

## Verification
- python scripts/check_policy_to_proof_page.py
- npx eslint app/mcp-governance/page.tsx app/mcp-gateway/page.tsx app/agent-api-governance/page.tsx --no-error-on-unmatched-pattern
- npm run build
- local rendered verification for all three pages on 127.0.0.1:3009
- independent reviewer pass
