### PR TITLE
fix: align agent API governance triad

### DIFF
--- a/satgate-landing/app/agent-api-governance/page.tsx
+++ b/satgate-landing/app/agent-api-governance/page.tsx
@@ -298,14 +298,12 @@ export default function AgentApiGovernancePage() {
       <section className="border-y border-gray-900 bg-gray-950/60">
         <div className="max-w-6xl mx-auto px-6 py-20 grid lg:grid-cols-2 gap-8">
           <div>
-            <h2 className="text-3xl font-bold text-white mb-6">Governance loop</h2>
+            <h2 className="text-3xl font-bold text-white mb-6">Observe, Control, Prove agent API use</h2>
             <div className="space-y-4">
               {[
-                ['Mint', 'Issue a scoped capability for one agent, task, route, or workflow.'],
-                ['Observe', 'Attribute calls and learn real access/spend patterns.'],
-                ['Control', 'Enforce budgets, route policy, tool limits, and revocation.'],
-                ['Delegate', 'Allow sub-agents to receive narrower authority than the parent.'],
-                ['Prove', 'Record policy decisions, spend, outcomes, revocation events, and Evidence Pack receipts.'],
+                ['Observe', 'Attribute calls by agent, worker, route, tenant, and workflow so real access and spend patterns are visible before policy tightens.'],
+                ['Control', 'Issue scoped capabilities, enforce budgets and route policy, attenuate delegation, and revoke authority before the next request.'],
+                ['Prove', 'Record policy decisions, spend, outcomes, revocation events, and Evidence Pack receipts for each governed API action.'],
               ].map(([title, body]) => (
                 <div key={title} className="rounded-xl border border-gray-800 bg-black p-5">
                   <h3 className="text-lg font-bold text-white mb-2">{title}</h3>

--- a/satgate-landing/scripts/check_policy_to_proof_page.py
+++ b/satgate-landing/scripts/check_policy_to_proof_page.py
@@ -498,6 +498,8 @@ mcp_authority_required_phrases = {
         "Evidence Pack",
         "finance-automation",
         "invoice-reconciler",
+        "Observe, Control, Prove agent API use",
+        "Issue scoped capabilities, enforce budgets and route policy, attenuate delegation",
         "2026-12-31T00:00:00Z",
         "See SatGate governance",
         "See Policy-to-Proof",
@@ -539,6 +541,9 @@ mcp_authority_forbidden_phrases = {
         "Economic firewall overview",
         "Macaroons vs API keys <ArrowRight",
         "2026-04-26T00:00:00Z",
+        "Governance loop",
+        "['Mint', 'Issue a scoped capability",
+        "['Delegate', 'Allow sub-agents",
     ],
 }
 


### PR DESCRIPTION
## Summary
- Align `/agent-api-governance` to the site-standard Observe / Control / Prove triad
- Demote Mint and Delegate into Control copy instead of presenting them as separate stages
- Extend the Policy-to-Proof regression guard so the stale 5-stage section cannot return

## Verification
- `python3 scripts/check_policy_to_proof_page.py`
- `npx eslint app/agent-api-governance/page.tsx scripts/check_policy_to_proof_page.py` (Python file ignored by ESLint config as expected; TSX clean)
- `npm run build`
- Independent diff review via subagent: no issues found
