### PR TITLE
fix: align spend clickthroughs with policy proof

### DIFF
--- a/satgate-landing/app/ai-agent-cost-control/page.tsx
+++ b/satgate-landing/app/ai-agent-cost-control/page.tsx
@@ -309,7 +309,7 @@ export default function AiAgentCostControlPage() {
         <div className="max-w-6xl mx-auto px-6 py-20">
           <h2 className="text-3xl font-bold text-white mb-4">What SatGate controls</h2>
           <p className="text-gray-400 max-w-3xl mb-10 text-lg">
-            SatGate is not just an observability dashboard. It is the request-path economic control plane for agent/API activity.
+            SatGate is not just an observability dashboard. It is the request-path authority and proof layer for agent/API activity.
           </p>
 
           <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-5">

--- a/satgate-landing/app/design-partners/layout.tsx
+++ b/satgate-landing/app/design-partners/layout.tsx
@@ -4,7 +4,7 @@ export const metadata: Metadata = {
   title: "SatGate Design Partners | Economic Firewall for AI Agents",
   alternates: { canonical: "https://satgate.io/design-partners" },
   description:
-    "Join SatGate as a design partner for the economic firewall for AI agents. Shape request-path budget enforcement, MCP governance, agent API controls, and L402 Charge before launch.",
+    "Join SatGate as a design partner for Policy-to-Proof agent governance. Shape request-path budget enforcement, MCP governance, agent API controls, paid-rail context, and Evidence Pack proof before launch.",
   keywords: [
     "SatGate design partners",
     "economic firewall design partner",
@@ -12,12 +12,12 @@ export const metadata: Metadata = {
     "AI agent cost control early access",
     "MCP governance early access",
     "agent API governance",
-    "L402 Charge early access",
+    "Policy-to-Proof early access",
   ],
   openGraph: {
     title: "SatGate Design Partners | Economic Firewall for AI Agents",
     description:
-      "Early access for teams shaping AI agent budget enforcement, MCP governance, agent API controls, and L402 Charge.",
+      "Early access for teams shaping AI agent budget enforcement, MCP governance, agent API controls, paid-rail context, and Evidence Pack proof.",
     url: "https://satgate.io/design-partners",
     type: "website",
   },
@@ -25,7 +25,7 @@ export const metadata: Metadata = {
     card: "summary_large_image",
     title: "SatGate Design Partners | Economic Firewall for AI Agents",
     description:
-      "Shape the economic firewall category for AI agents with SatGate.",
+      "Shape Policy-to-Proof governance for enterprise AI agents with SatGate.",
   },
 };
 

--- a/satgate-landing/app/design-partners/page.tsx
+++ b/satgate-landing/app/design-partners/page.tsx
@@ -68,10 +68,10 @@ export default function DesignPartnersPage() {
 
   const faqs = [
     { q: 'How long is the program?', a: '90 days. After that, you keep everything you built and get priority access to GA pricing.' },
-    { q: 'Is it really free?', a: 'Yes. Observe mode is completely free—no credit card, no commitment. You get full visibility into your AI agent traffic at zero cost.' },
-    { q: 'Do I need to change my code?', a: 'No. One DNS change points your AI agent traffic through SatGate. Zero code modifications. Takes about 5 minutes.' },
+    { q: 'Is it really free?', a: 'Yes. The design-partner path starts with an agreed staging lane and no credit card. You get visibility into agent traffic and help shape the authority, budget, revocation, and Evidence Pack workflows that matter in your environment.' },
+    { q: 'Do I need to change my code?', a: 'Usually no. Most pilots start with a DNS, proxy, or MCP configuration change around one staging endpoint or tool. We verify the path together before expanding.' },
     { q: 'Where does my data go?', a: 'Your infrastructure in hybrid mode. The SatGate gateway runs in your VPC. We never see your API payloads or sensitive data.' },
-    { q: 'Is this production-ready?', a: 'Yes. 60+ dashboard pages, full deployment options (Docker, K8s, Terraform, SaaS), and a battle-tested Go binary with zero dependencies.' },
+    { q: 'Is this for production traffic?', a: 'Design partners usually start in staging or a bounded pilot lane. The goal is to verify request-path policy, revocation, budgets, and Evidence Pack proof before expanding scope.' },
   ];
 
   const webPageJsonLd = {
@@ -79,7 +79,7 @@ export default function DesignPartnersPage() {
     '@type': 'WebPage',
     name: 'SatGate Design Partners Program',
     url: 'https://satgate.io/design-partners',
-    description: 'Early access for teams shaping SatGate economic firewall capabilities for AI agent budget enforcement, MCP governance, API controls, and L402 Charge.',
+    description: 'Early access for teams shaping SatGate Policy-to-Proof capabilities for AI agent budget enforcement, MCP governance, API controls, paid-rail context, and Evidence Pack proof.',
     datePublished: '2026-04-27',
     dateModified: '2026-05-02',
     isPartOf: { '@type': 'WebSite', name: 'SatGate', url: 'https://satgate.io' },
@@ -87,7 +87,7 @@ export default function DesignPartnersPage() {
       { '@type': 'Thing', name: 'AI agent economic governance' },
       { '@type': 'Thing', name: 'economic firewall design partners' },
       { '@type': 'Thing', name: 'MCP governance' },
-      { '@type': 'Thing', name: 'L402 Charge' },
+      { '@type': 'Thing', name: 'Policy-to-Proof Evidence Packs' },
     ],
   };
 
@@ -117,7 +117,7 @@ export default function DesignPartnersPage() {
     serviceType: 'AI agent economic governance design partner program',
     url: 'https://satgate.io/design-partners',
     provider: { '@type': 'Organization', name: 'SatGate', url: 'https://satgate.io' },
-    description: 'Early access for teams shaping SatGate economic firewall capabilities across AI agent budget enforcement, MCP governance, agent API controls, and L402 Charge.',
+    description: 'Early access for teams shaping SatGate Policy-to-Proof capabilities across AI agent budget enforcement, MCP governance, agent API controls, paid-rail context, and Evidence Pack proof.',
     areaServed: 'Global',
   };
 
@@ -139,7 +139,7 @@ export default function DesignPartnersPage() {
           <div className="hidden md:flex gap-6 text-sm font-medium text-gray-400">
             <Link href="/mint-demo" className="hover:text-white transition">Mint Demo</Link>
             <Link href="/protect" className="hover:text-white transition">Control Demo</Link>
-            <Link href="/pay" className="hover:text-white transition">Charge Demo</Link>
+            <Link href="/policy-to-proof" className="hover:text-white transition">Policy-to-Proof</Link>
             <Link href="/govern" className="hover:text-white transition">Enterprise</Link>
             <Link href="/pricing" className="hover:text-white transition">Pricing</Link>
             <a href="https://cloud.satgate.io/docs" target="_blank" rel="noopener noreferrer" className="hover:text-white transition">Docs</a>
@@ -161,7 +161,7 @@ export default function DesignPartnersPage() {
             {[
               { href: '/mint-demo', label: 'Mint Demo' },
               { href: '/protect', label: 'Control Demo' },
-              { href: '/pay', label: 'Charge Demo' },
+              { href: '/policy-to-proof', label: 'Policy-to-Proof' },
               { href: '/govern', label: 'Enterprise' },
               { href: '/pricing', label: 'Pricing' },
             ].map(item => (
@@ -192,8 +192,7 @@ export default function DesignPartnersPage() {
             </span>
           </h1>
           <p className="text-xl text-gray-400 mb-10 max-w-2xl mx-auto leading-relaxed">
-            We're working with <strong className="text-white">10 enterprises</strong> to deploy the Economic Firewall
-            that enforces Economic Access Control for AI agent requests. Gate your MCP tool servers, REST APIs, and LLM endpoints — see what each agent spends per call. Get free access, direct engineering support, and a product shaped by your needs.
+            We're working with <strong className="text-white">10 enterprises</strong> to shape SatGate's Policy-to-Proof layer for AI agent requests. Gate one MCP tool, REST API, or LLM endpoint in a bounded lane — see which agent had authority, what it spent, what was denied, and what Evidence Pack proof was preserved. Get direct engineering support and a product shaped by your needs.
           </p>
           <a href="#apply" className="inline-flex items-center gap-2 bg-white text-black px-8 py-3 rounded-lg font-bold hover:bg-gray-200 transition">
             Apply Now <ArrowRight size={18} />
@@ -216,7 +215,7 @@ export default function DesignPartnersPage() {
                 <h3 className="font-bold text-lg">Free Observe Mode</h3>
               </div>
               <p className="text-gray-400 text-sm leading-relaxed">
-                Full visibility into your AI agent traffic on your staging environment. See every API call, every token, every cost—across MCP servers, REST APIs, LLM endpoints—completely free.
+                Full visibility into your AI agent traffic in a bounded staging lane. See every API call, token, cost, policy decision, and Evidence Pack receipt across MCP servers, REST APIs, and LLM endpoints.
               </p>
             </div>
 
@@ -240,7 +239,7 @@ export default function DesignPartnersPage() {
                 <h3 className="font-bold text-lg">Your Feedback Shapes Product</h3>
               </div>
               <p className="text-gray-400 text-sm leading-relaxed">
-                Design partners get direct influence on the roadmap. The dashboards, alerts, and governance features you need—built with your input.
+                Design partners get direct influence on the roadmap. The authority, revocation, Evidence Pack, dashboard, alert, and governance workflows you need are shaped with your input.
               </p>
             </div>
           </div>
@@ -329,7 +328,7 @@ export default function DesignPartnersPage() {
                 step: '4',
                 title: 'Your Reports',
                 time: 'Week 3+',
-                desc: 'Your data, your dashboards. Cost attribution, security insights, governance reports—all yours.',
+                desc: 'Your data, your dashboards. Cost attribution, authority decisions, revocation proof, and Evidence Pack reports — all yours.',
                 color: 'yellow',
                 icon: <BarChart3 size={20} />,
               },
@@ -538,13 +537,13 @@ export default function DesignPartnersPage() {
                 <Image src="/logo_white_transparent.png" alt="SatGate" width={24} height={24} className="w-6 h-6" />
                 <h4 className="font-bold text-white">SatGate</h4>
               </div>
-              <p className="text-gray-500 text-sm">The Economic Firewall for AI agent requests.</p>
+              <p className="text-gray-500 text-sm">Policy-to-Proof governance for AI agent requests.</p>
             </div>
             <div>
               <h4 className="font-bold text-white mb-4">Product</h4>
               <ul className="space-y-2 text-sm text-gray-500">
                 <li><Link href="/protect" className="hover:text-white transition">Protect</Link></li>
-                <li><Link href="/pay" className="hover:text-white transition">Pay</Link></li>
+                <li><Link href="/policy-to-proof" className="hover:text-white transition">Policy-to-Proof</Link></li>
                 <li><Link href="/govern" className="hover:text-white transition">Enterprise</Link></li>
               </ul>
             </div>

--- a/satgate-landing/app/mcp-budget-enforcement/page.tsx
+++ b/satgate-landing/app/mcp-budget-enforcement/page.tsx
@@ -32,6 +32,11 @@ export const metadata = {
 
 const controls = [
   {
+    icon: KeyRound,
+    title: 'Scoped capabilities',
+    body: 'Replace broad static access with expiring, revocable capabilities constrained by tool, route, budget, and calls.',
+  },
+  {
     icon: BadgeDollarSign,
     title: 'Per-tool pricing',
     body: 'Assign cost to search, browser, code, data, cloud, enrichment, and premium API tools before execution.',
@@ -45,11 +50,6 @@ const controls = [
     icon: ShieldCheck,
     title: 'Risk tiers',
     body: 'Treat harmless local tools differently from expensive external APIs, write actions, or privileged cloud tools.',
-  },
-  {
-    icon: KeyRound,
-    title: 'Scoped capabilities',
-    body: 'Replace broad static access with expiring, revocable capabilities constrained by tool, route, budget, and calls.',
   },
   {
     icon: ClipboardList,
@@ -200,7 +200,7 @@ export default function McpBudgetEnforcementPage() {
         <div className="rounded-2xl border border-cyan-900/50 bg-cyan-950/10 p-6">
           <h3 className="text-xl font-bold text-white mb-4">MCP budget policy answers</h3>
           <ul className="space-y-3 text-gray-300">
-            {['What does this tool call cost?', 'Which agent, tenant, workflow, and delegated sub-agent made it?', 'Is the call inside budget right now?', 'Should this route allow, deny, downgrade, ask approval, or require paid-rail context?', 'Can finance and security explain the decision later?'].map((item) => (
+            {['Which agent, tenant, workflow, and delegated sub-agent made it?', 'What scoped authority does it have?', 'What does this tool call cost?', 'Is the call inside budget right now?', 'Should this route allow, deny, downgrade, ask approval, or require paid-rail context?', 'Can finance and security explain the decision later?'].map((item) => (
               <li key={item} className="rounded-lg border border-gray-800 bg-black/50 p-3">{item}</li>
             ))}
           </ul>

--- a/satgate-landing/app/runaway-agent-cost-calculator/page.tsx
+++ b/satgate-landing/app/runaway-agent-cost-calculator/page.tsx
@@ -107,7 +107,7 @@ export default function RunawayAgentCostCalculatorPage() {
       {
         '@type': 'Question',
         name: 'How does SatGate reduce runaway agent costs?',
-        acceptedAnswer: { '@type': 'Answer', text: 'SatGate enforces request-path budgets, per-tool spend caps, revocation, and route policy before upstream API or MCP tool calls execute.' },
+        acceptedAnswer: { '@type': 'Answer', text: 'SatGate enforces request-path budgets, scoped authority, per-tool spend caps, revocation, and route policy before upstream API or MCP tool calls execute, then records the decision in the Evidence Pack.' },
       },
       {
         '@type': 'Question',
@@ -209,7 +209,7 @@ export default function RunawayAgentCostCalculatorPage() {
           <div className="rounded-2xl border border-yellow-900/50 bg-yellow-950/10 p-6 md:p-8">
             <h2 className="mb-4 text-2xl font-bold text-white">If enforcement stops the loop at 5 minutes</h2>
             <p className="mb-6 leading-relaxed text-gray-300">
-              A request-path economic firewall can block new calls once a budget, per-tool cap, route policy, or revocation rule is hit. In this model, stopping the loop at five minutes reduces each incident from <strong className="text-white">{money.format(calc.incidentCost)}</strong> to <strong className="text-white">{money.format(calc.blockedAtFiveMinutes)}</strong>.
+              Request-path authority checks can block new calls once a budget, per-tool cap, route policy, or revocation rule is hit. In this model, stopping the loop at five minutes reduces each incident from <strong className="text-white">{money.format(calc.incidentCost)}</strong> to <strong className="text-white">{money.format(calc.blockedAtFiveMinutes)}</strong>.
             </p>
             <div className="rounded-xl border border-gray-800 bg-black p-5">
               <div className="mb-2 text-sm text-gray-400">Avoidable cost per incident</div>
@@ -262,7 +262,7 @@ export default function RunawayAgentCostCalculatorPage() {
             <div className="rounded-xl border border-gray-800 bg-gray-950 p-6">
               <h3 className="mb-2 text-xl font-bold text-white">How does SatGate reduce runaway agent costs?</h3>
               <p className="text-gray-400 leading-relaxed">
-                SatGate enforces request-path budgets, per-tool spend caps, revocation, and route policy before upstream API or MCP tool calls execute.
+                SatGate enforces request-path budgets, scoped authority, per-tool spend caps, revocation, and route policy before upstream API or MCP tool calls execute, then records the decision in the Evidence Pack.
               </p>
             </div>
             <div className="rounded-xl border border-gray-800 bg-gray-950 p-6">
@@ -285,14 +285,14 @@ export default function RunawayAgentCostCalculatorPage() {
         <div className="rounded-3xl border border-orange-900/60 bg-gradient-to-br from-orange-950/30 to-yellow-950/20 p-8 md:p-12">
           <h2 className="mb-4 text-3xl font-bold text-white">Stop runaway spend in the request path</h2>
           <p className="mb-8 max-w-3xl text-lg leading-relaxed text-gray-300">
-            SatGate observes agent/API spend, controls budgets before paid calls execute, and can charge robot customers with L402 when APIs become agent-native products.
+            SatGate puts authority before execution for agent/API spend: control budgets before paid calls execute, revoke unsafe authority, and preserve Evidence Pack receipts for every allowed, denied, routed, or paid decision.
           </p>
           <div className="flex flex-col gap-4 sm:flex-row">
-            <Link href="/economic-firewall" className="inline-flex items-center justify-center gap-2 rounded-lg bg-white px-6 py-3 font-bold text-black transition hover:bg-gray-200">
-              Learn economic firewalls <ArrowRight size={18} />
+            <Link href="/govern" className="inline-flex items-center justify-center gap-2 rounded-lg bg-white px-6 py-3 font-bold text-black transition hover:bg-gray-200">
+              Govern runaway spend <ArrowRight size={18} />
             </Link>
-            <Link href="/mcp-governance" className="inline-flex items-center justify-center gap-2 rounded-lg border border-gray-700 px-6 py-3 font-bold text-white transition hover:border-orange-500">
-              Govern MCP tool spend
+            <Link href="/policy-to-proof" className="inline-flex items-center justify-center gap-2 rounded-lg border border-gray-700 px-6 py-3 font-bold text-white transition hover:border-orange-500">
+              See Policy-to-Proof
             </Link>
           </div>
         </div>

--- a/satgate-landing/scripts/check_policy_to_proof_page.py
+++ b/satgate-landing/scripts/check_policy_to_proof_page.py
@@ -15,6 +15,10 @@ AGENT_BUDGET_POLICY_PAGE = ROOT / "app" / "agent-spend-policy-template" / "page.
 AGENT_BUDGET_POLICY_LAYOUT = ROOT / "app" / "agent-spend-policy-template" / "layout.tsx"
 CAPABILITY_TOKEN_TEMPLATE_PAGE = ROOT / "app" / "revocable-capability-token-policy-template" / "page.tsx"
 CAPABILITY_TOKEN_TEMPLATE_LAYOUT = ROOT / "app" / "revocable-capability-token-policy-template" / "layout.tsx"
+RUNAWAY_COST_CALCULATOR_PAGE = ROOT / "app" / "runaway-agent-cost-calculator" / "page.tsx"
+RUNAWAY_COST_CALCULATOR_LAYOUT = ROOT / "app" / "runaway-agent-cost-calculator" / "layout.tsx"
+DESIGN_PARTNERS_PAGE = ROOT / "app" / "design-partners" / "page.tsx"
+DESIGN_PARTNERS_LAYOUT = ROOT / "app" / "design-partners" / "layout.tsx"
 
 SPEND_LONGTAIL_PAGES = {
     "ai-agent-cost-control": ROOT / "app" / "ai-agent-cost-control" / "page.tsx",
@@ -255,6 +259,23 @@ tool_required_phrases = {
         "Policy-to-Proof receipt coverage",
         "Map ROI to Policy-to-Proof",
     ],
+    "runaway-agent-cost-calculator": [
+        "SatGate puts authority before execution",
+        "Evidence Pack receipts",
+        "Govern runaway spend",
+        "See Policy-to-Proof",
+        "/govern",
+        "/policy-to-proof",
+    ],
+    "design-partners": [
+        "Policy-to-Proof layer",
+        "Evidence Pack proof",
+        "bounded lane",
+        "policy decision",
+        "Policy-to-Proof governance for AI agent requests",
+        "/policy-to-proof",
+        "/govern",
+    ],
     "agent-budget-policy-template": [
         "Agent Budget Policy Template",
         "control_with_receipts",
@@ -286,6 +307,25 @@ tool_forbidden_phrases = {
         "/l402-api-pricing-calculator",
         "/runaway-agent-cost-calculator",
         "Observe, Control, and Charge",
+    ],
+    "runaway-agent-cost-calculator": [
+        "robot customers",
+        "Charge Demo",
+        "L402 Charge",
+        "Charge/L402",
+        "when APIs become agent-native products",
+        "Learn economic firewalls",
+        "A request-path economic firewall",
+        "/economic-firewall",
+    ],
+    "design-partners": [
+        "Charge Demo",
+        "L402 Charge",
+        "Charge/L402",
+        "production-ready",
+        "Is this production-ready?",
+        "The Economic Firewall for AI agent requests",
+        "/pay",
     ],
     "agent-budget-policy-template": [
         "control_and_charge",
@@ -385,6 +425,7 @@ spend_longtail_forbidden_phrases = {
         "when agents become customers",
         "03 / CHARGE",
         "/robot-customer-payments",
+        "economic control plane",
     ],
     "ai-api-budget-enforcement": [
         "Charge robot customers",
@@ -631,6 +672,10 @@ def main() -> int:
         "revocable-capability-token-policy-template": CAPABILITY_TOKEN_TEMPLATE_PAGE.read_text()
         + "\n"
         + CAPABILITY_TOKEN_TEMPLATE_LAYOUT.read_text(),
+        "runaway-agent-cost-calculator": RUNAWAY_COST_CALCULATOR_PAGE.read_text()
+        + "\n"
+        + RUNAWAY_COST_CALCULATOR_LAYOUT.read_text(),
+        "design-partners": DESIGN_PARTNERS_PAGE.read_text() + "\n" + DESIGN_PARTNERS_LAYOUT.read_text(),
     }
     for name, tool_text in tool_texts.items():
         tool_missing = [phrase for phrase in tool_required_phrases[name] if phrase not in tool_text]


### PR DESCRIPTION
## Summary
- Reorders `/mcp-budget-enforcement` controls so scoped authority leads spend/pricing.
- Cleans benchmark click-through destinations: `/runaway-agent-cost-calculator`, `/ai-agent-cost-control`, and `/design-partners` no longer leak Charge/robot/economic-control-plane framing.
- Extends `check_policy_to_proof_page.py` guards to cover the calculator and design-partner funnel.

## Verification
- `python3 scripts/check_policy_to_proof_page.py`
- `npm run build`
- destination stale-term sweep for `/runaway-agent-cost-calculator`, `/ai-agent-cost-control`, `/agent-spend-policy-template`, `/design-partners`
