### PR TITLE
fix: repair tool metadata and proof triad

### DIFF
--- a/satgate-landing/app/agent-spend-policy-template/layout.tsx
+++ b/satgate-landing/app/agent-spend-policy-template/layout.tsx
@@ -5,6 +5,27 @@ export const metadata: Metadata = {
   description:
     'Generate YAML and JSON agent budget policy with authority, MCP tool caps, revocation, receipts, and Evidence Pack fields.',
   alternates: { canonical: 'https://satgate.io/agent-spend-policy-template' },
+  keywords: [
+    'agent budget policy template',
+    'AI agent budget policy',
+    'MCP tool budget policy',
+    'agent spend policy template',
+    'Policy-to-Proof',
+    'Evidence Pack',
+  ],
+  openGraph: {
+    title: 'Agent Budget Policy Template: Policy-to-Proof Controls',
+    description:
+      'Generate copyable YAML and JSON policies for AI agent authority, budgets, MCP tool caps, revocation, receipts, and Evidence Pack proof.',
+    url: 'https://satgate.io/agent-spend-policy-template',
+    type: 'website',
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Agent Budget Policy Template: Policy-to-Proof Controls',
+    description:
+      'Generate AI agent budget policy templates with scoped authority, revocation, receipts, and Evidence Pack fields.',
+  },
 };
 
 export default function AgentSpendPolicyTemplateLayout({ children }: { children: React.ReactNode }) {

--- a/satgate-landing/app/ai-agent-cost-control/page.tsx
+++ b/satgate-landing/app/ai-agent-cost-control/page.tsx
@@ -325,22 +325,22 @@ export default function AiAgentCostControlPage() {
       </section>
 
       <section className="max-w-6xl mx-auto px-6 py-20">
-        <h2 className="text-3xl font-bold text-white mb-8">Start with Observe. Graduate to Control. Preserve proof when value moves.</h2>
+        <h2 className="text-3xl font-bold text-white mb-8">Start with Observe. Graduate to Control. Preserve proof for every decision.</h2>
         <div className="grid lg:grid-cols-3 gap-6">
           <div className="rounded-2xl border border-gray-800 bg-gray-950 p-6">
             <div className="text-purple-300 font-mono text-sm mb-3">01 / OBSERVE</div>
-            <h3 className="text-xl font-bold text-white mb-3">Attribute every call</h3>
-            <p className="text-gray-400 leading-relaxed">Route agent traffic through SatGate to see spend by agent, model, route, tool, tenant, and workflow without blocking production workloads.</p>
+            <h3 className="text-xl font-bold text-white mb-3">Attribute every request</h3>
+            <p className="text-gray-400 leading-relaxed">See tenant, workflow, agent, delegated sub-agent, model, route, MCP tool, and spend before turning on enforcement.</p>
           </div>
           <div className="rounded-2xl border border-gray-800 bg-gray-950 p-6">
             <div className="text-cyan-300 font-mono text-sm mb-3">02 / CONTROL</div>
-            <h3 className="text-xl font-bold text-white mb-3">Enforce budgets</h3>
+            <h3 className="text-xl font-bold text-white mb-3">Enforce before execution</h3>
             <p className="text-gray-400 leading-relaxed">Apply hard caps, per-request ceilings, route policy, revocation, expiry, and kill switches before the expensive call happens.</p>
           </div>
           <div className="rounded-2xl border border-gray-800 bg-gray-950 p-6">
-            <div className="text-yellow-300 font-mono text-sm mb-3">03 / PROOF</div>
-            <h3 className="text-xl font-bold text-white mb-3">Preserve paid-access evidence</h3>
-            <p className="text-gray-400 leading-relaxed">When value moves, record the policy decision, payment context, route, authority, and receipt before unlocking the protected resource.</p>
+            <div className="text-yellow-300 font-mono text-sm mb-3">03 / PROVE</div>
+            <h3 className="text-xl font-bold text-white mb-3">Preserve decision evidence</h3>
+            <p className="text-gray-400 leading-relaxed">Record every authority decision — allowed, denied, delegated, revoked, or paid — in the Evidence Pack. Payment proves value moved; SatGate proves the agent was allowed to move it.</p>
           </div>
         </div>
       </section>

--- a/satgate-landing/app/l402-api-pricing-calculator/layout.tsx
+++ b/satgate-landing/app/l402-api-pricing-calculator/layout.tsx
@@ -3,8 +3,29 @@ import type { Metadata } from 'next';
 export const metadata: Metadata = {
   title: 'L402 API Pricing Calculator',
   description:
-    'Estimate per-request L402 API pricing, robot-customer revenue, gross margin, free allowance, and Lightning sats per request for AI agent API monetization.',
+    'Estimate L402 API pricing, per-request margins, free allowances, and paid-rail context for governed AI agent access.',
   alternates: { canonical: 'https://satgate.io/l402-api-pricing-calculator' },
+  keywords: [
+    'L402 API pricing calculator',
+    'AI agent payment pricing',
+    'paid API access calculator',
+    'Lightning API pricing',
+    'agent payment controls',
+    'paid-rail context',
+  ],
+  openGraph: {
+    title: 'L402 API Pricing Calculator',
+    description:
+      'Model L402 API pricing and margin while preserving paid-rail context for governed AI agent access.',
+    url: 'https://satgate.io/l402-api-pricing-calculator',
+    type: 'website',
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'L402 API Pricing Calculator',
+    description:
+      'Estimate per-request L402 API pricing, margins, free allowances, and paid-rail context for AI agent access.',
+  },
 };
 
 export default function L402ApiPricingCalculatorLayout({ children }: { children: React.ReactNode }) {

--- a/satgate-landing/app/mcp-proxy-config-generator/layout.tsx
+++ b/satgate-landing/app/mcp-proxy-config-generator/layout.tsx
@@ -3,8 +3,29 @@ import type { Metadata } from 'next';
 export const metadata: Metadata = {
   title: 'MCP Proxy Config Generator',
   description:
-    'Generate MCP proxy configuration for Cursor, Claude Desktop, Claude Code, OpenClaw, and custom MCP clients with budgets, audit, revocation, and L402 charge options.',
+    'Generate MCP proxy configuration for Cursor, Claude Desktop, Claude Code, OpenClaw, and custom MCP clients with scoped authority, budgets, audit receipts, and revocation.',
   alternates: { canonical: 'https://satgate.io/mcp-proxy-config-generator' },
+  keywords: [
+    'MCP proxy config generator',
+    'MCP server proxy configuration',
+    'Claude Desktop MCP proxy',
+    'Cursor MCP proxy',
+    'MCP budget policy',
+    'agent tool governance',
+  ],
+  openGraph: {
+    title: 'MCP Proxy Config Generator',
+    description:
+      'Generate MCP proxy configs with scoped authority, budgets, audit receipts, revocation, and Evidence Pack-ready policy fields.',
+    url: 'https://satgate.io/mcp-proxy-config-generator',
+    type: 'website',
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'MCP Proxy Config Generator',
+    description:
+      'Create MCP proxy configuration for agent tools with scoped authority, budgets, audit receipts, and revocation.',
+  },
 };
 
 export default function McpProxyConfigGeneratorLayout({ children }: { children: React.ReactNode }) {

--- a/satgate-landing/scripts/check_policy_to_proof_page.py
+++ b/satgate-landing/scripts/check_policy_to_proof_page.py
@@ -19,6 +19,8 @@ RUNAWAY_COST_CALCULATOR_PAGE = ROOT / "app" / "runaway-agent-cost-calculator" / 
 RUNAWAY_COST_CALCULATOR_LAYOUT = ROOT / "app" / "runaway-agent-cost-calculator" / "layout.tsx"
 DESIGN_PARTNERS_PAGE = ROOT / "app" / "design-partners" / "page.tsx"
 DESIGN_PARTNERS_LAYOUT = ROOT / "app" / "design-partners" / "layout.tsx"
+MCP_PROXY_CONFIG_LAYOUT = ROOT / "app" / "mcp-proxy-config-generator" / "layout.tsx"
+L402_API_PRICING_LAYOUT = ROOT / "app" / "l402-api-pricing-calculator" / "layout.tsx"
 
 SPEND_LONGTAIL_PAGES = {
     "ai-agent-cost-control": ROOT / "app" / "ai-agent-cost-control" / "page.tsx",
@@ -359,6 +361,9 @@ spend_longtail_required_phrases = {
         "/govern",
         "/policy-to-proof",
         "paid-rail evidence",
+        "Preserve proof for every decision",
+        "03 / PROVE",
+        "Record every authority decision",
     ],
     "ai-api-budget-enforcement": [
         "authority before execution",
@@ -426,6 +431,10 @@ spend_longtail_forbidden_phrases = {
         "03 / CHARGE",
         "/robot-customer-payments",
         "economic control plane",
+        "Preserve proof when value moves",
+        "03 / PROOF",
+        "Preserve paid-access evidence",
+        "When value moves",
     ],
     "ai-api-budget-enforcement": [
         "Charge robot customers",
@@ -488,6 +497,50 @@ spend_longtail_forbidden_phrases = {
         "economic control plane for AI agents",
         "Learn economic firewalls",
         "How does an economic firewall reduce runaway spend?",
+    ],
+}
+
+
+tool_metadata_required_phrases = {
+    "agent-spend-policy-template": [
+        "keywords",
+        "openGraph",
+        "twitter",
+        "https://satgate.io/agent-spend-policy-template",
+        "Agent Budget Policy Template: Policy-to-Proof Controls",
+    ],
+    "mcp-proxy-config-generator": [
+        "keywords",
+        "openGraph",
+        "twitter",
+        "https://satgate.io/mcp-proxy-config-generator",
+        "MCP Proxy Config Generator",
+    ],
+    "l402-api-pricing-calculator": [
+        "keywords",
+        "openGraph",
+        "twitter",
+        "https://satgate.io/l402-api-pricing-calculator",
+        "L402 API Pricing Calculator",
+    ],
+}
+
+tool_metadata_forbidden_phrases = {
+    "agent-spend-policy-template": [
+        "url: 'https://satgate.io'",
+        "The Economic Firewall for AI Agent Requests",
+        "Control AI agent API spend at the request layer",
+    ],
+    "mcp-proxy-config-generator": [
+        "url: 'https://satgate.io'",
+        "L402 charge options",
+        "L402 Charge",
+    ],
+    "l402-api-pricing-calculator": [
+        "url: 'https://satgate.io'",
+        "robot-customer revenue",
+        "robot-customer products",
+        "robot customers",
     ],
 }
 
@@ -693,6 +746,20 @@ def main() -> int:
         stale_longtail = [phrase for phrase in spend_longtail_forbidden_phrases[name] if phrase in page_text]
         if stale_longtail:
             raise SystemExit(f"stale {name} spend/Charge-first phrases remain:\n" + "\n".join(stale_longtail))
+
+
+    metadata_texts = {
+        "agent-spend-policy-template": AGENT_BUDGET_POLICY_LAYOUT.read_text(),
+        "mcp-proxy-config-generator": MCP_PROXY_CONFIG_LAYOUT.read_text(),
+        "l402-api-pricing-calculator": L402_API_PRICING_LAYOUT.read_text(),
+    }
+    for name, metadata_text in metadata_texts.items():
+        missing_metadata = [phrase for phrase in tool_metadata_required_phrases[name] if phrase not in metadata_text]
+        if missing_metadata:
+            raise SystemExit(f"missing {name} OpenGraph/Twitter metadata phrases:\n" + "\n".join(missing_metadata))
+        stale_metadata = [phrase for phrase in tool_metadata_forbidden_phrases[name] if phrase in metadata_text]
+        if stale_metadata:
+            raise SystemExit(f"stale {name} inherited/stale metadata phrases remain:\n" + "\n".join(stale_metadata))
 
     for name, path in L402_RAIL_PAGES.items():
         page_text = path.read_text()


### PR DESCRIPTION
## Summary
- Fixes `/agent-spend-policy-template` OpenGraph, Twitter, canonical URL, and keywords metadata so shares do not inherit homepage tags.
- Audits/fixes the same metadata inheritance gap on `/mcp-proxy-config-generator` and `/l402-api-pricing-calculator`.
- Cleans `/ai-agent-cost-control` triad language: unconditional proof, `03 / PROVE`, and Evidence Pack decision proof.
- Extends `check_policy_to_proof_page.py` guards for tool metadata and stale triad phrasing.

## Verification
- `python3 scripts/check_policy_to_proof_page.py`
- `npm run build`
- Local `next start` HTML metadata checks for `/agent-spend-policy-template`, `/mcp-proxy-config-generator`, `/l402-api-pricing-calculator`, and `/ai-agent-cost-control`
