### PR TITLE
fix: align remaining tool generators with proof framing

### DIFF
--- a/satgate-landing/app/l402-api-pricing-calculator/page.tsx
+++ b/satgate-landing/app/l402-api-pricing-calculator/page.tsx
@@ -67,15 +67,15 @@ export default function L402ApiPricingCalculatorPage() {
     '@type': 'WebPage',
     name: 'L402 API Pricing Calculator',
     url: 'https://satgate.io/l402-api-pricing-calculator',
-    description: 'Estimate per-request L402 API pricing, robot-customer revenue, gross margin, free allowance, and Lightning sats per request for AI agent API monetization.',
+    description: 'Estimate per-request L402 API pricing, paid-agent access revenue, gross margin, free allowance, and Lightning sats per request for governed AI agent API access.',
     datePublished: '2026-05-01',
     dateModified: '2026-05-03',
     isPartOf: { '@type': 'WebSite', name: 'SatGate', url: 'https://satgate.io' },
     about: [
       { '@type': 'Thing', name: 'L402 API pricing' },
-      { '@type': 'Thing', name: 'robot-customer revenue' },
+      { '@type': 'Thing', name: 'paid-agent access revenue' },
       { '@type': 'Thing', name: 'Lightning sats per request' },
-      { '@type': 'Thing', name: 'AI agent API monetization' },
+      { '@type': 'Thing', name: 'governed AI agent paid access' },
       { '@type': 'Thing', name: 'request-path paid access' },
     ],
   };
@@ -87,7 +87,7 @@ export default function L402ApiPricingCalculatorPage() {
     applicationCategory: 'BusinessApplication',
     operatingSystem: 'Web',
     url: 'https://satgate.io/l402-api-pricing-calculator',
-    description: 'Estimate per-request L402 API pricing, robot-customer revenue, gross margin, free allowance, and Lightning sats per request for AI agent API monetization.',
+    description: 'Estimate per-request L402 API pricing, paid-agent access revenue, gross margin, free allowance, and Lightning sats per request for governed AI agent API access.',
     publisher: { '@type': 'Organization', name: 'SatGate', url: 'https://satgate.io' },
     dateModified: '2026-05-03',
     featureList: ['Per-request L402 pricing', 'Robot-customer revenue estimate', 'Gross margin modeling', 'Free allowance planning', 'Sats per request conversion'],
@@ -118,18 +118,18 @@ export default function L402ApiPricingCalculatorPage() {
       },
       {
         '@type': 'Question',
-        name: 'How should APIs price robot customers?',
+        name: 'How should APIs price paid agent access?',
         acceptedAnswer: {
           '@type': 'Answer',
-          text: 'Start from marginal cost per request, add target gross margin, account for free allowances or trial traffic, and enforce payment or budget policy before upstream access. SatGate Charge uses L402 Lightning payments for this flow.',
+          text: 'Start from marginal cost per request, add target gross margin, account for free allowances or trial traffic, and enforce payment or budget policy before upstream access. L402 is one paid rail; SatGate preserves the authority and receipt context around access.',
         },
       },
       {
         '@type': 'Question',
-        name: 'Is SatGate Charge Fiat402?',
+        name: 'Is L402 the same as Fiat402?',
         acceptedAnswer: {
           '@type': 'Answer',
-          text: 'No. SatGate Charge is L402 Lightning-based payment for API access. Fiat402 is separate and should not be conflated with SatGate Charge.',
+          text: 'No. L402 is Lightning-based payment for API access. Fiat402 is separate. SatGate can preserve paid-rail context without conflating the rails.',
         },
       },
       {
@@ -142,7 +142,7 @@ export default function L402ApiPricingCalculatorPage() {
       },
       {
         '@type': 'Question',
-        name: 'Should robot-customer pricing include free allowances?',
+        name: 'Should paid agent access pricing include free allowances?',
         acceptedAnswer: {
           '@type': 'Answer',
           text: 'Usually yes. Free allowances help agents test value before paying, but paid access should still be enforced with request-path pricing, budget checks, scoped access, and audit records.',
@@ -168,7 +168,7 @@ export default function L402ApiPricingCalculatorPage() {
             L402 API Pricing Calculator for Robot Customers
           </h1>
           <p className="mb-10 max-w-4xl text-xl leading-relaxed text-gray-300 md:text-2xl">
-            Estimate per-request pricing, gross margin, paid robot-customer demand, and Lightning sats per request before you expose paid API access to autonomous agents.
+            Estimate per-request pricing, gross margin, paid agent-access demand, and Lightning sats per request before you expose paid API access to autonomous agents.
           </p>
           <div className="flex flex-col gap-4 sm:flex-row">
             <a href="#calculator" className="inline-flex items-center justify-center gap-2 rounded-lg bg-white px-6 py-3 font-bold text-black transition hover:bg-gray-200">
@@ -247,15 +247,15 @@ export default function L402ApiPricingCalculatorPage() {
               </p>
             </div>
             <div className="rounded-xl border border-gray-800 bg-gray-950 p-6">
-              <h3 className="mb-2 text-xl font-bold text-white">How should APIs price robot customers?</h3>
+              <h3 className="mb-2 text-xl font-bold text-white">How should APIs price paid agent access?</h3>
               <p className="text-gray-400 leading-relaxed">
-                Start from marginal cost per request, add target gross margin, account for free allowances or trial traffic, and enforce payment or budget policy before upstream access. SatGate Charge uses L402 Lightning payments for this flow.
+                Start from marginal cost per request, add target gross margin, account for free allowances or trial traffic, and enforce payment or budget policy before upstream access. L402 is one paid rail; SatGate preserves the authority and receipt context around access.
               </p>
             </div>
             <div className="rounded-xl border border-gray-800 bg-gray-950 p-6">
-              <h3 className="mb-2 text-xl font-bold text-white">Is SatGate Charge Fiat402?</h3>
+              <h3 className="mb-2 text-xl font-bold text-white">Is L402 the same as Fiat402?</h3>
               <p className="text-gray-400 leading-relaxed">
-                No. SatGate Charge is L402 Lightning-based payment for API access. Fiat402 is separate and should not be conflated with SatGate Charge.
+                No. L402 is Lightning-based payment for API access. Fiat402 is separate. SatGate can preserve paid-rail context without conflating the rails.
               </p>
             </div>
             <div className="rounded-xl border border-gray-800 bg-gray-950 p-6">
@@ -265,7 +265,7 @@ export default function L402ApiPricingCalculatorPage() {
               </p>
             </div>
             <div className="rounded-xl border border-gray-800 bg-gray-950 p-6">
-              <h3 className="mb-2 text-xl font-bold text-white">Should robot-customer pricing include free allowances?</h3>
+              <h3 className="mb-2 text-xl font-bold text-white">Should paid agent access pricing include free allowances?</h3>
               <p className="text-gray-400 leading-relaxed">
                 Usually yes. Free allowances help agents test value before paying, but paid access should still be enforced with request-path pricing, budget checks, scoped access, and audit records.
               </p>
@@ -276,13 +276,13 @@ export default function L402ApiPricingCalculatorPage() {
 
       <section className="mx-auto max-w-6xl px-6 py-20">
         <div className="rounded-3xl border border-yellow-900/60 bg-gradient-to-br from-yellow-950/25 to-cyan-950/25 p-8 md:p-12">
-          <h2 className="mb-4 text-3xl font-bold text-white">Charge robot customers with L402 Lightning.</h2>
+          <h2 className="mb-4 text-3xl font-bold text-white">Model L402 paid access with policy proof.</h2>
           <p className="mb-8 max-w-3xl text-lg leading-relaxed text-gray-300">
-            SatGate Charge lets protected APIs challenge, verify, and unlock paid access for autonomous agents in the request path. Observe demand, control spend, then charge when access should be monetized.
+            L402 can challenge and verify payment for protected API access. SatGate keeps authority, budget, revocation, paid-rail context, and Evidence Pack receipts in the request path.
           </p>
           <div className="flex flex-col gap-4 sm:flex-row">
-            <Link href="/robot-customer-payments" className="inline-flex items-center justify-center gap-2 rounded-lg bg-white px-6 py-3 font-bold text-black transition hover:bg-gray-200">
-              Robot customer payments <ArrowRight size={18} />
+            <Link href="/http-402-for-ai-agents" className="inline-flex items-center justify-center gap-2 rounded-lg bg-white px-6 py-3 font-bold text-black transition hover:bg-gray-200">
+              Govern HTTP 402 access <ArrowRight size={18} />
             </Link>
             <Link href="/blog/l402-protocol-explained" className="inline-flex items-center justify-center gap-2 rounded-lg border border-gray-700 px-6 py-3 font-bold text-white transition hover:border-yellow-500">
               L402 protocol explained

--- a/satgate-landing/app/mcp-proxy-config-generator/page.tsx
+++ b/satgate-landing/app/mcp-proxy-config-generator/page.tsx
@@ -15,7 +15,7 @@ const clients = {
 const modes = {
   observe: { label: 'Observe', block: false, charge: false, audit: 'full' },
   control: { label: 'Control', block: true, charge: false, audit: 'full' },
-  charge: { label: 'Control + Charge', block: true, charge: true, audit: 'full' },
+  paid: { label: 'Control + Paid Rail', block: true, charge: true, audit: 'full' },
 };
 
 type ClientKey = keyof typeof clients;
@@ -62,7 +62,7 @@ export default function McpProxyConfigGeneratorPage() {
     '@type': 'WebPage',
     name: 'MCP Proxy Config Generator',
     url: 'https://satgate.io/mcp-proxy-config-generator',
-    description: 'Generate MCP proxy configs for Cursor, Claude, OpenClaw, and custom MCP clients with budgets, audit, revocation, and L402 Charge options.',
+    description: 'Generate MCP proxy configs for Cursor, Claude, OpenClaw, and custom MCP clients with scoped authority, budgets, audit receipts, revocation, and optional paid-rail context.',
     datePublished: '2026-04-12',
     dateModified: '2026-05-03',
     isPartOf: { '@type': 'WebSite', name: 'SatGate', url: 'https://satgate.io' },
@@ -71,7 +71,7 @@ export default function McpProxyConfigGeneratorPage() {
       { '@type': 'Thing', name: 'SatGate MCP proxy' },
       { '@type': 'Thing', name: 'Cursor and Claude MCP governance' },
       { '@type': 'Thing', name: 'MCP request-path budget enforcement' },
-      { '@type': 'Thing', name: 'L402 Charge for MCP tools' },
+      { '@type': 'Thing', name: 'paid-rail context for MCP tools' },
     ],
     audience: { '@type': 'Audience', audienceType: 'AI engineering, platform, API, and security teams using MCP clients' },
   };
@@ -83,11 +83,11 @@ export default function McpProxyConfigGeneratorPage() {
     applicationCategory: 'DeveloperApplication',
     operatingSystem: 'Web',
     url: 'https://satgate.io/mcp-proxy-config-generator',
-    description: 'Generate MCP proxy configs for Cursor, Claude, OpenClaw, and custom MCP clients with budgets, audit, revocation, and L402 Charge options.',
+    description: 'Generate MCP proxy configs for Cursor, Claude, OpenClaw, and custom MCP clients with scoped authority, budgets, audit receipts, revocation, and optional paid-rail context.',
     publisher: { '@type': 'Organization', name: 'SatGate', url: 'https://satgate.io' },
     dateModified: '2026-05-03',
     audience: webPageJsonLd.audience,
-    featureList: ['Cursor MCP config generation', 'Claude MCP config generation', 'OpenClaw MCP config generation', 'Budget and audit policy generation', 'Optional L402 Charge config'],
+    featureList: ['Cursor MCP config generation', 'Claude MCP config generation', 'OpenClaw MCP config generation', 'Budget and audit policy generation', 'Optional paid-rail context config'],
     offers: { '@type': 'Offer', price: '0', priceCurrency: 'USD' },
   };
 
@@ -142,7 +142,7 @@ export default function McpProxyConfigGeneratorPage() {
         name: 'What policy should an MCP proxy enforce?',
         acceptedAnswer: {
           '@type': 'Answer',
-          text: 'An MCP proxy should enforce agent and task identity, session budgets, per-tool cost caps, unknown-tool behavior, revocation triggers, audit fields, and optional L402 payment before tool execution.',
+          text: 'An MCP proxy should enforce agent and task identity, session budgets, per-tool cost caps, unknown-tool behavior, revocation triggers, audit fields, and optional paid-rail context before tool execution.',
         },
       },
     ],
@@ -165,7 +165,7 @@ export default function McpProxyConfigGeneratorPage() {
             MCP Proxy Config Generator
           </h1>
           <p className="mb-10 max-w-4xl text-xl leading-relaxed text-gray-300 md:text-2xl">
-            Generate a starter SatGate MCP proxy config for Cursor, Claude Desktop, Claude Code, OpenClaw, or custom MCP clients with budgets, audit, revocation, and optional L402 Charge.
+            Generate a starter SatGate MCP proxy config for Cursor, Claude Desktop, Claude Code, OpenClaw, or custom MCP clients with budgets, audit, revocation, and optional paid-rail context.
           </p>
           <div className="flex flex-col gap-4 sm:flex-row">
             <a href="#generator" className="inline-flex items-center justify-center gap-2 rounded-lg bg-white px-6 py-3 font-bold text-black transition hover:bg-gray-200">
@@ -238,7 +238,7 @@ export default function McpProxyConfigGeneratorPage() {
               [KeyRound, 'Capabilities', 'Require scoped, revocable, expiring authority instead of broad ambient access.'],
               [ReceiptText, 'Audit', 'Record agent, task, server, tool, cost, budget, policy, and decision.'],
               [ShieldCheck, 'Revocation', 'Stop future tool calls when a loop, violation, or risky delegation appears.'],
-              [ClipboardList, 'Modes', 'Start in Observe, enforce in Control, and use Charge/L402 when tools become paid products.'],
+              [ClipboardList, 'Modes', 'Start in Observe, enforce in Control, and preserve paid-rail context when tools require payment.'],
             ].map(([Icon, title, body]) => {
               const CardIcon = Icon as typeof Wrench;
               return (
@@ -285,7 +285,7 @@ export default function McpProxyConfigGeneratorPage() {
             <div className="rounded-xl border border-gray-800 bg-gray-950 p-6">
               <h3 className="mb-2 text-xl font-bold text-white">What policy should an MCP proxy enforce?</h3>
               <p className="text-gray-400 leading-relaxed">
-                An MCP proxy should enforce agent and task identity, session budgets, per-tool cost caps, unknown-tool behavior, revocation triggers, audit fields, and optional L402 payment before tool execution.
+                An MCP proxy should enforce agent and task identity, session budgets, per-tool cost caps, unknown-tool behavior, revocation triggers, audit fields, and optional paid-rail context before tool execution.
               </p>
             </div>
           </div>

--- a/satgate-landing/scripts/check_policy_to_proof_page.py
+++ b/satgate-landing/scripts/check_policy_to_proof_page.py
@@ -19,7 +19,9 @@ RUNAWAY_COST_CALCULATOR_PAGE = ROOT / "app" / "runaway-agent-cost-calculator" / 
 RUNAWAY_COST_CALCULATOR_LAYOUT = ROOT / "app" / "runaway-agent-cost-calculator" / "layout.tsx"
 DESIGN_PARTNERS_PAGE = ROOT / "app" / "design-partners" / "page.tsx"
 DESIGN_PARTNERS_LAYOUT = ROOT / "app" / "design-partners" / "layout.tsx"
+MCP_PROXY_CONFIG_PAGE = ROOT / "app" / "mcp-proxy-config-generator" / "page.tsx"
 MCP_PROXY_CONFIG_LAYOUT = ROOT / "app" / "mcp-proxy-config-generator" / "layout.tsx"
+L402_API_PRICING_PAGE = ROOT / "app" / "l402-api-pricing-calculator" / "page.tsx"
 L402_API_PRICING_LAYOUT = ROOT / "app" / "l402-api-pricing-calculator" / "layout.tsx"
 
 SPEND_LONGTAIL_PAGES = {
@@ -760,6 +762,49 @@ def main() -> int:
         stale_metadata = [phrase for phrase in tool_metadata_forbidden_phrases[name] if phrase in metadata_text]
         if stale_metadata:
             raise SystemExit(f"stale {name} inherited/stale metadata phrases remain:\n" + "\n".join(stale_metadata))
+
+
+    generator_texts = {
+        "mcp-proxy-config-generator": MCP_PROXY_CONFIG_PAGE.read_text() + "\n" + MCP_PROXY_CONFIG_LAYOUT.read_text(),
+        "l402-api-pricing-calculator": L402_API_PRICING_PAGE.read_text() + "\n" + L402_API_PRICING_LAYOUT.read_text(),
+    }
+    generator_forbidden_phrases = {
+        "mcp-proxy-config-generator": [
+            "L402 Charge",
+            "Charge/L402",
+            "charge options",
+            "robot customers",
+        ],
+        "l402-api-pricing-calculator": [
+            "robot-customer",
+            "robot customer",
+            "robot customers",
+            "SatGate Charge",
+            "Charge robot",
+            "/robot-customer-payments",
+        ],
+    }
+    generator_required_phrases = {
+        "mcp-proxy-config-generator": [
+            "scoped authority",
+            "optional paid-rail context",
+            "preserve paid-rail context",
+        ],
+        "l402-api-pricing-calculator": [
+            "paid-agent access revenue",
+            "paid-rail context",
+            "Evidence Pack receipts",
+            "/http-402-for-ai-agents",
+        ],
+    }
+    for name, generator_text in generator_texts.items():
+        missing_generator = [phrase for phrase in generator_required_phrases[name] if phrase not in generator_text]
+        if missing_generator:
+            raise SystemExit(f"missing {name} generator authority/proof phrases:\n" + "\n".join(missing_generator))
+        stale_generator = [phrase for phrase in generator_forbidden_phrases[name] if phrase in generator_text]
+        if stale_generator:
+            raise SystemExit(f"stale {name} generator Charge/robot phrases remain:\n" + "\n".join(stale_generator))
+
 
     for name, path in L402_RAIL_PAGES.items():
         page_text = path.read_text()


### PR DESCRIPTION
## Summary
- Removes remaining `L402 Charge` / `Charge/L402` phrasing from `/mcp-proxy-config-generator` page content and JSON-LD.
- Removes remaining `robot-customer` / `SatGate Charge` phrasing and `/robot-customer-payments` exit from `/l402-api-pricing-calculator`.
- Reframes both as paid-rail context + request-path authority/proof, and extends the Policy-to-Proof guard to prevent regressions.

## Verification
- `python3 scripts/check_policy_to_proof_page.py`
- `npm run build`
