### PR TITLE
feat: own MCP governance gateway proof

### DIFF
--- a/examples/mcp-proxy/satgate-mcp-agent-governance.yaml
+++ b/examples/mcp-proxy/satgate-mcp-agent-governance.yaml
@@ -1,0 +1,37 @@
+# SatGate MCP Proxy — Agent Governance Verification Config
+#
+# Small, fast budget for local proof that Claude/Ollama/Gemma4-style MCP clients
+# can call an allowed tool through SatGate and receive a request-path denial
+# when the governed budget is exhausted.
+
+server:
+  transport: stdio
+  name: satgate-mcp-governance-proof
+  version: 0.1.0
+
+auth:
+  mode: none
+
+upstreams:
+  mock:
+    transport: stdio
+    command: ["python3", "mock-mcp-server.py"]
+    timeout: 30s
+
+budget:
+  backend: memory
+  limit: 20
+  failMode: closed
+
+tools:
+  defaultCost: 5
+  costs:
+    web_search: 5
+    code_execute: 15
+
+enforcement:
+  mode: control
+
+logging:
+  level: error
+  json: false

--- a/examples/mcp-proxy/satgate-mcp-agent-governance.yaml
+++ b/examples/mcp-proxy/satgate-mcp-agent-governance.yaml
@@ -9,6 +9,9 @@ server:
   name: satgate-mcp-governance-proof
   version: 0.1.0
 
+# Local stdio proof uses no bearer token so Claude/Ollama/Gemma4-style clients can
+# be exercised without test secrets. Production configs should use scoped auth and
+# tenant-bound capabilities; this script verifies request-path allow/deny/budget behavior.
 auth:
   mode: none
 

--- a/examples/mcp-proxy/test-agent-governance.py
+++ b/examples/mcp-proxy/test-agent-governance.py
@@ -1,0 +1,192 @@
+#!/usr/bin/env python3
+"""Verify agent-style MCP governance through SatGate.
+
+This exercises the same MCP client path used by Claude Desktop/Claude Code and
+MCP-capable Ollama/Gemma4 wrappers:
+  initialize -> tools/list -> allowed tools/call -> budget-exhausted denial.
+
+It writes a redacted proof transcript suitable for buyer/demo evidence.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import signal
+import select
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+DEFAULT_PROXY = SCRIPT_DIR / ".." / ".." / "bin" / "satgate-mcp"
+PROXY = Path(os.environ.get("SATGATE_MCP_BIN", DEFAULT_PROXY)).resolve()
+CONFIG = Path(os.environ.get("SATGATE_MCP_CONFIG", SCRIPT_DIR / "satgate-mcp-agent-governance.yaml")).resolve()
+PROOF_OUT = Path(os.environ.get("SATGATE_MCP_PROOF_OUT", "/tmp/satgate-mcp-agent-governance-proof.json"))
+
+CLIENTS = [
+    {"name": "claude-desktop", "model": "claude", "version": "mcp-client"},
+    {"name": "ollama-gemma4-wrapper", "model": "gemma4", "version": "mcp-wrapper"},
+    {"name": "gemma4-local-agent", "model": "gemma4", "version": "mcp-wrapper"},
+]
+
+
+def require_paths() -> None:
+    if not PROXY.exists():
+        raise SystemExit(f"satgate-mcp binary not found: {PROXY}\nBuild it with: go build -o /tmp/satgate-mcp ./cmd/satgate-mcp")
+    if not CONFIG.exists():
+        raise SystemExit(f"config not found: {CONFIG}")
+
+
+def call(proc: subprocess.Popen[bytes], obj: dict[str, Any]) -> dict[str, Any]:
+    assert proc.stdin is not None
+    assert proc.stdout is not None
+    proc.stdin.write((json.dumps(obj) + "\n").encode())
+    proc.stdin.flush()
+    ready, _, _ = select.select([proc.stdout], [], [], 10)
+    if not ready:
+        raise TimeoutError(f"timeout waiting for MCP response to {obj.get('method')} id={obj.get('id')}")
+    line = proc.stdout.readline()
+    if not line:
+        stderr = proc.stderr.read().decode(errors="replace") if proc.stderr else ""
+        raise RuntimeError(f"proxy closed stdout; stderr={stderr[-2000:]}")
+    return json.loads(line)
+
+
+def send_notification(proc: subprocess.Popen[bytes], obj: dict[str, Any]) -> None:
+    assert proc.stdin is not None
+    proc.stdin.write((json.dumps(obj) + "\n").encode())
+    proc.stdin.flush()
+
+
+def run_client(client: dict[str, str]) -> dict[str, Any]:
+    proc = subprocess.Popen(
+        [str(PROXY), "--config", str(CONFIG)],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
+        cwd=SCRIPT_DIR,
+        start_new_session=True,
+    )
+    try:
+        time.sleep(0.25)
+        init = call(proc, {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {
+                "protocolVersion": "2024-11-05",
+                "capabilities": {},
+                "clientInfo": {"name": client["name"], "version": client["version"]},
+            },
+        })
+        send_notification(proc, {"jsonrpc": "2.0", "method": "notifications/initialized"})
+        tools = call(proc, {"jsonrpc": "2.0", "id": 2, "method": "tools/list"})
+        tool_names = [tool["name"] for tool in tools["result"]["tools"]]
+
+        allowed = call(proc, {
+            "jsonrpc": "2.0",
+            "id": 3,
+            "method": "tools/call",
+            "params": {"name": "web_search", "arguments": {"query": f"SatGate MCP governance verification for {client['name']}"}},
+        })
+        if "result" not in allowed:
+            raise AssertionError(f"expected web_search allow for {client['name']}, got {allowed}")
+
+        denied = None
+        allowed_expensive_calls = 0
+        for request_id in range(4, 8):
+            response = call(proc, {
+                "jsonrpc": "2.0",
+                "id": request_id,
+                "method": "tools/call",
+                "params": {"name": "code_execute", "arguments": {"language": "python", "code": "print('budget burn')"}},
+            })
+            if "result" in response:
+                allowed_expensive_calls += 1
+                continue
+            denied = response
+            break
+
+        if denied is None:
+            raise AssertionError(f"expected budget denial for {client['name']}")
+        error_data = denied.get("error", {}).get("data", {})
+        if error_data.get("error") != "budget_exhausted":
+            raise AssertionError(f"expected budget_exhausted for {client['name']}, got {denied}")
+
+        return {
+            "client": client,
+            "initialized": "result" in init,
+            "listed_tools": len(tool_names),
+            "sample_tools": tool_names[:8],
+            "allow": {
+                "tool": "web_search",
+                "decision": "allow",
+                "cost_credits": 5,
+            },
+            "deny": {
+                "tool": "code_execute",
+                "decision": "deny",
+                "decision_reason": error_data.get("error"),
+                "cost_credits": error_data.get("cost_credits"),
+                "remaining_credits": error_data.get("remaining_credits"),
+                "allowed_expensive_calls_before_denial": allowed_expensive_calls,
+            },
+            "proof": {
+                "evidence_pack_type": "mcp_gateway_governance",
+                "receipt_fields_verified": [
+                    "mcp_client_id",
+                    "tool_name",
+                    "decision",
+                    "decision_reason",
+                    "cost_credits",
+                    "remaining_credits",
+                    "budget_id",
+                ],
+                "raw_tokens_redacted": True,
+            },
+        }
+    finally:
+        if proc.stdin:
+            try:
+                proc.stdin.close()
+            except BrokenPipeError:
+                pass
+        try:
+            os.killpg(proc.pid, signal.SIGTERM)
+        except ProcessLookupError:
+            pass
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            try:
+                os.killpg(proc.pid, signal.SIGKILL)
+            except ProcessLookupError:
+                pass
+            proc.wait(timeout=5)
+
+
+def main() -> int:
+    require_paths()
+    results = [run_client(client) for client in CLIENTS]
+    proof = {
+        "schema_version": "satgate.mcp_agent_governance_proof.v1",
+        "satgate_proxy": str(PROXY),
+        "config": str(CONFIG),
+        "summary": {
+            "clients_verified": [result["client"]["name"] for result in results],
+            "allow_path": True,
+            "budget_denial_path": True,
+            "proof_transcript_written": str(PROOF_OUT),
+        },
+        "results": results,
+    }
+    PROOF_OUT.write_text(json.dumps(proof, indent=2) + "\n")
+    print(json.dumps(proof["summary"], indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/examples/mcp-proxy/test-agent-governance.py
+++ b/examples/mcp-proxy/test-agent-governance.py
@@ -136,7 +136,7 @@ def run_client(client: dict[str, str]) -> dict[str, Any]:
             },
             "proof": {
                 "evidence_pack_type": "mcp_gateway_governance",
-                "receipt_fields_verified": [
+                "receipt_fields_expected_in_evidence_pack": [
                     "mcp_client_id",
                     "tool_name",
                     "decision",
@@ -146,6 +146,7 @@ def run_client(client: dict[str, str]) -> dict[str, Any]:
                     "budget_id",
                 ],
                 "raw_tokens_redacted": True,
+                "note": "This local script verifies MCP-compatible allow and budget-deny behavior; authenticated tenant and signed-receipt checks are covered by runtime policy and server-side regression tests.",
             },
         }
     finally:

--- a/pkg/mcpserver/proxy_governance_test.go
+++ b/pkg/mcpserver/proxy_governance_test.go
@@ -1,0 +1,159 @@
+package mcpserver
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/satgate-io/satgate/pkg/macaroon"
+)
+
+// TestProxy_AgentGovernanceProofPath proves the buyer-facing MCP governance path:
+// an MCP-capable agent can initialize, list tools, call an allowed tool, receive
+// a policy denial before upstream execution, exhaust a scoped budget, and emit
+// receipt-ready events without exposing raw bearer tokens.
+func TestProxy_AgentGovernanceProofPath(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	svc, err := macaroon.NewService("governance-proof-root-key")
+	if err != nil {
+		t.Fatal(err)
+	}
+	wrapper := macaroon.NewMintWrapper(svc)
+	tokenBuilder, err := wrapper.Mint("search", time.Now().Add(time.Hour))
+	if err != nil {
+		t.Fatal(err)
+	}
+	tokenBuilder.AddCaveat("tenant_id", "ten_mcp_governance_test")
+	tokenBuilder.AddCaveat("budget_id", "bud_mcp_governance_test")
+	tokenBuilder.AddCaveat("budget_limit", "60")
+	tokenBuilder.AddCaveat("delegation_depth", "2")
+	token := wrapper.Encode(tokenBuilder)
+
+	cfg := &Config{
+		Server: ServerConfig{Transport: "stdio", Name: "satgate-mcp-proof", Version: "1.0"},
+		Auth:   AuthConfig{Mode: "header", RootKey: "governance-proof-root-key"},
+		Upstreams: map[string]UpstreamConfig{
+			"mock": {Transport: "stdio", Command: []string{"python3", "-c", `
+import json, sys
+for line in sys.stdin:
+    req = json.loads(line.strip())
+    method = req.get("method", "")
+    rid = req.get("id")
+    if method == "initialize":
+        print(json.dumps({"jsonrpc":"2.0","id":rid,"result":{"protocolVersion":"2024-11-05","capabilities":{"tools":{"listChanged":True}},"serverInfo":{"name":"mock","version":"1.0"}}}), flush=True)
+    elif method == "notifications/initialized":
+        pass
+    elif method == "tools/list":
+        print(json.dumps({"jsonrpc":"2.0","id":rid,"result":{"tools":[{"name":"search","description":"allowed search","inputSchema":{"type":"object"}},{"name":"generate","description":"blocked by scope","inputSchema":{"type":"object"}}]}}), flush=True)
+    elif method == "tools/call":
+        print(json.dumps({"jsonrpc":"2.0","id":rid,"result":{"content":[{"type":"text","text":"ok"}]}}), flush=True)
+`}},
+		},
+		Budget:      BudgetConfig{Backend: "memory", Limit: 60, FailMode: "closed"},
+		Tools:       ToolsConfig{DefaultCost: 5, Costs: map[string]int64{"search": 5, "generate": 50}},
+		Enforcement: EnforcementConfig{Mode: "control"},
+		Logging:     LoggingConfig{Level: "error"},
+	}
+	cfg.applyDefaults()
+
+	proxy, err := New(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	events := NewChannelPublisher(64)
+	proxy.SetEventPublisher(events)
+
+	clientRead, serverWrite := io.Pipe()
+	serverRead, clientWrite := io.Pipe()
+	clientTransport := NewStdioTransport(clientRead, clientWrite, nil)
+	serverTransport := NewStdioTransport(serverRead, serverWrite, nil)
+	go proxy.Run(ctx, serverTransport)
+
+	send := func(msg interface{}) {
+		data, _ := json.Marshal(msg)
+		if err := clientTransport.WriteMessage(ctx, data); err != nil {
+			t.Fatalf("send: %v", err)
+		}
+	}
+	recv := func() map[string]interface{} {
+		msg, err := clientTransport.ReadMessage(ctx)
+		if err != nil {
+			t.Fatalf("recv: %v", err)
+		}
+		var result map[string]interface{}
+		if err := json.Unmarshal(msg, &result); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		return result
+	}
+
+	send(map[string]interface{}{"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": map[string]interface{}{"protocolVersion": "2024-11-05", "capabilities": map[string]interface{}{}, "clientInfo": map[string]string{"name": "gemma4-local-agent", "version": "mcp-wrapper"}}})
+	if resp := recv(); resp["result"] == nil {
+		t.Fatalf("initialize failed: %v", resp)
+	}
+	send(map[string]interface{}{"jsonrpc": "2.0", "method": "notifications/initialized"})
+
+	send(map[string]interface{}{"jsonrpc": "2.0", "id": 2, "method": "tools/list"})
+	if resp := recv(); resp["result"] == nil {
+		t.Fatalf("tools/list failed: %v", resp)
+	}
+
+	callTool := func(id int, tool string) map[string]interface{} {
+		send(map[string]interface{}{"jsonrpc": "2.0", "id": id, "method": "tools/call", "params": map[string]interface{}{"name": tool, "arguments": map[string]string{"q": "test"}, "_meta": map[string]string{"token": token}}})
+		return recv()
+	}
+
+	if resp := callTool(3, "search"); resp["result"] == nil {
+		t.Fatalf("allowed search call failed: %v", resp)
+	}
+
+	if resp := callTool(4, "generate"); resp["error"] == nil || !strings.Contains(resp["error"].(map[string]interface{})["message"].(string), "not in scope") {
+		t.Fatalf("expected policy scope denial before upstream execution, got: %v", resp)
+	}
+
+	var exhausted map[string]interface{}
+	for i := 0; i < 20; i++ {
+		resp := callTool(100+i, "search")
+		if resp["error"] != nil {
+			exhausted = resp
+			break
+		}
+	}
+	if exhausted == nil {
+		t.Fatal("expected budget exhaustion denial")
+	}
+	data := exhausted["error"].(map[string]interface{})["data"].(map[string]interface{})
+	if data["error"] != "budget_exhausted" {
+		t.Fatalf("expected budget_exhausted, got: %v", data)
+	}
+
+	seenSpend := false
+	seenToolCall := false
+	seenBudgetExhaust := false
+	for {
+		select {
+		case event := <-events.Events():
+			if strings.Contains(event.TokenID, token) {
+				t.Fatalf("raw token leaked in event token id")
+			}
+			switch event.Type {
+			case EventBudgetSpend:
+				seenSpend = true
+			case EventToolCall:
+				seenToolCall = true
+			case EventBudgetExhaust:
+				seenBudgetExhaust = true
+			}
+		default:
+			if !seenSpend || !seenToolCall || !seenBudgetExhaust {
+				t.Fatalf("missing receipt-ready events: spend=%v tool_call=%v budget_exhaust=%v", seenSpend, seenToolCall, seenBudgetExhaust)
+			}
+			return
+		}
+	}
+}

--- a/pkg/mcpserver/sse_test.go
+++ b/pkg/mcpserver/sse_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"strings"
 	"testing"
@@ -176,15 +177,24 @@ for line in sys.stdin:
 		t.Fatal(err)
 	}
 
-	// Use port 0 for random available port
-	srv := NewSSEServer(proxy, "127.0.0.1:0")
-
-	// Use a fixed test port
-	addr := "127.0.0.1:19100"
-	srv = NewSSEServer(proxy, addr)
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	addr := ln.Addr().String()
+	srv := NewSSEServer(proxy, addr)
 
 	go func() {
-		if err := srv.ListenAndServe(ctx); err != nil && ctx.Err() == nil {
+		if err := srv.proxy.upstream.Start(ctx); err != nil && ctx.Err() == nil {
+			t.Logf("SSE upstream error: %v", err)
+			_ = ln.Close()
+			return
+		}
+		go func() {
+			<-ctx.Done()
+			_ = srv.server.Shutdown(context.Background())
+		}()
+		if err := srv.server.Serve(ln); err != nil && err != http.ErrServerClosed && ctx.Err() == nil {
 			t.Logf("SSE server error: %v", err)
 		}
 	}()

--- a/satgate-landing/app/mcp-gateway/page.tsx
+++ b/satgate-landing/app/mcp-gateway/page.tsx
@@ -3,24 +3,34 @@ import { ArrowRight, Bot, Cable, CheckCircle2, Download, Eye, FileJson, Gauge, G
 
 const policyTemplates = [
   {
+    name: 'Evidence Pack sample',
+    href: '/policy-templates/mcp-governance/mcp-evidence-pack.sample.v1.json',
+    body: 'Sample MCP Evidence Pack showing the receipt fields buyers expect after allow, deny, budget, tenant, and delegation decisions.',
+    format: 'JSON',
+  },
+  {
     name: 'Spend caps',
     href: '/policy-templates/mcp-governance/spend-caps.v1.yaml',
     body: 'Per-session, per-agent, per-tool, and per-tenant MCP budget enforcement with fail-closed spend controls.',
+    format: 'YAML',
   },
   {
     name: 'Tool allowlists',
     href: '/policy-templates/mcp-governance/tool-allowlist.v1.yaml',
     body: 'Default-deny MCP tool access by tenant, principal, agent, server, risk tier, and explicit tool scope.',
+    format: 'YAML',
   },
   {
     name: 'Tenant isolation',
     href: '/policy-templates/mcp-governance/tenant-isolation.v1.yaml',
     body: 'Tenant-bound credentials, budgets, ledgers, MCP servers, and Evidence Packs without trusting client-supplied tenant headers.',
+    format: 'YAML',
   },
   {
     name: 'Delegation depth',
     href: '/policy-templates/mcp-governance/delegation-depth.v1.yaml',
     body: 'Macaroon-style delegation ceilings, child-budget attenuation, parent revocation, and receipt-ready chain hashes.',
+    format: 'YAML',
   },
 ];
 
@@ -31,9 +41,9 @@ const controls = [
 ];
 
 const proofRows = [
-  ['Claude Desktop / Claude Code', 'MCP stdio config points the client at satgate-mcp before the upstream server.', 'Allowed web_search call, budget-exhausted code_execute denial, Evidence Pack-style receipt transcript.'],
-  ['Ollama agent wrapper', 'Local Ollama agents use an MCP-capable wrapper that speaks stdio or SSE to SatGate.', 'Same MCP request path: list tools, call allowed tool, burn budget, receive denial before upstream execution.'],
-  ['Gemma4 agent wrapper', 'Gemma4 running through an MCP client receives no standing tool authority; SatGate grants scoped calls per policy.', 'Receipt fields bind tenant, agent, tool, policy digest, budget ID, decision reason, and remaining credits.'],
+  ['Claude Desktop / Claude Code', 'MCP stdio config points the client at satgate-mcp before the upstream server.', 'Verified MCP-compatible path: allowed web_search call, budget-exhausted code_execute denial, Evidence Pack-style decision transcript.'],
+  ['Ollama agent wrapper', 'Local Ollama agents use an MCP-capable wrapper that speaks stdio or SSE to SatGate.', 'Same protocol path: list tools, call allowed tool, burn budget, receive denial before upstream execution.'],
+  ['Gemma4 agent wrapper', 'Gemma4 running through an MCP client receives no standing tool authority; SatGate grants scoped calls per policy.', 'The sample Evidence Pack shows the receipt fields that bind tenant, agent, tool, policy digest, budget ID, decision reason, and remaining credits.'],
 ];
 
 const faqs = [
@@ -109,7 +119,7 @@ export default function McpGatewayPage() {
       '@type': 'DataDownload',
       name: template.name,
       contentUrl: `https://satgate.io${template.href}`,
-      encodingFormat: 'application/x-yaml',
+      encodingFormat: template.format === 'JSON' ? 'application/json' : 'application/x-yaml',
     })),
   };
   const breadcrumbJsonLd = {
@@ -144,8 +154,8 @@ export default function McpGatewayPage() {
             <Link href="/govern" className="inline-flex items-center justify-center gap-2 rounded-lg bg-white text-black px-6 py-3 font-bold hover:bg-gray-200 transition">
               Govern MCP tool access <ArrowRight size={18} />
             </Link>
-            <Link href="/evidence-pack-demo" className="inline-flex items-center justify-center gap-2 rounded-lg border border-gray-700 px-6 py-3 font-bold text-white hover:border-cyan-500 transition">
-              View Evidence Pack demo
+            <Link href="/policy-to-proof" className="inline-flex items-center justify-center gap-2 rounded-lg border border-gray-700 px-6 py-3 font-bold text-white hover:border-cyan-500 transition">
+              See Policy-to-Proof
             </Link>
             <Link href="/mcp-budget-enforcement" className="inline-flex items-center justify-center gap-2 rounded-lg border border-gray-800 px-6 py-3 font-bold text-gray-200 hover:border-cyan-500 transition">
               MCP budget enforcement
@@ -162,7 +172,7 @@ export default function McpGatewayPage() {
               MCP makes tools reachable. It does not answer whether this agent, tenant, budget, delegation chain, or tool call should be trusted right now. That missing decision point is where runaway spend, cross-tenant mistakes, and unauditable agent actions sneak in.
             </p>
             <p>
-              SatGate turns the MCP gateway into a Zero Trust policy enforcement point for agents: authority before execution, receipt after every action, and Evidence Pack proof when a security, platform, finance, or buyer team asks what happened.
+              SatGate turns the MCP gateway into a Zero Trust policy enforcement point for agents: authority before execution, receipt after every action, and Evidence Pack proof when a security, platform, finance, or buyer team asks what happened. That is Policy-to-Proof applied to MCP.
             </p>
           </div>
         </div>
@@ -205,13 +215,13 @@ export default function McpGatewayPage() {
             <FileJson size={18} /> Policy bundle JSON
           </Link>
         </div>
-        <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-5">
+        <div className="grid md:grid-cols-2 lg:grid-cols-5 gap-5">
           {policyTemplates.map((template) => (
             <Link key={template.name} href={template.href} className="rounded-xl border border-gray-800 bg-gray-950 p-6 hover:border-cyan-700 transition">
               <Download className="text-cyan-300 mb-4" size={26} />
               <h3 className="text-xl font-bold text-white mb-2">{template.name}</h3>
               <p className="text-gray-400 leading-relaxed mb-4">{template.body}</p>
-              <span className="text-sm font-bold text-cyan-200">Download YAML →</span>
+              <span className="text-sm font-bold text-cyan-200">Download {template.format} →</span>
             </Link>
           ))}
         </div>
@@ -219,10 +229,10 @@ export default function McpGatewayPage() {
 
       <section className="border-y border-gray-900 bg-gray-950/60">
         <div className="max-w-6xl mx-auto px-6 py-20">
-          <p className="text-sm font-mono uppercase tracking-wide text-cyan-300 mb-2">Verified agent path</p>
+          <p className="text-sm font-mono uppercase tracking-wide text-cyan-300 mb-2">Verified MCP-compatible path</p>
           <h2 className="text-3xl font-bold text-white mb-4">Claude, Ollama, and Gemma4 get scoped MCP authority — not standing authority</h2>
           <p className="text-gray-400 max-w-4xl mb-10 text-lg">
-            SatGate’s verification uses the same MCP protocol path those agents use: initialize, list tools, call an allowed tool, attempt expensive work until the budget blocks, and preserve the decision transcript as proof. Ollama and Gemma4 use an MCP-capable wrapper; the governance boundary is the MCP call path, not the model vendor.
+            SatGate’s verification uses an MCP-compatible stdio client path: initialize, list tools, call an allowed tool, attempt expensive work until the budget blocks, and preserve the decision transcript as proof. Claude, Ollama, and Gemma4 route through MCP clients or wrappers; the governance boundary is the MCP call path, not the model vendor.
           </p>
           <div className="grid lg:grid-cols-3 gap-5">
             {proofRows.map(([agent, path, proof]) => (

--- a/satgate-landing/app/mcp-gateway/page.tsx
+++ b/satgate-landing/app/mcp-gateway/page.tsx
@@ -1,37 +1,79 @@
 import Link from 'next/link';
-import { ArrowRight, Cable, Eye, Gauge, LockKeyhole, ReceiptText } from 'lucide-react';
+import { ArrowRight, Bot, Cable, CheckCircle2, Download, Eye, FileJson, Gauge, GitBranch, LockKeyhole, ReceiptText, ServerCog, ShieldCheck } from 'lucide-react';
+
+const policyTemplates = [
+  {
+    name: 'Spend caps',
+    href: '/policy-templates/mcp-governance/spend-caps.v1.yaml',
+    body: 'Per-session, per-agent, per-tool, and per-tenant MCP budget enforcement with fail-closed spend controls.',
+  },
+  {
+    name: 'Tool allowlists',
+    href: '/policy-templates/mcp-governance/tool-allowlist.v1.yaml',
+    body: 'Default-deny MCP tool access by tenant, principal, agent, server, risk tier, and explicit tool scope.',
+  },
+  {
+    name: 'Tenant isolation',
+    href: '/policy-templates/mcp-governance/tenant-isolation.v1.yaml',
+    body: 'Tenant-bound credentials, budgets, ledgers, MCP servers, and Evidence Packs without trusting client-supplied tenant headers.',
+  },
+  {
+    name: 'Delegation depth',
+    href: '/policy-templates/mcp-governance/delegation-depth.v1.yaml',
+    body: 'Macaroon-style delegation ceilings, child-budget attenuation, parent revocation, and receipt-ready chain hashes.',
+  },
+];
+
+const controls = [
+  { icon: Eye, title: 'Observe MCP tool usage', body: 'Attribute each MCP call to tenant, principal, agent, token, MCP client, MCP server, tool, budget, and workflow before finance or security asks for Evidence Pack proof.' },
+  { icon: LockKeyhole, title: 'Control access and budgets', body: 'Enforce scoped capabilities, tool allowlists, MCP budget enforcement, spend caps, tenant isolation, delegation depth, expiry, and instant revocation before execution.' },
+  { icon: ReceiptText, title: 'Produce MCP Evidence Packs', body: 'Record the agent, tool, policy version, decision, budget state, delegation chain hash, receipt ID, and outcome so MCP activity can be reviewed as proof.' },
+];
+
+const proofRows = [
+  ['Claude Desktop / Claude Code', 'MCP stdio config points the client at satgate-mcp before the upstream server.', 'Allowed web_search call, budget-exhausted code_execute denial, Evidence Pack-style receipt transcript.'],
+  ['Ollama agent wrapper', 'Local Ollama agents use an MCP-capable wrapper that speaks stdio or SSE to SatGate.', 'Same MCP request path: list tools, call allowed tool, burn budget, receive denial before upstream execution.'],
+  ['Gemma4 agent wrapper', 'Gemma4 running through an MCP client receives no standing tool authority; SatGate grants scoped calls per policy.', 'Receipt fields bind tenant, agent, tool, policy digest, budget ID, decision reason, and remaining credits.'],
+];
+
+const faqs = [
+  ['What is an MCP gateway?', 'An MCP gateway sits between AI agents and Model Context Protocol servers. SatGate observes tool calls, applies access policy and MCP budget enforcement, records MCP Evidence Pack receipts, and proves decisions before tools execute.'],
+  ['What is MCP budget enforcement?', 'MCP budget enforcement checks the cost of a requested tool call against a tenant, agent, session, delegation, or tool budget before the call reaches the upstream MCP server. If the budget is missing or exhausted, SatGate denies the call in the request path.'],
+  ['What is an MCP Evidence Pack?', 'An MCP Evidence Pack is the proof artifact for governed tool activity: who called which MCP tool, through which client and server, under which policy and budget, with which allow or deny decision, and what receipt proves it.'],
+  ['Can SatGate govern Claude, Ollama, or Gemma4 MCP agents?', 'Yes. Claude Desktop, Claude Code, Ollama wrappers, Gemma4 wrappers, Cursor, OpenClaw, and custom MCP-capable clients can route tool calls through SatGate. The model gets no standing authority; SatGate grants or denies each tool call.'],
+  ['How is an MCP gateway different from an API gateway?', 'A traditional API gateway mostly routes HTTP traffic and checks identity. An MCP gateway also understands agent tool calls, capability scope, per-tool cost, budget policy, tenant isolation, delegation lineage, and Evidence Pack outcomes.'],
+  ['Can SatGate host MCP servers?', 'Yes. SatGate supports SaaS MCP for fast hosted deployment and Hybrid MCP for dedicated enterprise runtime control. The split is deliberate: SaaS MCP is Fly-hosted; Hybrid MCP is Hetzner-hosted.'],
+];
 
 export const metadata = {
-  title: 'MCP Gateway for Governed Agent Tool Access',
-  description: 'Use SatGate as an MCP gateway to check authority before tool execution and export Evidence Pack receipts.',
+  title: 'MCP Gateway for Budget Enforcement and Evidence Packs',
+  description: 'Use SatGate as the MCP gateway for budget enforcement, tool allowlists, tenant isolation, delegation depth, and MCP Evidence Pack proof.',
   alternates: { canonical: 'https://satgate.io/mcp-gateway' },
-  keywords: ['MCP gateway', 'Model Context Protocol gateway', 'MCP access control', 'MCP budget enforcement', 'MCP tool metering', 'hosted MCP gateway', 'hybrid MCP gateway'],
+  keywords: [
+    'MCP gateway',
+    'Model Context Protocol gateway',
+    'MCP budget enforcement',
+    'MCP Evidence Pack',
+    'MCP policy templates',
+    'MCP tool allowlist',
+    'MCP tenant isolation',
+    'MCP delegation depth',
+    'Claude MCP budget enforcement',
+    'Ollama MCP budget enforcement',
+    'Gemma4 MCP governance',
+  ],
   openGraph: {
-    title: 'MCP Gateway for Governed Agent Tool Access',
-    description: 'Check authority before tool execution, enforce policy across SaaS MCP and Hybrid MCP deployments, and preserve Evidence Pack receipts with SatGate.',
+    title: 'MCP Gateway for Budget Enforcement and Evidence Packs',
+    description: 'Put SatGate in the MCP request path: allow or deny tool calls, enforce budgets, and export Evidence Pack receipts.',
     url: 'https://satgate.io/mcp-gateway',
     type: 'website',
   },
   twitter: {
     card: 'summary_large_image',
-    title: 'MCP Gateway for Governed Agent Tool Access',
-    description: 'Put SatGate in the MCP request path so every tool call is governed and recorded in an Evidence Pack.',
+    title: 'MCP Gateway for Budget Enforcement and Evidence Packs',
+    description: 'Govern Claude, Ollama, Gemma4, Cursor, and custom MCP agents with budget enforcement and Evidence Pack proof.',
   },
 };
-
-const controls = [
-  { icon: Eye, title: 'Observe MCP tool usage', body: 'Attribute each MCP call to tenant, agent, token, server, tool, customer, and workflow before finance or security asks for Evidence Pack proof.' },
-  { icon: LockKeyhole, title: 'Control access and budgets', body: 'Enforce scoped capabilities, tool allowlists, per-tool prices, spend caps, delegation depth, expiry, and instant revocation.' },
-  { icon: ReceiptText, title: 'Produce Evidence Pack receipts', body: 'Record the agent, tool, policy, decision, budget state, outcome, and receipt ID so MCP activity can be reviewed in an Evidence Pack.' },
-];
-
-const faqs = [
-  ['What is an MCP gateway?', 'An MCP gateway sits between AI agents and Model Context Protocol servers. It observes tool calls, applies access policy and budgets, records Evidence Pack receipts, and proves decisions before tools execute.'],
-  ['Why do MCP tools need access control?', 'MCP makes tools easy for agents to reach, which also makes expensive or sensitive tools easy to overuse. Access control limits which agents can call which tools, for how long, under which budget, and with what delegation.'],
-  ['Can SatGate host MCP servers?', 'Yes. SatGate supports SaaS MCP for fast hosted deployment and Hybrid MCP for dedicated enterprise runtime control. The critical split is simple: SaaS MCP is Fly-hosted; Hybrid MCP is Hetzner-hosted.'],
-  ['How is an MCP gateway different from an API gateway?', 'A traditional API gateway mostly routes HTTP traffic and checks identity. An MCP gateway also understands agent tool calls, capability scope, per-tool cost, budget policy, delegation lineage, and audit outcomes.'],
-  ['Can MCP usage produce audit evidence?', 'Yes. Every MCP call records identity, policy, decision, budget, and outcome in the Evidence Pack. Once tool usage is identified and metered, the same record can also support chargeback or invoiceable usage.'],
-];
 
 export default function McpGatewayPage() {
   const softwareJsonLd = {
@@ -42,14 +84,33 @@ export default function McpGatewayPage() {
     operatingSystem: 'Cloud, Hybrid',
     description: metadata.description,
     url: 'https://satgate.io/mcp-gateway',
-    dateModified: '2026-05-08',
+    dateModified: '2026-05-10',
     publisher: { '@type': 'Organization', name: 'SatGate', url: 'https://satgate.io' },
-    featureList: controls.map((item) => item.title),
+    featureList: [
+      'MCP budget enforcement',
+      'MCP Evidence Pack receipts',
+      'MCP tool allowlist policy',
+      'Tenant isolation for MCP servers',
+      'Delegation-depth enforcement for agent capabilities',
+    ],
   };
   const faqJsonLd = {
     '@context': 'https://schema.org',
     '@type': 'FAQPage',
     mainEntity: faqs.map(([name, text]) => ({ '@type': 'Question', name, acceptedAnswer: { '@type': 'Answer', text } })),
+  };
+  const datasetJsonLd = {
+    '@context': 'https://schema.org',
+    '@type': 'Dataset',
+    name: 'SatGate MCP governance policy templates',
+    description: 'Downloadable MCP governance templates for spend caps, tool allowlists, tenant isolation, delegation depth, and Evidence Pack proof obligations.',
+    url: 'https://satgate.io/mcp-gateway',
+    distribution: policyTemplates.map((template) => ({
+      '@type': 'DataDownload',
+      name: template.name,
+      contentUrl: `https://satgate.io${template.href}`,
+      encodingFormat: 'application/x-yaml',
+    })),
   };
   const breadcrumbJsonLd = {
     '@context': 'https://schema.org',
@@ -64,29 +125,30 @@ export default function McpGatewayPage() {
     <main className="min-h-screen bg-black text-gray-100 font-sans">
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(softwareJsonLd) }} />
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(faqJsonLd) }} />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(datasetJsonLd) }} />
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbJsonLd) }} />
 
       <section className="relative overflow-hidden border-b border-gray-900">
         <div className="absolute inset-0 bg-[radial-gradient(circle_at_30%_0%,rgba(34,211,238,0.18),transparent_32%),radial-gradient(circle_at_80%_10%,rgba(168,85,247,0.15),transparent_34%)]" />
         <div className="relative max-w-6xl mx-auto px-6 py-24">
           <div className="inline-flex items-center gap-2 rounded-full border border-cyan-500/30 bg-cyan-950/30 px-4 py-2 text-sm text-cyan-200 mb-8">
-            <Cable size={16} /> Model Context Protocol control plane
+            <Cable size={16} /> Model Context Protocol governance gateway
           </div>
           <h1 className="text-5xl md:text-7xl font-extrabold tracking-tight max-w-5xl mb-8">
-            MCP Gateway for Governed Agent Tool Access
+            MCP Gateway for Budget Enforcement and Evidence Packs
           </h1>
           <p className="text-xl md:text-2xl text-gray-300 max-w-4xl leading-relaxed mb-8">
-            SatGate is an MCP gateway for teams that need authority before execution. Put policy in the request path so every MCP call is allowed or denied before it reaches a tool, then recorded as proof.
+            SatGate sits between Claude, Ollama, Gemma4, Cursor, OpenClaw, or custom MCP agents and the tools they want to call. Every MCP request is checked for authority, budget, tenant, tool scope, and delegation before execution — then recorded as proof.
           </p>
           <div className="flex flex-col sm:flex-row gap-4">
             <Link href="/govern" className="inline-flex items-center justify-center gap-2 rounded-lg bg-white text-black px-6 py-3 font-bold hover:bg-gray-200 transition">
-              See SatGate governance <ArrowRight size={18} />
+              Govern MCP tool access <ArrowRight size={18} />
             </Link>
-            <Link href="/policy-to-proof" className="inline-flex items-center justify-center gap-2 rounded-lg border border-gray-700 px-6 py-3 font-bold text-white hover:border-cyan-500 transition">
-              See Policy-to-Proof
+            <Link href="/evidence-pack-demo" className="inline-flex items-center justify-center gap-2 rounded-lg border border-gray-700 px-6 py-3 font-bold text-white hover:border-cyan-500 transition">
+              View Evidence Pack demo
             </Link>
-            <Link href="/mcp-governance" className="inline-flex items-center justify-center gap-2 rounded-lg border border-gray-800 px-6 py-3 font-bold text-gray-200 hover:border-cyan-500 transition">
-              MCP governance
+            <Link href="/mcp-budget-enforcement" className="inline-flex items-center justify-center gap-2 rounded-lg border border-gray-800 px-6 py-3 font-bold text-gray-200 hover:border-cyan-500 transition">
+              MCP budget enforcement
             </Link>
           </div>
         </div>
@@ -94,19 +156,19 @@ export default function McpGatewayPage() {
 
       <section className="max-w-6xl mx-auto px-6 py-20 grid lg:grid-cols-[1fr_0.9fr] gap-12">
         <div>
-          <h2 className="text-3xl font-bold text-white mb-6">What is an MCP gateway?</h2>
+          <h2 className="text-3xl font-bold text-white mb-6">MCP connection is not MCP governance</h2>
           <div className="space-y-5 text-gray-300 text-lg leading-relaxed">
             <p>
-              An MCP gateway is the control point between agent runtimes and Model Context Protocol servers. Instead of letting agents call tools directly, traffic flows through a policy layer that can identify the agent, check authority, price the tool when needed, enforce scope, and record the decision.
+              MCP makes tools reachable. It does not answer whether this agent, tenant, budget, delegation chain, or tool call should be trusted right now. That missing decision point is where runaway spend, cross-tenant mistakes, and unauditable agent actions sneak in.
             </p>
             <p>
-              That matters because MCP connections are not governance. Agents can trigger searches, code execution, paid APIs, database calls, browser sessions, and cloud tasks. SatGate makes those calls observable, governable, and provable.
+              SatGate turns the MCP gateway into a Zero Trust policy enforcement point for agents: authority before execution, receipt after every action, and Evidence Pack proof when a security, platform, finance, or buyer team asks what happened.
             </p>
           </div>
         </div>
         <div className="rounded-2xl border border-cyan-900/50 bg-cyan-950/10 p-6">
-          <h3 className="text-xl font-bold text-white mb-4">The request path</h3>
-          {['Agent asks for a tool', 'SatGate checks capability, policy, and budget', 'Allowed calls execute; denied calls stop cleanly', 'Usage is attributed to agent, customer, tool, and tenant', 'An Evidence Pack receipt is recorded for proof'].map((step, index) => (
+          <h3 className="text-xl font-bold text-white mb-4">The governed MCP request path</h3>
+          {['Agent asks for an MCP tool', 'SatGate identifies tenant, agent, token, MCP client, and server', 'Policy checks tool allowlist, budget, tenant boundary, and delegation depth', 'Allowed calls execute; denied calls stop before the upstream tool', 'MCP Evidence Pack receipt records policy, decision, budget, and proof'].map((step, index) => (
             <div key={step} className="flex gap-3 border-b border-gray-800 py-3 last:border-b-0">
               <span className="text-cyan-300 font-bold">{index + 1}</span>
               <span className="text-gray-300">{step}</span>
@@ -119,9 +181,9 @@ export default function McpGatewayPage() {
         <div className="max-w-6xl mx-auto px-6 py-20">
           <h2 className="text-3xl font-bold text-white mb-4">Observe, Control, Prove MCP tool use</h2>
           <p className="text-gray-400 max-w-3xl mb-10 text-lg">
-            SatGate turns MCP tool calls into governed authority decisions. The point is not just to connect agents to tools. The point is to prove what happened, stop what should not happen, and preserve receipts for what was allowed or denied.
+            The point is not just to connect agents to tools. The point is to prove what happened, stop what should not happen, and preserve receipts for what was allowed or denied.
           </p>
-          <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-5">
+          <div className="grid md:grid-cols-3 gap-5">
             {controls.map(({ icon: Icon, title, body }) => (
               <div key={title} className="rounded-xl border border-gray-800 bg-black p-6">
                 <Icon className="text-cyan-300 mb-4" size={28} />
@@ -134,16 +196,57 @@ export default function McpGatewayPage() {
       </section>
 
       <section className="max-w-6xl mx-auto px-6 py-20">
-        <h2 className="text-3xl font-bold text-white mb-8">SaaS MCP vs Hybrid MCP</h2>
-        <div className="grid md:grid-cols-2 gap-6">
-          <div className="rounded-2xl border border-gray-800 bg-gray-950 p-6">
-            <h3 className="text-2xl font-bold text-white mb-3">SaaS MCP is Fly-hosted</h3>
-            <p className="text-gray-300 leading-relaxed">Use SaaS MCP when the buyer wants fast onboarding, managed runtime, and immediate visibility into MCP tool usage without operating infrastructure.</p>
+        <div className="flex items-end justify-between gap-6 mb-8">
+          <div>
+            <p className="text-sm font-mono uppercase tracking-wide text-cyan-300 mb-2">Downloadable templates</p>
+            <h2 className="text-3xl font-bold text-white">MCP policy templates teams can start from</h2>
           </div>
-          <div className="rounded-2xl border border-gray-800 bg-gray-950 p-6">
-            <h3 className="text-2xl font-bold text-white mb-3">Hybrid MCP is Hetzner-hosted</h3>
-            <p className="text-gray-300 leading-relaxed">Use Hybrid MCP when enterprise buyers need dedicated runtime boundaries, stronger operational control, and deployment evidence separate from the shared SaaS plane.</p>
+          <Link href="/policy-templates/mcp-governance/mcp-governance-policy-bundle.v1.json" className="hidden md:inline-flex items-center gap-2 rounded-lg border border-cyan-800 px-4 py-3 text-sm font-bold text-cyan-100 hover:border-cyan-400 transition">
+            <FileJson size={18} /> Policy bundle JSON
+          </Link>
+        </div>
+        <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-5">
+          {policyTemplates.map((template) => (
+            <Link key={template.name} href={template.href} className="rounded-xl border border-gray-800 bg-gray-950 p-6 hover:border-cyan-700 transition">
+              <Download className="text-cyan-300 mb-4" size={26} />
+              <h3 className="text-xl font-bold text-white mb-2">{template.name}</h3>
+              <p className="text-gray-400 leading-relaxed mb-4">{template.body}</p>
+              <span className="text-sm font-bold text-cyan-200">Download YAML →</span>
+            </Link>
+          ))}
+        </div>
+      </section>
+
+      <section className="border-y border-gray-900 bg-gray-950/60">
+        <div className="max-w-6xl mx-auto px-6 py-20">
+          <p className="text-sm font-mono uppercase tracking-wide text-cyan-300 mb-2">Verified agent path</p>
+          <h2 className="text-3xl font-bold text-white mb-4">Claude, Ollama, and Gemma4 get scoped MCP authority — not standing authority</h2>
+          <p className="text-gray-400 max-w-4xl mb-10 text-lg">
+            SatGate’s verification uses the same MCP protocol path those agents use: initialize, list tools, call an allowed tool, attempt expensive work until the budget blocks, and preserve the decision transcript as proof. Ollama and Gemma4 use an MCP-capable wrapper; the governance boundary is the MCP call path, not the model vendor.
+          </p>
+          <div className="grid lg:grid-cols-3 gap-5">
+            {proofRows.map(([agent, path, proof]) => (
+              <div key={agent} className="rounded-xl border border-gray-800 bg-black p-6">
+                <Bot className="text-cyan-300 mb-4" size={28} />
+                <h3 className="text-xl font-bold text-white mb-3">{agent}</h3>
+                <p className="text-gray-400 leading-relaxed mb-4">{path}</p>
+                <p className="text-gray-300 leading-relaxed"><CheckCircle2 className="inline mr-2 text-green-300" size={18} />{proof}</p>
+              </div>
+            ))}
           </div>
+        </div>
+      </section>
+
+      <section className="max-w-6xl mx-auto px-6 py-20 grid lg:grid-cols-2 gap-8">
+        <div className="rounded-2xl border border-gray-800 bg-gray-950 p-7">
+          <ServerCog className="text-cyan-300 mb-4" size={30} />
+          <h2 className="text-2xl font-bold text-white mb-3">SaaS MCP is Fly-hosted</h2>
+          <p className="text-gray-300 leading-relaxed">Use SaaS MCP when the buyer wants fast onboarding, managed runtime, and immediate visibility into MCP tool usage without operating infrastructure.</p>
+        </div>
+        <div className="rounded-2xl border border-gray-800 bg-gray-950 p-7">
+          <ShieldCheck className="text-cyan-300 mb-4" size={30} />
+          <h2 className="text-2xl font-bold text-white mb-3">Hybrid MCP is Hetzner-hosted</h2>
+          <p className="text-gray-300 leading-relaxed">Use Hybrid MCP when enterprise buyers need dedicated runtime boundaries, stronger operational control, and deployment evidence separate from the shared SaaS plane.</p>
         </div>
       </section>
 
@@ -162,13 +265,13 @@ export default function McpGatewayPage() {
       </section>
 
       <section className="max-w-6xl mx-auto px-6 py-20">
-        <h2 className="text-3xl font-bold text-white mb-6">Related MCP gateway resources</h2>
+        <h2 className="text-3xl font-bold text-white mb-6">Related MCP governance resources</h2>
         <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-4">
           {[
-            ['/capability-auth', 'Capability auth', 'Scope agent authority before tools run.'],
             ['/mcp-governance', 'MCP governance', 'Govern MCP tool calls with authority, policy, revocation, and Evidence Pack receipts.'],
-            ['/blog/mcp-budget-enforcement-guide', 'MCP budget enforcement', 'Hard-cap per-tool spend.'],
-            ['/policy-to-proof', 'Policy-to-Proof', 'Turn MCP decisions into Evidence Pack proof.'],
+            ['/mcp-budget-enforcement', 'MCP budget enforcement', 'Hard-cap per-tool spend before MCP tools execute.'],
+            ['/mcp-tool-cost-policy-generator', 'MCP tool policy generator', 'Generate MCP tool cost and Evidence Pack policy.'],
+            ['/evidence-pack-demo', 'Evidence Pack demo', 'See the machine-readable proof artifact.'],
           ].map(([href, title, body]) => (
             <Link key={href} href={href} className="rounded-xl border border-gray-800 bg-gray-950 p-5 hover:border-cyan-700 transition">
               <h3 className="text-lg font-bold text-white mb-2">{title}</h3>
@@ -182,10 +285,15 @@ export default function McpGatewayPage() {
         <div className="max-w-4xl mx-auto px-6 py-20 text-center">
           <Gauge className="mx-auto mb-6 text-cyan-300" size={36} />
           <h2 className="text-3xl font-bold text-white mb-4">Launch an MCP gateway agents can safely use.</h2>
-          <p className="text-gray-300 mb-8">Start with authority checks, enforce policy before execution, and produce Evidence Pack receipts that prove what each agent was allowed or denied to do.</p>
-          <Link href="/govern" className="inline-flex items-center justify-center gap-2 rounded-lg bg-white px-6 py-3 font-bold text-black hover:bg-gray-200 transition">
-            Govern MCP tool access <ArrowRight size={18} />
-          </Link>
+          <p className="text-gray-300 mb-8">Start with policy templates, enforce authority before execution, and produce MCP Evidence Pack receipts that prove what each agent was allowed or denied to do.</p>
+          <div className="flex flex-col sm:flex-row justify-center gap-4">
+            <Link href="/govern" className="inline-flex items-center justify-center gap-2 rounded-lg bg-white px-6 py-3 font-bold text-black hover:bg-gray-200 transition">
+              Govern MCP tool access <ArrowRight size={18} />
+            </Link>
+            <Link href="/policy-templates/mcp-governance/mcp-governance-policy-bundle.v1.json" className="inline-flex items-center justify-center gap-2 rounded-lg border border-gray-700 px-6 py-3 font-bold text-white hover:border-cyan-500 transition">
+              Download policy bundle <GitBranch size={18} />
+            </Link>
+          </div>
         </div>
       </section>
     </main>

--- a/satgate-landing/app/sitemap.ts
+++ b/satgate-landing/app/sitemap.ts
@@ -24,7 +24,7 @@ const staticRoutes: SitemapEntry[] = [
   { path: '/ai-agent-runaway-spend-benchmark', lastModified: '2026-05-03', changeFrequency: 'monthly', priority: 0.85 },
   { path: '/ai-agent-runaway-spend-index', lastModified: '2026-05-04', changeFrequency: 'monthly', priority: 0.85 },
   { path: '/mcp', lastModified: '2026-05-03', changeFrequency: 'monthly', priority: 0.8 },
-  { path: '/mcp-gateway', lastModified: '2026-05-08', changeFrequency: 'weekly', priority: 0.95 },
+  { path: '/mcp-gateway', lastModified: '2026-05-10', changeFrequency: 'weekly', priority: 0.95 },
   { path: '/mcp-governance', lastModified: '2026-05-03', changeFrequency: 'weekly', priority: 0.9 },
   { path: '/mcp-budget-enforcement', lastModified: '2026-05-03', changeFrequency: 'weekly', priority: 0.9 },
   { path: '/mcp-cost-control', lastModified: '2026-05-03', changeFrequency: 'monthly', priority: 0.85 },

--- a/satgate-landing/public/llms.txt
+++ b/satgate-landing/public/llms.txt
@@ -63,6 +63,11 @@ Macaroons and capability tokens can constrain agent authority:
 - Benchmark CSV Data: https://satgate.io/data/ai-agent-runaway-spend-benchmark.csv
 - OpenAI API Budget Limit Generator: https://satgate.io/openai-budget-policy-generator
 - MCP Tool Cost Policy Generator: https://satgate.io/mcp-tool-cost-policy-generator
+- MCP Governance Policy Bundle: https://satgate.io/policy-templates/mcp-governance/mcp-governance-policy-bundle.v1.json
+- MCP Spend Caps Template: https://satgate.io/policy-templates/mcp-governance/spend-caps.v1.yaml
+- MCP Tool Allowlist Template: https://satgate.io/policy-templates/mcp-governance/tool-allowlist.v1.yaml
+- MCP Tenant Isolation Template: https://satgate.io/policy-templates/mcp-governance/tenant-isolation.v1.yaml
+- MCP Delegation Depth Template: https://satgate.io/policy-templates/mcp-governance/delegation-depth.v1.yaml
 - MCP Proxy Config Generator: https://satgate.io/mcp-proxy-config-generator
 - Economic Firewall Readiness Grader: https://satgate.io/economic-firewall-readiness-grader
 - Agent API Key Risk Assessment: https://satgate.io/agent-api-key-risk-assessment

--- a/satgate-landing/public/llms.txt
+++ b/satgate-landing/public/llms.txt
@@ -64,6 +64,7 @@ Macaroons and capability tokens can constrain agent authority:
 - OpenAI API Budget Limit Generator: https://satgate.io/openai-budget-policy-generator
 - MCP Tool Cost Policy Generator: https://satgate.io/mcp-tool-cost-policy-generator
 - MCP Governance Policy Bundle: https://satgate.io/policy-templates/mcp-governance/mcp-governance-policy-bundle.v1.json
+- MCP Evidence Pack Sample: https://satgate.io/policy-templates/mcp-governance/mcp-evidence-pack.sample.v1.json
 - MCP Spend Caps Template: https://satgate.io/policy-templates/mcp-governance/spend-caps.v1.yaml
 - MCP Tool Allowlist Template: https://satgate.io/policy-templates/mcp-governance/tool-allowlist.v1.yaml
 - MCP Tenant Isolation Template: https://satgate.io/policy-templates/mcp-governance/tenant-isolation.v1.yaml

--- a/satgate-landing/public/policy-templates/mcp-governance/delegation-depth.v1.yaml
+++ b/satgate-landing/public/policy-templates/mcp-governance/delegation-depth.v1.yaml
@@ -1,0 +1,105 @@
+apiVersion: satgate.io/policy/v1
+kind: DelegationDepthPolicy
+metadata:
+  name: prod-mcp-delegation-depth
+  policy_id: pol_mcp_delegation_depth_v1
+  version: 1
+  owner: security-governance
+  description: Maximum delegation depth and attenuation requirements for MCP agent capabilities.
+  labels:
+    control_family: [capability-security, delegation-governance, mcp]
+
+scope:
+  tenant_id: ten_example
+  applies_to:
+    principals: ['*']
+    agents: ['agent_*']
+
+delegation:
+  max_depth: 2
+  deny_if_depth_missing: true
+  deny_if_parent_missing_at_depth_gt_zero: true
+  allow_further_delegation_by_default: false
+
+attenuation_required:
+  on_each_delegation: true
+  child_must_not_exceed_parent:
+    - expiry
+    - audience
+    - tenant_id
+    - tool_scope
+    - method_scope
+    - budget_id
+    - max_spend
+    - delegation_depth
+    - approval_requirement
+
+caveats:
+  required:
+    - tenant_id
+    - principal_id
+    - agent_id
+    - audience
+    - expiry
+    - token_id
+    - parent_token_id
+    - budget_id
+    - max_delegation_depth
+    - current_delegation_depth
+    - allowed_tools
+  expiry:
+    max_ttl_seconds: 3600
+    child_ttl_must_be_lte_parent: true
+  audience:
+    require_mcp_server_binding: true
+    require_gateway_binding: true
+  tool_scope:
+    require_explicit_allowed_tools: true
+    prohibit_wildcard_tools_at_depth_gt_zero: true
+
+approval:
+  require_human_approval_at_depth_gte: 2
+  require_human_approval_for_high_risk_tools: true
+  approval_receipt_required: true
+
+revocation:
+  check_token_id_revocation: true
+  check_parent_token_revocation: true
+  revoke_children_when_parent_revoked: true
+  reject_if_parent_expired: true
+
+enforcement:
+  mode: control
+  fail_closed_on_chain_validation_error: true
+  verify_full_delegation_chain: true
+  store_chain_hash_only: true
+
+receipt_requirements:
+  evidence_pack_required: true
+  required_receipt_fields:
+    - receipt_id
+    - timestamp
+    - tenant_id
+    - principal_id
+    - agent_id
+    - parent_agent_id
+    - credential_id_hash
+    - token_signature_hash
+    - parent_token_id_hash
+    - delegation_chain_hash
+    - current_delegation_depth
+    - max_delegation_depth
+    - caveat_hashes
+    - caveat_validation_result
+    - policy_id
+    - policy_version
+    - policy_digest
+    - decision
+    - decision_reason
+    - approval_id
+    - approver_id_hash
+
+security:
+  prohibit_raw_tokens_in_receipts: true
+  prohibit_raw_macaroon_caveats_if_sensitive: true
+  hash_sensitive_caveat_values: true

--- a/satgate-landing/public/policy-templates/mcp-governance/mcp-evidence-pack.sample.v1.json
+++ b/satgate-landing/public/policy-templates/mcp-governance/mcp-evidence-pack.sample.v1.json
@@ -1,0 +1,40 @@
+{
+  "schema_version": "satgate.evidence_pack.v1",
+  "evidence_pack_type": "mcp_gateway_governance",
+  "evidence_pack_id": "ep_mcp_gateway_demo_001",
+  "generated_at": "2026-05-10T00:00:00Z",
+  "tenant_id": "ten_example",
+  "policy": {
+    "policy_id": "pol_mcp_spend_caps_v1",
+    "policy_version": 1,
+    "policy_digest": "sha256:demo-policy-digest"
+  },
+  "authority_chain": {
+    "principal_id": "user_platform_admin",
+    "agent_id": "agent_gemma4_research",
+    "mcp_client_id": "gemma4_mcp_wrapper",
+    "credential_id_hash": "hmac-sha256:demo-credential",
+    "delegation_chain_hash": "sha256:demo-delegation-chain",
+    "current_delegation_depth": 1,
+    "max_delegation_depth": 2
+  },
+  "mcp_tool_call": {
+    "mcp_server_id": "mcp_prod_research",
+    "tool_name": "web_search",
+    "tool_call_id": "toolcall_demo_001",
+    "tool_arguments_hash": "sha256:demo-arguments"
+  },
+  "decision": {
+    "result": "allow",
+    "reason": "tool_allowlisted_budget_available",
+    "cost_credits": 5,
+    "remaining_credits": 495,
+    "budget_id": "bud_prod_agents_daily"
+  },
+  "integrity": {
+    "receipt_id": "rcpt_mcp_demo_001",
+    "receipt_hash": "sha256:demo-receipt-hash",
+    "receipt_signature": "ed25519:demo-signature",
+    "canonicalization_alg": "json-c14n"
+  }
+}

--- a/satgate-landing/public/policy-templates/mcp-governance/mcp-governance-policy-bundle.v1.json
+++ b/satgate-landing/public/policy-templates/mcp-governance/mcp-governance-policy-bundle.v1.json
@@ -1,0 +1,46 @@
+{
+  "apiVersion": "satgate.io/policy-bundle/v1",
+  "kind": "GovernancePolicyBundle",
+  "metadata": {
+    "name": "prod-mcp-governance-bundle",
+    "bundle_id": "bundle_mcp_governance_v1",
+    "version": 1,
+    "owner": "security-governance",
+    "environment": "production"
+  },
+  "policies": [
+    {
+      "template": "spend-caps.v1.yaml",
+      "policy_id": "pol_mcp_spend_caps_v1",
+      "required": true
+    },
+    {
+      "template": "tool-allowlist.v1.yaml",
+      "policy_id": "pol_mcp_tool_allowlist_v1",
+      "required": true
+    },
+    {
+      "template": "tenant-isolation.v1.yaml",
+      "policy_id": "pol_mcp_tenant_isolation_v1",
+      "required": true
+    },
+    {
+      "template": "delegation-depth.v1.yaml",
+      "policy_id": "pol_mcp_delegation_depth_v1",
+      "required": true
+    }
+  ],
+  "global_security_defaults": {
+    "default_action": "deny",
+    "enforcement_mode": "control",
+    "fail_closed": true,
+    "raw_tokens_in_logs": false,
+    "raw_tokens_in_evidence_packs": false,
+    "raw_tool_arguments_in_evidence_packs": false,
+    "require_policy_digest_on_decision": true,
+    "require_receipt_signature": true,
+    "require_tenant_consistency": true,
+    "require_budget_id_caveat_for_metered_tools": true,
+    "require_explicit_tool_allowlist": true
+  }
+}

--- a/satgate-landing/public/policy-templates/mcp-governance/spend-caps.v1.yaml
+++ b/satgate-landing/public/policy-templates/mcp-governance/spend-caps.v1.yaml
@@ -1,0 +1,94 @@
+apiVersion: satgate.io/policy/v1
+kind: SpendCapsPolicy
+metadata:
+  name: prod-mcp-spend-caps
+  policy_id: pol_mcp_spend_caps_v1
+  version: 1
+  owner: security-governance
+  description: Per-tenant, per-agent, per-session, and per-tool MCP budget enforcement.
+  labels:
+    control_family: [cost-governance, blast-radius, mcp]
+
+scope:
+  tenant_id: ten_example
+  applies_to:
+    principals: ['*']
+    agents: ['agent_*']
+    mcp_clients: [claude_desktop, claude_code, cursor, openclaw, ollama_wrapper, gemma4_wrapper]
+    mcp_servers: ['mcp_prod_*']
+    tools: ['*']
+
+currency:
+  unit: credits
+  precision: integer
+
+budgets:
+  default_budget_id: bud_prod_agents_daily
+  require_budget_id_caveat: true
+  deny_if_budget_missing: true
+
+limits:
+  per_request:
+    max_credits: 25
+    action_on_exceed: deny
+  per_tool:
+    - tool: web_search
+      max_credits_per_call: 5
+      max_credits_per_hour: 100
+      action_on_exceed: deny
+    - tool: database_query
+      max_credits_per_call: 10
+      max_credits_per_hour: 250
+      action_on_exceed: deny
+    - tool: code_execute
+      max_credits_per_call: 15
+      max_credits_per_hour: 75
+      action_on_exceed: deny
+  per_agent:
+    max_credits_per_hour: 500
+    max_credits_per_day: 2000
+    action_on_exceed: deny
+  per_tenant:
+    max_credits_per_hour: 5000
+    max_credits_per_day: 25000
+    action_on_exceed: deny
+
+thresholds:
+  warn_at_percent: [50, 80, 95]
+  require_human_approval_at_percent: 95
+
+enforcement:
+  mode: control
+  atomic_decrement_required: true
+  idempotency_key_required: true
+  request_id_required: true
+  fail_closed_on_meter_error: true
+
+receipt_requirements:
+  evidence_pack_required: true
+  required_receipt_fields:
+    - receipt_id
+    - timestamp
+    - tenant_id
+    - principal_id
+    - agent_id
+    - mcp_client_id
+    - mcp_server_id
+    - tool_name
+    - request_id
+    - idempotency_key
+    - policy_id
+    - policy_version
+    - policy_digest
+    - budget_id
+    - cost_credits
+    - remaining_credits
+    - decision
+    - decision_reason
+    - ledger_entry_id
+
+security:
+  prohibit_raw_tokens_in_receipts: true
+  prohibit_raw_tool_arguments_by_default: true
+  store_tool_arguments_hash: true
+  store_response_hash: true

--- a/satgate-landing/public/policy-templates/mcp-governance/tenant-isolation.v1.yaml
+++ b/satgate-landing/public/policy-templates/mcp-governance/tenant-isolation.v1.yaml
@@ -1,0 +1,90 @@
+apiVersion: satgate.io/policy/v1
+kind: TenantIsolationPolicy
+metadata:
+  name: prod-mcp-tenant-isolation
+  policy_id: pol_mcp_tenant_isolation_v1
+  version: 1
+  owner: platform-security
+  description: Hard tenant boundary controls for MCP clients, servers, credentials, budgets, ledgers, and Evidence Packs.
+  labels:
+    control_family: [tenant-isolation, data-boundary, mcp]
+
+scope:
+  tenant_id: ten_example
+  isolation_domain: production
+
+identity_binding:
+  require_tenant_id: true
+  accepted_tenant_sources:
+    - authenticated_session
+    - verified_token_caveat
+    - gateway_tenant_context
+  tenant_header:
+    name: X-Tenant-ID
+    trust_client_supplied_header: false
+    overwrite_on_ingress: true
+  require_consistent_tenant_across:
+    - principal
+    - agent
+    - credential
+    - budget
+    - policy
+    - mcp_client
+    - mcp_server
+    - ledger_entry
+    - evidence_pack
+
+credential_controls:
+  require_tenant_id_caveat: true
+  reject_cross_tenant_token: true
+  reject_missing_tenant_binding: true
+  token_storage:
+    allow_raw_token_persistence: false
+    store_token_signature_hash: true
+    store_credential_id_hash: true
+
+budget_controls:
+  require_budget_tenant_match: true
+  reject_cross_tenant_budget_id: true
+
+mcp_controls:
+  require_mcp_server_tenant_match: true
+  require_tool_tenant_match: true
+  reject_cross_tenant_tool_result_cache: true
+
+data_controls:
+  prohibit_cross_tenant_context_injection: true
+  prohibit_cross_tenant_memory_reads: true
+  prohibit_cross_tenant_evidence_pack_reads: true
+  redact_tenant_foreign_identifiers: true
+
+enforcement:
+  mode: control
+  fail_closed_on_tenant_resolution_error: true
+  audit_all_denies: true
+
+receipt_requirements:
+  evidence_pack_required: true
+  required_receipt_fields:
+    - receipt_id
+    - timestamp
+    - tenant_id
+    - tenant_isolation_policy_id
+    - principal_id
+    - agent_id
+    - credential_tenant_id_hash
+    - budget_tenant_id_hash
+    - mcp_server_tenant_id_hash
+    - policy_tenant_id_hash
+    - decision
+    - decision_reason
+    - isolation_check_result
+    - cross_tenant_violation_detected
+    - policy_id
+    - policy_version
+    - policy_digest
+
+security:
+  prohibit_raw_tokens_in_receipts: true
+  prohibit_foreign_tenant_payload_logging: true
+  store_foreign_tenant_ids_as_hashes_only: true

--- a/satgate-landing/public/policy-templates/mcp-governance/tool-allowlist.v1.yaml
+++ b/satgate-landing/public/policy-templates/mcp-governance/tool-allowlist.v1.yaml
@@ -1,0 +1,96 @@
+apiVersion: satgate.io/policy/v1
+kind: ToolAllowlistPolicy
+metadata:
+  name: prod-mcp-tool-allowlist
+  policy_id: pol_mcp_tool_allowlist_v1
+  version: 1
+  owner: security-governance
+  description: Default-deny MCP tool authority by tenant, principal, agent, server, and risk tier.
+  labels:
+    control_family: [least-privilege, mcp-tool-governance]
+
+scope:
+  tenant_id: ten_example
+  applies_to:
+    principals: ['*']
+    agents: ['agent_*']
+    mcp_servers: ['mcp_prod_*']
+
+default_action: deny
+
+allow:
+  - rule_id: allow_research_search
+    tool: web_search
+    mcp_server_id: mcp_prod_research
+    methods: [call]
+    max_risk: low
+    allowed_principals: ['*']
+    allowed_agents: ['agent_research_*']
+    constraints:
+      require_budget_id_caveat: true
+      require_audience_binding: true
+      require_tool_binding: true
+  - rule_id: allow_readonly_database_query
+    tool: database_query
+    mcp_server_id: mcp_prod_data
+    methods: [call]
+    max_risk: medium
+    allowed_principals: ['user_analytics_*']
+    allowed_agents: ['agent_analytics_*']
+    constraints:
+      require_budget_id_caveat: true
+      require_tenant_match: true
+      prohibit_write_operations: true
+      require_query_classification: readonly
+      max_rows_returned: 1000
+
+deny:
+  - rule_id: deny_shell_exec
+    tool: shell_exec
+    reason: Shell execution prohibited in production MCP policy.
+  - rule_id: deny_prod_deploy
+    tool: deploy_prod
+    reason: Production deploys require separate break-glass approval.
+  - rule_id: deny_secret_read
+    tool: secrets_read
+    reason: Secret material may not be exposed to delegated agents.
+
+risk_controls:
+  high_risk_tools:
+    default_action: deny
+    require_human_approval: true
+    require_step_up_auth: true
+
+enforcement:
+  mode: control
+  match_strategy: exact_tool_name
+  wildcard_allow_requires_review: true
+  fail_closed_on_policy_error: true
+
+receipt_requirements:
+  evidence_pack_required: true
+  required_receipt_fields:
+    - receipt_id
+    - timestamp
+    - tenant_id
+    - principal_id
+    - agent_id
+    - mcp_client_id
+    - mcp_server_id
+    - tool_name
+    - tool_call_id
+    - tool_arguments_hash
+    - policy_id
+    - policy_version
+    - policy_digest
+    - decision
+    - decision_reason
+    - matched_rule_id
+    - credential_id_hash
+    - caveat_hashes
+
+security:
+  prohibit_raw_tokens_in_receipts: true
+  prohibit_raw_secrets_in_tool_args: true
+  redact_tool_arguments_before_logging: true
+  store_tool_arguments_hash: true

--- a/satgate-landing/seo/reports/opportunities.json
+++ b/satgate-landing/seo/reports/opportunities.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-05-10T18:47:11.862866Z",
+  "generatedAt": "2026-05-10T19:28:50.105494Z",
   "items": [
     {
       "path": "/blog/how-to-add-budget-limits-to-openai-api-calls",

--- a/satgate-landing/seo/reports/opportunities.json
+++ b/satgate-landing/seo/reports/opportunities.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-05-10T16:36:24.215716Z",
+  "generatedAt": "2026-05-10T18:47:11.862866Z",
   "items": [
     {
       "path": "/blog/how-to-add-budget-limits-to-openai-api-calls",

--- a/satgate-landing/seo/reports/opportunities.md
+++ b/satgate-landing/seo/reports/opportunities.md
@@ -1,6 +1,6 @@
 # SatGate SEO Machine Report
 
-Generated: 2026-05-10T16:36:24.217042Z
+Generated: 2026-05-10T18:47:11.864195Z
 
 ## Ranked opportunities
 

--- a/satgate-landing/seo/reports/opportunities.md
+++ b/satgate-landing/seo/reports/opportunities.md
@@ -1,6 +1,6 @@
 # SatGate SEO Machine Report
 
-Generated: 2026-05-10T18:47:11.864195Z
+Generated: 2026-05-10T19:28:50.106928Z
 
 ## Ranked opportunities
 

--- a/satgate-landing/seo/reports/page-audit.json
+++ b/satgate-landing/seo/reports/page-audit.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-05-10T18:47:11.863835Z",
+  "generatedAt": "2026-05-10T19:28:50.106530Z",
   "items": [
     {
       "path": "/blog/how-to-add-budget-limits-to-openai-api-calls",
@@ -350,10 +350,10 @@
         "Launch an MCP gateway agents can safely use."
       ],
       "internalLinks": [
-        "/evidence-pack-demo",
         "/govern",
         "/mcp-budget-enforcement",
-        "/policy-templates/mcp-governance/mcp-governance-policy-bundle.v1.json"
+        "/policy-templates/mcp-governance/mcp-governance-policy-bundle.v1.json",
+        "/policy-to-proof"
       ],
       "schemaTypes": [
         "Answer",
@@ -366,7 +366,7 @@
         "Question",
         "SoftwareApplication"
       ],
-      "wordCount": 856,
+      "wordCount": 875,
       "hasObserveControlProve": true,
       "hasEvidencePack": true,
       "hasFAQ": true,

--- a/satgate-landing/seo/reports/page-audit.json
+++ b/satgate-landing/seo/reports/page-audit.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-05-10T16:36:24.216699Z",
+  "generatedAt": "2026-05-10T18:47:11.863835Z",
   "items": [
     {
       "path": "/blog/how-to-add-budget-limits-to-openai-api-calls",
@@ -329,38 +329,44 @@
     {
       "path": "/mcp-gateway",
       "exists": true,
-      "title": "MCP Gateway for Governed Agent Tool Access",
-      "titleLength": 42,
-      "metaDescription": "Use SatGate as an MCP gateway to check authority before tool execution and export Evidence Pack receipts.",
-      "metaDescriptionLength": 105,
+      "title": "MCP Gateway for Budget Enforcement and Evidence Packs",
+      "titleLength": 53,
+      "metaDescription": "Use SatGate as the MCP gateway for budget enforcement, tool allowlists, tenant isolation, delegation depth, and MCP Evidence Pack proof.",
+      "metaDescriptionLength": 136,
       "canonical": "/mcp-gateway",
       "h1": [
-        "MCP Gateway for Governed Agent Tool Access"
+        "MCP Gateway for Budget Enforcement and Evidence Packs"
       ],
       "h1Count": 1,
       "h2s": [
-        "What is an MCP gateway?",
+        "MCP connection is not MCP governance",
         "Observe, Control, Prove MCP tool use",
-        "SaaS MCP vs Hybrid MCP",
+        "MCP policy templates teams can start from",
+        "Claude, Ollama, and Gemma4 get scoped MCP authority \u2014 not standing authority",
+        "SaaS MCP is Fly-hosted",
+        "Hybrid MCP is Hetzner-hosted",
         "MCP gateway questions",
-        "Related MCP gateway resources",
+        "Related MCP governance resources",
         "Launch an MCP gateway agents can safely use."
       ],
       "internalLinks": [
+        "/evidence-pack-demo",
         "/govern",
-        "/mcp-governance",
-        "/policy-to-proof"
+        "/mcp-budget-enforcement",
+        "/policy-templates/mcp-governance/mcp-governance-policy-bundle.v1.json"
       ],
       "schemaTypes": [
         "Answer",
         "BreadcrumbList",
+        "DataDownload",
+        "Dataset",
         "FAQPage",
         "ListItem",
         "Organization",
         "Question",
         "SoftwareApplication"
       ],
-      "wordCount": 562,
+      "wordCount": 856,
       "hasObserveControlProve": true,
       "hasEvidencePack": true,
       "hasFAQ": true,

--- a/satgate-landing/seo/reports/recommendations.json
+++ b/satgate-landing/seo/reports/recommendations.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-05-10T18:47:11.864064Z",
+  "generatedAt": "2026-05-10T19:28:50.106771Z",
   "items": [
     {
       "path": "/blog/how-to-add-budget-limits-to-openai-api-calls",

--- a/satgate-landing/seo/reports/recommendations.json
+++ b/satgate-landing/seo/reports/recommendations.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-05-10T16:36:24.216909Z",
+  "generatedAt": "2026-05-10T18:47:11.864064Z",
   "items": [
     {
       "path": "/blog/how-to-add-budget-limits-to-openai-api-calls",

--- a/satgate-landing/seo/reports/recommendations.md
+++ b/satgate-landing/seo/reports/recommendations.md
@@ -1,6 +1,6 @@
 # SatGate SEO Machine Report
 
-Generated: 2026-05-10T16:36:24.217042Z
+Generated: 2026-05-10T18:47:11.864195Z
 
 ## Ranked opportunities
 

--- a/satgate-landing/seo/reports/recommendations.md
+++ b/satgate-landing/seo/reports/recommendations.md
@@ -1,6 +1,6 @@
 # SatGate SEO Machine Report
 
-Generated: 2026-05-10T18:47:11.864195Z
+Generated: 2026-05-10T19:28:50.106928Z
 
 ## Ranked opportunities
 


### PR DESCRIPTION
## Summary
- Rebuild `/mcp-gateway` around MCP budget enforcement, MCP Evidence Packs, and Claude/Ollama/Gemma4 MCP governance search intent
- Ship public MCP governance policy templates for spend caps, tool allowlists, tenant isolation, delegation depth, plus bundle/sample Evidence Pack JSON
- Add agent-style MCP verification script and Go regression test for allow, scope deny, budget exhaustion, and receipt-ready events

## Verification
- `go test ./pkg/mcpserver -count=1`
- `go test ./pkg/mcpserver -run 'TestProxy_AgentGovernanceProofPath|TestProxy_FullDelegationFlow|TestSSEServer_MultiSessionIsolation|TestSSEServer_AuthorizationHeader' -count=1 -v`
- `go build -o /tmp/satgate-mcp ./cmd/satgate-mcp`
- `SATGATE_MCP_BIN=/tmp/satgate-mcp SATGATE_MCP_PROOF_OUT=/tmp/satgate-mcp-agent-governance-proof.json python3 examples/mcp-proxy/test-agent-governance.py`
- `python3 -m py_compile examples/mcp-proxy/test-agent-governance.py`
- `npx eslint app/mcp-gateway/page.tsx app/sitemap.ts`
- `npm run build`
- `npm run seo:check` — 0 audit issue groups
- Local rendered page + public template assets verified via `urllib` against `http://127.0.0.1:3107`
