### PR TITLE
fix: standardize next-request revocation copy

### DIFF
--- a/satgate-landing/app/agent-control-plane/page.tsx
+++ b/satgate-landing/app/agent-control-plane/page.tsx
@@ -203,7 +203,7 @@ const jsonLd = {
         "Request-path budget enforcement",
         "MCP tool governance",
         "Agent Evidence Packs",
-        "Instant revocation and kill switch",
+        "Next-request revocation and kill switch",
       ],
     },
     {

--- a/satgate-landing/app/agents/page.tsx
+++ b/satgate-landing/app/agents/page.tsx
@@ -101,7 +101,7 @@ export default function AgentsLandingPage() {
 
           <p className="text-lg sm:text-xl text-gray-400 max-w-2xl mx-auto mb-10">
             HTTP APIs and MCP tool calls — authenticated, logged, cost-tracked, and budget-enforced. 
-            Per-agent budgets. Delegation hierarchies. Instant revocation. Connect in 5 minutes.
+            Per-agent budgets. Delegation hierarchies. Next-request revocation. Connect in 5 minutes.
           </p>
 
           <div className="flex flex-col sm:flex-row gap-4 justify-center">

--- a/satgate-landing/app/components/HomeClient.tsx
+++ b/satgate-landing/app/components/HomeClient.tsx
@@ -308,7 +308,7 @@ const LandingPage = () => {
             <div className="flex flex-wrap gap-4 text-sm text-gray-500">
               <span>✓ Capabilities + Caveats</span>
               <span>✓ Delegation chains</span>
-              <span>✓ Instant revocation</span>
+              <span>✓ Next-request revocation</span>
               <span>✓ Tamper-evident audit</span>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- broadens the public app copy audit beyond the pages fixed in #85
- replaces remaining public “instant revocation” claims with “next-request revocation”
- keeps revocation language consistent with request-path gateway enforcement

## Verification
- public app copy scan for internal/meta phrases, overheated comparison tone, and `instant revocation`: `PUBLIC_APP_COPY_SCAN_OK`
- `npx eslint app/agents/page.tsx app/components/HomeClient.tsx app/agent-control-plane/page.tsx` (warnings only; pre-existing unused imports/img warnings)
- `npm run build`
