### PR TITLE
fix: lead homepage with economic firewall category

### DIFF
--- a/satgate-landing/app/components/HomeClient.tsx
+++ b/satgate-landing/app/components/HomeClient.tsx
@@ -161,7 +161,7 @@ const LandingPage = () => {
           {/* Left: Copy */}
           <div>
             <div className="inline-flex items-center gap-2 px-3 py-1 rounded-full bg-purple-900/30 border border-purple-500/30 text-purple-300 text-xs font-mono mb-6">
-              <Zap size={12} /> Policy-to-Proof for AI Agents
+              <Zap size={12} /> Economic Firewall for AI Agents
             </div>
             <h1 className="text-5xl md:text-6xl font-extrabold tracking-tight mb-6">
               Govern agent authority<br/>

--- a/satgate-landing/app/layout.tsx
+++ b/satgate-landing/app/layout.tsx
@@ -15,7 +15,7 @@ const geistMono = Geist_Mono({
 export const metadata: Metadata = {
   metadataBase: new URL("https://satgate.io"),
   title: {
-    default: "SatGate — Policy-to-Proof Governance for AI Agents",
+    default: "SatGate — Economic Firewall for AI Agents",
     template: "%s | SatGate",
   },
   description:
@@ -48,7 +48,7 @@ export const metadata: Metadata = {
     "Fiat402",
   ],
   openGraph: {
-    title: "SatGate — Policy-to-Proof Governance for AI Agents",
+    title: "SatGate — Economic Firewall for AI Agents",
     description:
       "Authority before execution. Evidence Packs after every decision across MCP, APIs, API keys, and rail-neutral paid-rail governance.",
     url: "https://satgate.io",
@@ -58,7 +58,7 @@ export const metadata: Metadata = {
         url: "/logo.png",
         width: 512,
         height: 512,
-        alt: "SatGate — Policy-to-Proof Governance for AI Agents",
+        alt: "SatGate — Economic Firewall for AI Agents",
       },
     ],
     locale: "en_US",
@@ -66,7 +66,7 @@ export const metadata: Metadata = {
   },
   twitter: {
     card: "summary_large_image",
-    title: "SatGate — Policy-to-Proof Governance for AI Agents",
+    title: "SatGate — Economic Firewall for AI Agents",
     description:
       "Policy-to-Proof governance for enterprise agents across MCP, APIs, API keys, and paid rails.",
     images: ["/logo.png"],

--- a/satgate-landing/app/page.tsx
+++ b/satgate-landing/app/page.tsx
@@ -2,14 +2,14 @@ import type { Metadata } from "next";
 import HomeClient from "./components/HomeClient";
 
 export const metadata: Metadata = {
-  title: "SatGate — Policy-to-Proof Governance for AI Agents",
+  title: "SatGate — Economic Firewall for AI Agents",
   description:
     "Authority before execution. Evidence Packs after every decision across MCP, APIs, API keys, L402, x402, AgentCore Payments, Pay.sh, and enterprise billing.",
   alternates: {
     canonical: "https://satgate.io",
   },
   openGraph: {
-    title: "SatGate — Policy-to-Proof Governance for AI Agents",
+    title: "SatGate — Economic Firewall for AI Agents",
     description:
       "Policy-to-Proof governance for enterprise agents: scoped authority before execution and Evidence Packs across APIs, MCP tools, and paid rails.",
     url: "https://satgate.io",
@@ -17,7 +17,7 @@ export const metadata: Metadata = {
   },
   twitter: {
     card: "summary_large_image",
-    title: "SatGate — Policy-to-Proof Governance for AI Agents",
+    title: "SatGate — Economic Firewall for AI Agents",
     description:
       "Policy-to-Proof governance for enterprise agents: scoped authority before execution and Evidence Packs across APIs, MCP tools, and paid rails.",
   },
@@ -42,7 +42,7 @@ export default function HomePage() {
       },
       {
         '@type': 'WebPage',
-        name: 'SatGate — Policy-to-Proof Governance for AI Agents',
+        name: 'SatGate — Economic Firewall for AI Agents',
         url: 'https://satgate.io',
         description: 'Authority before execution. Evidence Packs after every decision across MCP, APIs, API keys, L402, x402, AgentCore Payments, Pay.sh, and enterprise billing.',
         datePublished: '2026-04-30',


### PR DESCRIPTION
## Summary
- changes the homepage hero badge from `Policy-to-Proof for AI Agents` to `Economic Firewall for AI Agents`
- updates homepage/default metadata, OpenGraph, Twitter title, and JSON-LD page name to the Economic Firewall category
- keeps Policy-to-Proof as the mechanism/proof story in body copy where appropriate

## Verification
- `npx eslint app/components/HomeClient.tsx app/page.tsx app/layout.tsx` (0 errors; existing warnings only)
- `npm run build`
- local production server browser check confirmed hero badge and document title
- local HTML scan confirmed old exact strings are gone
