### PR TITLE
fix: replace Gemma4 copy with Hermes

### DIFF
--- a/examples/mcp-proxy/satgate-mcp-agent-governance.yaml
+++ b/examples/mcp-proxy/satgate-mcp-agent-governance.yaml
@@ -1,6 +1,6 @@
 # SatGate MCP Proxy — Agent Governance Verification Config
 #
-# Small, fast budget for local proof that Claude/Ollama/Gemma4-style MCP clients
+# Small, fast budget for local proof that Claude/Hermes/Ollama-style MCP clients
 # can call an allowed tool through SatGate and receive a request-path denial
 # when the governed budget is exhausted.
 
@@ -9,7 +9,7 @@ server:
   name: satgate-mcp-governance-proof
   version: 0.1.0
 
-# Local stdio proof uses no bearer token so Claude/Ollama/Gemma4-style clients can
+# Local stdio proof uses no bearer token so Claude/Hermes/Ollama-style clients can
 # be exercised without test secrets. Production configs should use scoped auth and
 # tenant-bound capabilities; this script verifies request-path allow/deny/budget behavior.
 auth:

--- a/examples/mcp-proxy/test-agent-governance.py
+++ b/examples/mcp-proxy/test-agent-governance.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
 """Verify agent-style MCP governance through SatGate.
 
-This exercises the same MCP client path used by Claude Desktop/Claude Code and
-MCP-capable Ollama/Gemma4 wrappers:
+This exercises the same MCP client path used by Claude Desktop/Claude Code,
+Hermes, and MCP-capable Ollama wrappers:
   initialize -> tools/list -> allowed tools/call -> budget-exhausted denial.
 
 It writes a redacted proof transcript suitable for buyer/demo evidence.
@@ -28,8 +28,8 @@ PROOF_OUT = Path(os.environ.get("SATGATE_MCP_PROOF_OUT", "/tmp/satgate-mcp-agent
 
 CLIENTS = [
     {"name": "claude-desktop", "model": "claude", "version": "mcp-client"},
-    {"name": "ollama-gemma4-wrapper", "model": "gemma4", "version": "mcp-wrapper"},
-    {"name": "gemma4-local-agent", "model": "gemma4", "version": "mcp-wrapper"},
+    {"name": "hermes-agent", "model": "hermes", "version": "mcp-client"},
+    {"name": "ollama-local-wrapper", "model": "ollama", "version": "mcp-wrapper"},
 ]
 
 

--- a/pkg/mcpserver/proxy_governance_test.go
+++ b/pkg/mcpserver/proxy_governance_test.go
@@ -92,7 +92,7 @@ for line in sys.stdin:
 		return result
 	}
 
-	send(map[string]interface{}{"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": map[string]interface{}{"protocolVersion": "2024-11-05", "capabilities": map[string]interface{}{}, "clientInfo": map[string]string{"name": "gemma4-local-agent", "version": "mcp-wrapper"}}})
+	send(map[string]interface{}{"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": map[string]interface{}{"protocolVersion": "2024-11-05", "capabilities": map[string]interface{}{}, "clientInfo": map[string]string{"name": "hermes-agent", "version": "mcp-client"}}})
 	if resp := recv(); resp["result"] == nil {
 		t.Fatalf("initialize failed: %v", resp)
 	}

--- a/satgate-landing/app/mcp-gateway/page.tsx
+++ b/satgate-landing/app/mcp-gateway/page.tsx
@@ -43,14 +43,14 @@ const controls = [
 const proofRows = [
   ['Claude Desktop / Claude Code', 'MCP stdio config points the client at satgate-mcp before the upstream server.', 'Verified MCP-compatible path: allowed web_search call, budget-exhausted code_execute denial, Evidence Pack-style decision transcript.'],
   ['Ollama agent wrapper', 'Local Ollama agents use an MCP-capable wrapper that speaks stdio or SSE to SatGate.', 'Same protocol path: list tools, call allowed tool, burn budget, receive denial before upstream execution.'],
-  ['Gemma4 agent wrapper', 'Gemma4 running through an MCP client receives no standing tool authority; SatGate grants scoped calls per policy.', 'The sample Evidence Pack shows the receipt fields that bind tenant, agent, tool, policy digest, budget ID, decision reason, and remaining credits.'],
+  ['Hermes agent runtime', 'Hermes agents running through an MCP client receive no standing tool authority; SatGate grants scoped calls per policy.', 'The sample Evidence Pack shows the receipt fields that bind tenant, agent, tool, policy digest, budget ID, decision reason, and remaining credits.'],
 ];
 
 const faqs = [
   ['What is an MCP gateway?', 'An MCP gateway sits between AI agents and Model Context Protocol servers. SatGate observes tool calls, applies access policy and MCP budget enforcement, records MCP Evidence Pack receipts, and proves decisions before tools execute.'],
   ['What is MCP budget enforcement?', 'MCP budget enforcement checks the cost of a requested tool call against a tenant, agent, session, delegation, or tool budget before the call reaches the upstream MCP server. If the budget is missing or exhausted, SatGate denies the call in the request path.'],
   ['What is an MCP Evidence Pack?', 'An MCP Evidence Pack is the proof artifact for governed tool activity: who called which MCP tool, through which client and server, under which policy and budget, with which allow or deny decision, and what receipt proves it.'],
-  ['Can SatGate govern Claude, Ollama, or Gemma4 MCP agents?', 'Yes. Claude Desktop, Claude Code, Ollama wrappers, Gemma4 wrappers, Cursor, OpenClaw, and custom MCP-capable clients can route tool calls through SatGate. The model gets no standing authority; SatGate grants or denies each tool call.'],
+  ['Can SatGate govern Claude, Hermes, or Ollama MCP agents?', 'Yes. Claude Desktop, Claude Code, Hermes, Ollama wrappers, Cursor, OpenClaw, and custom MCP-capable clients can route tool calls through SatGate. The agent gets no standing authority; SatGate grants or denies each tool call.'],
   ['How is an MCP gateway different from an API gateway?', 'A traditional API gateway mostly routes HTTP traffic and checks identity. An MCP gateway also understands agent tool calls, capability scope, per-tool cost, budget policy, tenant isolation, delegation lineage, and Evidence Pack outcomes.'],
   ['Can SatGate host MCP servers?', 'Yes. SatGate supports SaaS MCP for fast hosted deployment and Hybrid MCP for dedicated enterprise runtime control. The split is deliberate: SaaS MCP is Fly-hosted; Hybrid MCP is Hetzner-hosted.'],
 ];
@@ -70,7 +70,7 @@ export const metadata = {
     'MCP delegation depth',
     'Claude MCP budget enforcement',
     'Ollama MCP budget enforcement',
-    'Gemma4 MCP governance',
+    'Hermes MCP governance',
   ],
   openGraph: {
     title: 'MCP Gateway for Budget Enforcement and Evidence Packs',
@@ -81,7 +81,7 @@ export const metadata = {
   twitter: {
     card: 'summary_large_image',
     title: 'MCP Gateway for Budget Enforcement and Evidence Packs',
-    description: 'Govern Claude, Ollama, Gemma4, Cursor, and custom MCP agents with budget enforcement and Evidence Pack proof.',
+    description: 'Govern Claude, Hermes, Ollama, Cursor, and custom MCP agents with budget enforcement and Evidence Pack proof.',
   },
 };
 
@@ -148,7 +148,7 @@ export default function McpGatewayPage() {
             MCP Gateway for Budget Enforcement and Evidence Packs
           </h1>
           <p className="text-xl md:text-2xl text-gray-300 max-w-4xl leading-relaxed mb-8">
-            SatGate sits between Claude, Ollama, Gemma4, Cursor, OpenClaw, or custom MCP agents and the tools they want to call. Every MCP request is checked for authority, budget, tenant, tool scope, and delegation before execution — then recorded as proof.
+            SatGate sits between AI agents — Claude, Hermes, Ollama, Cursor, OpenClaw, or custom MCP clients — and the tools they want to call. Every MCP request is checked for authority, budget, tenant, tool scope, and delegation before execution — then recorded as proof.
           </p>
           <div className="flex flex-col sm:flex-row gap-4">
             <Link href="/govern" className="inline-flex items-center justify-center gap-2 rounded-lg bg-white text-black px-6 py-3 font-bold hover:bg-gray-200 transition">
@@ -230,9 +230,9 @@ export default function McpGatewayPage() {
       <section className="border-y border-gray-900 bg-gray-950/60">
         <div className="max-w-6xl mx-auto px-6 py-20">
           <p className="text-sm font-mono uppercase tracking-wide text-cyan-300 mb-2">Verified MCP-compatible path</p>
-          <h2 className="text-3xl font-bold text-white mb-4">Claude, Ollama, and Gemma4 get scoped MCP authority — not standing authority</h2>
+          <h2 className="text-3xl font-bold text-white mb-4">Claude, Hermes, and Ollama get scoped MCP authority — not standing authority</h2>
           <p className="text-gray-400 max-w-4xl mb-10 text-lg">
-            SatGate’s verification uses an MCP-compatible stdio client path: initialize, list tools, call an allowed tool, attempt expensive work until the budget blocks, and preserve the decision transcript as proof. Claude, Ollama, and Gemma4 route through MCP clients or wrappers; the governance boundary is the MCP call path, not the model vendor.
+            SatGate’s verification uses an MCP-compatible stdio client path: initialize, list tools, call an allowed tool, attempt expensive work until the budget blocks, and preserve the decision transcript as proof. Claude, Hermes, Ollama, and other agents route through MCP clients or wrappers; the governance boundary is the MCP call path, not the model vendor.
           </p>
           <div className="grid lg:grid-cols-3 gap-5">
             {proofRows.map(([agent, path, proof]) => (

--- a/satgate-landing/public/policy-templates/mcp-governance/mcp-evidence-pack.sample.v1.json
+++ b/satgate-landing/public/policy-templates/mcp-governance/mcp-evidence-pack.sample.v1.json
@@ -11,8 +11,8 @@
   },
   "authority_chain": {
     "principal_id": "user_platform_admin",
-    "agent_id": "agent_gemma4_research",
-    "mcp_client_id": "gemma4_mcp_wrapper",
+    "agent_id": "agent_hermes_research",
+    "mcp_client_id": "hermes_mcp_client",
     "credential_id_hash": "hmac-sha256:demo-credential",
     "delegation_chain_hash": "sha256:demo-delegation-chain",
     "current_delegation_depth": 1,

--- a/satgate-landing/public/policy-templates/mcp-governance/spend-caps.v1.yaml
+++ b/satgate-landing/public/policy-templates/mcp-governance/spend-caps.v1.yaml
@@ -14,7 +14,7 @@ scope:
   applies_to:
     principals: ['*']
     agents: ['agent_*']
-    mcp_clients: [claude_desktop, claude_code, cursor, openclaw, ollama_wrapper, gemma4_wrapper]
+    mcp_clients: [claude_desktop, claude_code, hermes_mcp_client, cursor, openclaw, ollama_wrapper]
     mcp_servers: ['mcp_prod_*']
     tools: ['*']
 

--- a/satgate-landing/seo/reports/page-audit.json
+++ b/satgate-landing/seo/reports/page-audit.json
@@ -342,7 +342,7 @@
         "MCP connection is not MCP governance",
         "Observe, Control, Prove MCP tool use",
         "MCP policy templates teams can start from",
-        "Claude, Ollama, and Gemma4 get scoped MCP authority \u2014 not standing authority",
+        "Claude, Hermes, and Ollama get scoped MCP authority \u2014 not standing authority",
         "SaaS MCP is Fly-hosted",
         "Hybrid MCP is Hetzner-hosted",
         "MCP gateway questions",


### PR DESCRIPTION
## Summary
- Replace Gemma4-specific MCP gateway copy with Hermes/durable agent wording
- Update MCP Evidence Pack sample and spend caps policy template identifiers
- Refresh MCP governance examples/tests away from version-specific Gemma naming

## Verification
- `npm run build` in `satgate-landing`
- `npx eslint app/mcp-gateway/page.tsx` in `satgate-landing`
- `go test ./pkg/mcpserver`
- Source scan: `Gemma4|Gemma 4|Gemma|gemma4|gemma` returns 0 matches
- Local browser verified `/mcp-gateway` has 0 Gemma matches and 0 JS console errors

Note: full `npm run lint` still fails on pre-existing unrelated sitewide lint errors; targeted page lint passes.