### PR TITLE
feat: add SatGate build developer surface

### DIFF
--- a/satgate-landing/app/build/page.tsx
+++ b/satgate-landing/app/build/page.tsx
@@ -1,0 +1,370 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import {
+  ArrowRight,
+  BadgeCheck,
+  Braces,
+  CheckCircle2,
+  Code2,
+  FileCheck2,
+  KeyRound,
+  Layers3,
+  ReceiptText,
+  Route,
+  ShieldCheck,
+  TerminalSquare,
+} from "lucide-react";
+
+export const metadata: Metadata = {
+  title: "Build Agents That Can Spend Safely | SatGate",
+  description:
+    "Issue scoped capabilities, route paid calls, and verify receipts with SatGate's developer surface for agent authority, payment context, and Evidence Pack proof.",
+  keywords: [
+    "SatGate build",
+    "AI agent capabilities",
+    "agent receipts",
+    "agent payment rails",
+    "MCP capability tokens",
+    "AI agent SDK",
+    "Economic Firewall for AI agents",
+  ],
+  alternates: {
+    canonical: "https://satgate.io/build",
+  },
+  openGraph: {
+    title: "Build agents that can spend safely",
+    description:
+      "Capabilities in. Receipts out. Rails abstracted. Build agents with scoped authority, paid-call routing, and verifiable receipts.",
+    url: "https://satgate.io/build",
+    type: "website",
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "Build agents that can spend safely",
+    description:
+      "Issue capabilities, route paid calls, and verify receipts with SatGate's rail-neutral developer primitive.",
+  },
+};
+
+const quickstart = `from satgate import SatGate
+
+satgate = SatGate(api_key=os.environ["SATGATE_API_KEY"])
+
+capability = satgate.issue(
+    task="research market prices",
+    agent="research-agent",
+    allow=["mcp:web.search", "api:prices.read"],
+    budget_usd=25,
+    expires_in="1h",
+)
+
+receipt = satgate.pay(
+    upstream="https://api.example.com/search",
+    capability=capability,
+    max_usd=4.20,
+)
+
+verified = satgate.verify(receipt)
+print(verified.decision, verified.evidence_pack_id)`;
+
+const nodeExample = `import { SatGate } from "@satgate/sdk";
+
+const satgate = new SatGate({ apiKey: process.env.SATGATE_API_KEY });
+
+const capability = await satgate.issue({
+  task: "compare supplier prices",
+  agent: "procurement-agent",
+  allow: ["mcp:browser.search", "api:supplier.quote"],
+  budgetUsd: 25,
+  expiresIn: "1h",
+});
+
+const receipt = await satgate.pay({
+  upstream: "https://api.example.com/search",
+  capability,
+  maxUsd: 4.20,
+});
+
+const verified = await satgate.verify(receipt);
+console.log(verified.decision, verified.evidencePackId);`;
+
+const curlExample = `curl https://api.satgate.io/v1/capabilities \
+  -H "Authorization: Bearer $SATGATE_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "agent": "research-agent",
+    "task": "research market prices",
+    "allow": ["mcp:web.search", "api:prices.read"],
+    "budget_usd": 25,
+    "expires_in": "1h"
+  }'
+
+curl https://api.satgate.io/v1/pay \
+  -H "Authorization: Bearer $SATGATE_API_KEY" \
+  -d '{"capability":"cap_...","upstream":"https://api.example.com/search","max_usd":4.20}'`;
+
+const primitives = [
+  {
+    icon: KeyRound,
+    title: "Issue scoped capabilities",
+    label: "satgate.issue",
+    body: "Give an agent bounded authority for one task, budget, route set, expiry window, and delegation depth.",
+  },
+  {
+    icon: Route,
+    title: "Route paid calls",
+    label: "satgate.pay",
+    body: "Let the agent reach MCP tools, APIs, or paid rails through SatGate while policy is enforced before value moves.",
+  },
+  {
+    icon: ReceiptText,
+    title: "Verify receipts",
+    label: "satgate.verify",
+    body: "Return a signed decision receipt that can feed an Evidence Pack for audits, incidents, billing review, or revocation proof.",
+  },
+];
+
+const integrations = [
+  ["MCP server", "Forward tool calls with capability headers and receive decision receipts per tool invocation."],
+  ["OpenAI tools", "Attach a scoped capability to tool calls so agent actions inherit budget, route, and proof policy."],
+  ["Anthropic tools", "Keep Claude tool use bounded by the same authority and receipt model."],
+  ["LangChain", "Wrap tool execution with issue/pay/verify so chains do not hold standing authority."],
+  ["CrewAI", "Give crews attenuated capabilities instead of sharing broad provider keys."],
+  ["Raw HTTP", "Use headers and JSON receipts when you do not want an SDK dependency."],
+];
+
+const receiptPreview = {
+  receipt_id: "rcpt_7J4xQf9",
+  decision: "allowed",
+  decision_reason: "capability_scope_and_budget_ok",
+  agent_id: "research-agent",
+  capability_id: "cap_2Xn83k",
+  policy_version: "policy_2026_05_build_v1",
+  route_or_tool: "api.example.com/search",
+  amount_usd: "0.42",
+  rail: "enterprise_ledger",
+  evidence_pack_id: "ep_2026_05_12_001",
+  signature: "ed25519:demo_redacted",
+};
+
+const jsonLd = {
+  "@context": "https://schema.org",
+  "@graph": [
+    {
+      "@type": "WebPage",
+      name: "Build agents that can spend safely",
+      url: "https://satgate.io/build",
+      description: metadata.description,
+      datePublished: "2026-05-12",
+      dateModified: "2026-05-12",
+      isPartOf: { "@type": "WebSite", name: "SatGate", url: "https://satgate.io" },
+      about: [
+        { "@type": "Thing", name: "Economic Firewall for AI agents" },
+        { "@type": "Thing", name: "agent capabilities" },
+        { "@type": "Thing", name: "verifiable receipts" },
+        { "@type": "Thing", name: "rail-neutral payment governance" },
+      ],
+    },
+    {
+      "@type": "SoftwareSourceCode",
+      name: "SatGate issue/pay/verify quickstart",
+      codeSampleType: "full",
+      programmingLanguage: "Python",
+      text: quickstart,
+    },
+  ],
+};
+
+export default function BuildPage() {
+  return (
+    <main className="min-h-screen bg-black text-gray-100 font-sans">
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }} />
+
+      <section className="relative overflow-hidden border-b border-gray-900">
+        <div className="absolute inset-0 bg-[radial-gradient(circle_at_20%_0%,rgba(56,189,248,0.18),transparent_34%),radial-gradient(circle_at_85%_10%,rgba(168,85,247,0.18),transparent_32%),radial-gradient(circle_at_55%_80%,rgba(16,185,129,0.10),transparent_34%)]" />
+        <div className="relative mx-auto grid max-w-6xl gap-12 px-6 py-24 lg:grid-cols-[0.95fr_1.05fr] lg:items-center">
+          <div>
+            <div className="mb-6 inline-flex items-center gap-2 rounded-full border border-cyan-400/30 bg-cyan-400/10 px-4 py-2 text-sm font-semibold uppercase tracking-[0.22em] text-cyan-200">
+              <Code2 size={16} /> Developer primitive
+            </div>
+            <h1 className="max-w-4xl text-5xl font-black tracking-tight text-white sm:text-6xl lg:text-7xl">
+              Build agents that can spend safely
+            </h1>
+            <p className="mt-6 max-w-3xl text-xl leading-8 text-gray-300">
+              Issue scoped capabilities, route paid calls, and return verifiable receipts your principal can trust.
+            </p>
+            <p className="mt-5 max-w-3xl text-lg leading-8 text-gray-400">
+              SatGate is the <strong className="font-semibold text-white">Economic Firewall for AI agents</strong>. This is the developer surface: <strong className="font-semibold text-white">Capabilities in. Receipts out. Rails abstracted.</strong>
+            </p>
+            <div className="mt-8 flex flex-col gap-3 sm:flex-row sm:flex-wrap">
+              <a
+                href="https://cloud.satgate.io/docs"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center justify-center gap-2 rounded-lg bg-white px-6 py-3 font-bold text-black transition hover:bg-gray-200"
+              >
+                Read the docs <ArrowRight size={18} />
+              </a>
+              <a
+                href="https://github.com/SatGate-io/satgate"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center justify-center gap-2 rounded-lg border border-gray-700 px-6 py-3 font-bold text-white transition hover:border-cyan-400"
+              >
+                View SDK examples <TerminalSquare size={18} />
+              </a>
+              <Link href="/policy-to-proof" className="inline-flex items-center justify-center gap-2 rounded-lg border border-purple-700/60 bg-purple-950/20 px-6 py-3 font-bold text-purple-200 transition hover:border-purple-400">
+                See proof model <FileCheck2 size={18} />
+              </Link>
+            </div>
+          </div>
+
+          <div className="rounded-2xl border border-cyan-900/50 bg-gray-950/90 shadow-2xl shadow-cyan-950/30">
+            <div className="flex items-center gap-2 border-b border-gray-800 px-4 py-3">
+              <div className="h-3 w-3 rounded-full bg-red-500" />
+              <div className="h-3 w-3 rounded-full bg-yellow-500" />
+              <div className="h-3 w-3 rounded-full bg-green-500" />
+              <span className="ml-2 text-xs font-mono text-gray-500">issue_pay_verify.py</span>
+            </div>
+            <pre className="overflow-x-auto p-5 text-sm leading-6 text-gray-300"><code>{quickstart}</code></pre>
+          </div>
+        </div>
+      </section>
+
+      <section className="mx-auto max-w-6xl px-6 py-20">
+        <div className="mb-10 max-w-3xl">
+          <p className="mb-3 text-sm font-mono uppercase tracking-[0.22em] text-emerald-300">Three calls</p>
+          <h2 className="text-3xl font-bold text-white sm:text-4xl">Issue. Pay. Verify.</h2>
+          <p className="mt-4 text-lg leading-8 text-gray-400">
+            Developers should not wire payment rails, revocation logic, audit trails, and tool policy by hand. SatGate makes agent authority feel like a simple primitive while preserving enterprise proof.
+          </p>
+        </div>
+        <div className="grid gap-5 md:grid-cols-3">
+          {primitives.map(({ icon: Icon, title, label, body }) => (
+            <div key={title} className="rounded-2xl border border-gray-800 bg-gray-950 p-6">
+              <Icon className="mb-5 text-cyan-300" size={30} />
+              <div className="mb-3 inline-flex rounded-full border border-gray-800 bg-black px-3 py-1 font-mono text-xs text-gray-400">{label}</div>
+              <h3 className="mb-3 text-2xl font-bold text-white">{title}</h3>
+              <p className="leading-relaxed text-gray-400">{body}</p>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section className="border-y border-gray-900 bg-gray-950/60">
+        <div className="mx-auto grid max-w-6xl gap-10 px-6 py-20 lg:grid-cols-[0.9fr_1.1fr] lg:items-start">
+          <div>
+            <p className="mb-3 text-sm font-mono uppercase tracking-[0.22em] text-purple-300">Rail-neutral by design</p>
+            <h2 className="text-3xl font-bold text-white sm:text-4xl">Authority and evidence sit above the rail.</h2>
+            <div className="mt-5 space-y-5 text-lg leading-8 text-gray-400">
+              <p>
+                Payment rails change. The authority and evidence layer is the durable abstraction. SatGate can govern MCP tools, REST APIs, API-key billing, x402, L402, AgentCore Payments, Pay.sh, and enterprise ledgers without forcing your agent code to care which rail settled underneath.
+              </p>
+              <p>
+                Humans and platforms deploy the policies. Agents consume capabilities. Upstreams receive verifiable proof that the action was authorized, bounded, and recorded.
+              </p>
+            </div>
+          </div>
+          <div className="rounded-2xl border border-gray-800 bg-black p-6">
+            <div className="mb-4 flex items-center gap-2 text-emerald-200">
+              <BadgeCheck size={20} /> Receipt preview
+            </div>
+            <pre className="overflow-x-auto rounded-xl bg-gray-950 p-5 text-sm leading-6 text-gray-300"><code>{JSON.stringify(receiptPreview, null, 2)}</code></pre>
+          </div>
+        </div>
+      </section>
+
+      <section className="mx-auto max-w-6xl px-6 py-20">
+        <div className="mb-10 flex flex-col justify-between gap-6 lg:flex-row lg:items-end">
+          <div>
+            <p className="mb-3 text-sm font-mono uppercase tracking-[0.22em] text-cyan-300">Copy-paste paths</p>
+            <h2 className="text-3xl font-bold text-white sm:text-4xl">Use the same primitive from SDKs, MCP, or raw HTTP.</h2>
+          </div>
+          <a href="https://cloud.satgate.io/docs" target="_blank" rel="noopener noreferrer" className="inline-flex items-center gap-2 text-cyan-300 transition hover:text-cyan-200">
+            Open developer docs <ArrowRight size={16} />
+          </a>
+        </div>
+
+        <div className="grid gap-6 lg:grid-cols-2">
+          <div className="rounded-2xl border border-gray-800 bg-gray-950">
+            <div className="border-b border-gray-800 px-5 py-3 font-mono text-xs uppercase tracking-[0.18em] text-gray-500">Node preview</div>
+            <pre className="overflow-x-auto p-5 text-sm leading-6 text-gray-300"><code>{nodeExample}</code></pre>
+          </div>
+          <div className="rounded-2xl border border-gray-800 bg-gray-950">
+            <div className="border-b border-gray-800 px-5 py-3 font-mono text-xs uppercase tracking-[0.18em] text-gray-500">HTTP preview</div>
+            <pre className="overflow-x-auto p-5 text-sm leading-6 text-gray-300"><code>{curlExample}</code></pre>
+          </div>
+        </div>
+      </section>
+
+      <section className="border-y border-gray-900 bg-gray-950/60">
+        <div className="mx-auto max-w-6xl px-6 py-20">
+          <div className="mb-10 max-w-3xl">
+            <p className="mb-3 text-sm font-mono uppercase tracking-[0.22em] text-emerald-300">Agent integrations</p>
+            <h2 className="text-3xl font-bold text-white sm:text-4xl">Give every runtime bounded authority.</h2>
+            <p className="mt-4 text-lg leading-8 text-gray-400">
+              The runtime changes. The contract stays the same: capability before action, receipt after decision.
+            </p>
+          </div>
+          <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+            {integrations.map(([title, body]) => (
+              <div key={title} className="rounded-xl border border-gray-800 bg-black p-5">
+                <div className="mb-3 flex items-center gap-2 text-white">
+                  <CheckCircle2 className="text-emerald-300" size={18} />
+                  <h3 className="font-bold">{title}</h3>
+                </div>
+                <p className="text-sm leading-6 text-gray-400">{body}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section className="mx-auto max-w-6xl px-6 py-20">
+        <div className="rounded-3xl border border-cyan-900/50 bg-gradient-to-br from-cyan-950/30 via-gray-950 to-purple-950/30 p-8 md:p-10">
+          <div className="grid gap-8 lg:grid-cols-[0.9fr_1.1fr] lg:items-center">
+            <div>
+              <div className="mb-5 inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-4 py-2 text-sm text-gray-300">
+                <ShieldCheck size={16} /> Not a new marketplace. Not a separate brand.
+              </div>
+              <h2 className="text-3xl font-bold text-white sm:text-4xl">Start with the primitive. Let network effects come from receipts.</h2>
+              <p className="mt-5 text-lg leading-8 text-gray-300">
+                A trusted agent is one that can prove what it was allowed to do, what it actually did, and which policy governed the outcome. Build that path first; reputation and upstream acceptance can grow from the receipt trail later.
+              </p>
+            </div>
+            <div className="grid gap-3 text-sm text-gray-300">
+              {[
+                "Scoped authority before every action",
+                "Receipts for allowed, denied, delegated, revoked, and paid decisions",
+                "Evidence Pack IDs your principal can audit",
+                "Rail adapters below the authority layer",
+                "Developer docs instead of payment-company ceremony",
+              ].map((item) => (
+                <div key={item} className="flex items-start gap-3 rounded-xl border border-gray-800 bg-black/60 p-4">
+                  <Layers3 className="mt-0.5 text-cyan-300" size={18} />
+                  <span>{item}</span>
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="border-t border-gray-900 bg-black px-6 py-20 text-center">
+        <Braces className="mx-auto mb-6 text-cyan-300" size={36} />
+        <h2 className="mx-auto max-w-3xl text-3xl font-bold text-white sm:text-4xl">Build the agent path, then prove every decision.</h2>
+        <p className="mx-auto mt-5 max-w-2xl text-lg leading-8 text-gray-400">
+          Start with issue/pay/verify. Keep the buyer story on Economic Firewall and Policy-to-Proof. Let agents consume the primitives.
+        </p>
+        <div className="mt-8 flex flex-col items-center justify-center gap-3 sm:flex-row">
+          <a href="https://cloud.satgate.io/docs" target="_blank" rel="noopener noreferrer" className="inline-flex items-center justify-center gap-2 rounded-lg bg-white px-6 py-3 font-bold text-black transition hover:bg-gray-200">
+            Open docs <ArrowRight size={18} />
+          </a>
+          <Link href="/capability-auth" className="inline-flex items-center justify-center gap-2 rounded-lg border border-gray-700 px-6 py-3 font-bold text-white transition hover:border-cyan-400">
+            Capability auth model <ArrowRight size={18} />
+          </Link>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/satgate-landing/app/components/HomeClient.tsx
+++ b/satgate-landing/app/components/HomeClient.tsx
@@ -31,6 +31,7 @@ const LandingPage = () => {
             <Link href="/protect" className="hover:text-white transition">Live Demo</Link>
             <Link href="/govern" className="hover:text-white transition">Enterprise</Link>
             <Link href="/mcp-gateway" className="hover:text-white transition">MCP Gateway</Link>
+            <Link href="/build" className="hover:text-white transition">Build</Link>
             <Link href="/capability-auth" className="hover:text-white transition">Capability Auth</Link>
             <Link href="/agent-control-plane" className="hover:text-white transition">Control Plane</Link>
             <Link href="/pricing" className="hover:text-white transition">Pricing</Link>
@@ -80,6 +81,13 @@ const LandingPage = () => {
               className="block text-gray-400 hover:text-white hover:bg-gray-800/50 transition py-3 px-4 rounded-lg"
             >
               MCP Gateway
+            </Link>
+            <Link
+              href="/build"
+              onClick={() => setMobileMenuOpen(false)}
+              className="block text-gray-400 hover:text-white hover:bg-gray-800/50 transition py-3 px-4 rounded-lg"
+            >
+              Build
             </Link>
             <Link
               href="/capability-auth"
@@ -179,6 +187,9 @@ const LandingPage = () => {
               <a href="https://cloud.satgate.io/cloud/login" target="_blank" rel="noopener noreferrer" className="bg-gradient-to-r from-purple-600 to-cyan-600 hover:from-purple-500 hover:to-cyan-500 text-white px-8 py-3 rounded-lg font-bold transition flex items-center gap-2 shadow-lg shadow-purple-500/20">
                 Start Free <ArrowRight size={16} />
               </a>
+              <Link href="/build" className="border border-cyan-700/50 bg-cyan-900/15 px-8 py-3 rounded-lg font-bold hover:bg-cyan-900/30 transition flex items-center gap-2 text-cyan-300">
+                Build with SatGate <ArrowRight size={16} />
+              </Link>
               <Link href="/sandbox" className="border border-purple-700/50 bg-purple-900/20 px-8 py-3 rounded-lg font-bold hover:bg-purple-900/40 transition flex items-center gap-2 text-purple-300">
                 <Play size={16} /> See a Demo
               </Link>
@@ -724,6 +735,7 @@ const LandingPage = () => {
             <div>
               <h4 className="mb-4 font-bold text-white">Developers</h4>
               <ul className="space-y-2 text-sm text-gray-500">
+                <li><Link href="/build" className="hover:text-white transition">Build</Link></li>
                 <li><a href="https://cloud.satgate.io/docs" target="_blank" rel="noopener noreferrer" className="hover:text-white transition">Documentation</a></li>
                 <li><a href="https://github.com/SatGate-io/satgate" target="_blank" rel="noopener noreferrer" className="hover:text-white transition">GitHub</a></li>
                 <li><Link href="/mcp" className="hover:text-white transition">MCP Governance Hub</Link></li>

--- a/satgate-landing/app/sitemap.ts
+++ b/satgate-landing/app/sitemap.ts
@@ -30,6 +30,7 @@ const staticRoutes: SitemapEntry[] = [
   { path: '/mcp-budget-enforcement', lastModified: '2026-05-03', changeFrequency: 'weekly', priority: 0.9 },
   { path: '/mcp-cost-control', lastModified: '2026-05-03', changeFrequency: 'monthly', priority: 0.85 },
   { path: '/agent-api-governance', lastModified: '2026-05-05', changeFrequency: 'weekly', priority: 0.9 },
+  { path: '/build', lastModified: '2026-05-12', changeFrequency: 'weekly', priority: 0.95 },
   { path: '/capability-auth', lastModified: '2026-05-08', changeFrequency: 'weekly', priority: 0.95 },
   { path: '/agent-control-plane', lastModified: '2026-05-05', changeFrequency: 'weekly', priority: 0.9 },
   { path: '/evidence-pack-demo', lastModified: '2026-05-10', changeFrequency: 'weekly', priority: 0.95 },

--- a/satgate-landing/package.json
+++ b/satgate-landing/package.json
@@ -10,7 +10,8 @@
     "seo:gsc": "python3 scripts/gsc_telemetry.py",
     "seo:links": "python3 scripts/internal_link_audit.py",
     "seo:machine": "python3 scripts/seo_machine.py",
-    "seo:check": "python3 scripts/seo_machine.py --check"
+    "seo:check": "python3 scripts/seo_machine.py --check",
+    "test:build-page": "python3 scripts/check_build_page.py"
   },
   "dependencies": {
     "lucide-react": "^0.555.0",

--- a/satgate-landing/scripts/check_build_page.py
+++ b/satgate-landing/scripts/check_build_page.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+from pathlib import Path
+import re
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+PAGE = ROOT / "app" / "build" / "page.tsx"
+SITEMAP = ROOT / "app" / "sitemap.ts"
+HOME = ROOT / "app" / "components" / "HomeClient.tsx"
+
+required_page_strings = [
+    "Build agents that can spend safely",
+    "Capabilities in. Receipts out. Rails abstracted.",
+    "Issue scoped capabilities",
+    "Route paid calls",
+    "Verify receipts",
+    "satgate.issue",
+    "satgate.pay",
+    "satgate.verify",
+    "Economic Firewall for AI agents",
+    "authority and evidence layer",
+    "https://cloud.satgate.io/docs",
+]
+
+forbidden_page_patterns = [
+    r"robot[- ]customer",
+    r"SatGate Charge",
+    r"L402 Charge",
+    r"agent payment marketplace",
+    r"wallet[- ]first",
+    r"wallet-native",
+    r"when APIs become products",
+    r"autonomous spend platform",
+]
+
+errors: list[str] = []
+if not PAGE.exists():
+    errors.append("missing app/build/page.tsx")
+else:
+    text = PAGE.read_text()
+    for needle in required_page_strings:
+        if needle not in text:
+            errors.append(f"missing required /build string: {needle}")
+    for pattern in forbidden_page_patterns:
+        if re.search(pattern, text, flags=re.IGNORECASE):
+            errors.append(f"forbidden /build framing matched: {pattern}")
+
+sitemap = SITEMAP.read_text() if SITEMAP.exists() else ""
+if "path: '/build'" not in sitemap:
+    errors.append("/build missing from app/sitemap.ts")
+
+home = HOME.read_text() if HOME.exists() else ""
+if 'href="/build"' not in home:
+    errors.append("homepage navigation/CTA does not link to /build")
+
+if errors:
+    print("/build regression check failed:")
+    for err in errors:
+        print(f"- {err}")
+    sys.exit(1)
+
+print("/build regression check passed")


### PR DESCRIPTION
## Summary
- Adds `/build` as the developer surface for “Capabilities in. Receipts out. Rails abstracted.”
- Leads with “Build agents that can spend safely” and explains `issue`, `pay`, and `verify` primitives.
- Includes copy-paste Python, Node, and HTTP examples, receipt preview, rail-neutral integration copy, sitemap entry, homepage links, and a regression guard against stale framing.

## Verification
- `npm run test:build-page`
- `npx eslint app/build/page.tsx app/components/HomeClient.tsx app/sitemap.ts` (warnings only from pre-existing HomeClient unused/img patterns)
- `npm run build`
- Local rendered check: `curl http://127.0.0.1:3067/build` returned 200 and contained required copy/primitives
- Local rendered stale framing scan passed for `/build`: no wallet-first, marketplace-first, robot-customer, SatGate Charge, or L402-first framing

## Note
- Repo still has pre-existing legacy `/robot-customer-payments` route references outside this `/build` change; not touched here to avoid an SEO-side-effect PR.
