### PR TITLE
fix: harden build SDK beta access path

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 <p align="center">
   <strong>The Economic Firewall for AI Agents</strong><br/>
-  <em>Hard budget enforcement · Per-tool cost attribution · Rail-neutral paid-rail governance</em>
+  <em>Capabilities in · Receipts out · Rails abstracted</em>
 </p>
 
 <p align="center">
@@ -18,12 +18,58 @@
 
 <p align="center">
   <a href="#the-problem">Why</a> •
+  <a href="#build-agents-with-satgate">Build</a> •
   <a href="#features">Features</a> •
   <a href="#quick-start">Quick Start</a> •
   <a href="#documentation">Docs</a> •
   <a href="https://satgate.io">Website</a> •
   <a href="https://satgate.io/blog/why-routing-isnt-governance">Blog</a>
 </p>
+
+---
+
+## Build Agents with SatGate
+
+SatGate's developer primitive is three calls: `issue()`, `pay()`, and `verify()`.
+
+```python
+import os
+from satgate import SatGate
+
+satgate = SatGate(api_key=os.getenv("SATGATE_API_KEY"))
+
+capability = satgate.issue(
+    task="research market prices",
+    agent="research-agent",
+    allow=["mcp:web.search", "api:prices.read"],
+    budget_usd=25,
+    expires_in="1h",
+)
+
+receipt = satgate.pay(
+    upstream="https://api.example.com/search",
+    capability=capability,
+    max_usd=4.20,
+)
+
+verified = satgate.verify(receipt)
+print(verified.decision, verified.evidence_pack_id)
+```
+
+Install today:
+
+```bash
+pip install satgate
+npm install @satgate/sdk
+```
+
+The public packages install today; the `issue/pay/verify` API namespace is in private beta. Calls without private-beta access raise a structured error instead of returning fake receipts:
+
+```text
+SatGateAuthError: This API namespace requires private beta access. Visit cloud.satgate.io/docs to request access.
+```
+
+Works with: MCP · OpenAI tools · Anthropic tools · LangChain · CrewAI · Raw HTTP
 
 ---
 
@@ -117,7 +163,7 @@ curl -X POST http://localhost:8080/api/capability/mint \
   -d '{"scope": "api:read", "duration": "1h"}'
 
 # Use the token:
-curl -H "Authorization: Bearer <your-token>" \
+curl -H "Authorization: Bearer YOUR_CAPABILITY_TOKEN" \
   http://localhost:8080/api/capability/ping
 
 # 3. Paid — get a payment challenge (L402 today; x402/other rails as governed context)

--- a/satgate-landing/app/build/page.tsx
+++ b/satgate-landing/app/build/page.tsx
@@ -6,7 +6,6 @@ import {
   Braces,
   CheckCircle2,
   Code2,
-  FileCheck2,
   KeyRound,
   Layers3,
   ReceiptText,
@@ -46,9 +45,10 @@ export const metadata: Metadata = {
   },
 };
 
-const quickstart = `from satgate import SatGate
+const quickstart = `import os
+from satgate import SatGate
 
-satgate = SatGate(api_key=os.environ["SATGATE_API_KEY"])
+satgate = SatGate(api_key=os.getenv("SATGATE_API_KEY"))
 
 capability = satgate.issue(
     task="research market prices",
@@ -88,8 +88,7 @@ const receipt = await satgate.pay({
 const verified = await satgate.verify(receipt);
 console.log(verified.decision, verified.evidencePackId);`;
 
-const installCommands = String.raw`# Public packages are available today.
-# The issue/pay/verify namespace is private beta API access.
+const installCommands = String.raw`# Install today (public packages):
 pip install satgate
 npm install @satgate/sdk`;
 
@@ -135,6 +134,8 @@ const integrationLinks = [
   { title: "Runtime integrations", href: "/integrations", body: "See current agent-client surfaces and where OpenAI, Anthropic, LangChain, and CrewAI adapters fit." },
   { title: "Developer docs", href: "https://cloud.satgate.io/docs", body: "Use the docs for setup details while issue/pay/verify API access is in private beta." },
 ];
+
+const runtimeChips = ["MCP", "OpenAI tools", "Anthropic tools", "LangChain", "CrewAI", "Raw HTTP"];
 
 const allowedReceipt = {
   receipt_id: "rcpt_7J4xQf9",
@@ -230,9 +231,6 @@ export default function BuildPage() {
               >
                 View SDK examples <TerminalSquare size={18} />
               </a>
-              <Link href="/policy-to-proof" className="inline-flex items-center justify-center gap-2 rounded-lg border border-purple-700/60 bg-purple-950/20 px-6 py-3 font-bold text-purple-200 transition hover:border-purple-400">
-                See proof model <FileCheck2 size={18} />
-              </Link>
             </div>
           </div>
 
@@ -248,10 +246,7 @@ export default function BuildPage() {
               <p className="mb-2 text-xs font-mono uppercase tracking-[0.18em] text-cyan-300">SDK access</p>
               <pre className="max-w-full overflow-x-auto rounded-xl bg-black p-4 text-sm leading-6 text-gray-300"><code>{installCommands}</code></pre>
               <p className="mt-3 text-sm leading-6 text-gray-500">
-                Public packages install today; the issue/pay/verify API namespace is in private beta. <a href="https://cloud.satgate.io/docs" target="_blank" rel="noopener noreferrer" className="text-cyan-300 hover:text-cyan-200">Request API access in the docs</a>.
-              </p>
-              <p className="mt-2 text-xs leading-5 text-gray-600">
-                Duration fields accept human-readable values like <code className="rounded bg-gray-900 px-1 text-gray-400">1h</code>; ISO 8601 duration support belongs in the integration docs for clients that require structured durations.
+                The issue/pay/verify API namespace is in private beta. <a href="https://cloud.satgate.io/docs" target="_blank" rel="noopener noreferrer" className="text-cyan-300 hover:text-cyan-200">Request access →</a>
               </p>
             </div>
           </div>
@@ -320,9 +315,6 @@ export default function BuildPage() {
             <p className="mb-3 text-sm font-mono uppercase tracking-[0.22em] text-cyan-300">Copy-paste paths</p>
             <h2 className="text-3xl font-bold text-white sm:text-4xl">Use the same primitive from SDKs, MCP, or raw HTTP.</h2>
           </div>
-          <a href="https://cloud.satgate.io/docs" target="_blank" rel="noopener noreferrer" className="inline-flex items-center gap-2 text-cyan-300 transition hover:text-cyan-200">
-            Open developer docs <ArrowRight size={16} />
-          </a>
         </div>
 
         <div className="grid min-w-0 gap-6 lg:grid-cols-2">
@@ -345,6 +337,14 @@ export default function BuildPage() {
             <p className="mt-4 text-lg leading-8 text-gray-400">
               The runtime changes. The contract stays the same: capability before action, receipt after decision.
             </p>
+            <div className="mt-6 flex flex-wrap gap-2 text-sm text-gray-300">
+              <span className="mr-1 py-1 text-gray-500">Works with:</span>
+              {runtimeChips.map((chip) => (
+                <Link key={chip} href="/integrations" className="rounded-full border border-gray-800 bg-black px-3 py-1 transition hover:border-cyan-400 hover:text-white">
+                  {chip}
+                </Link>
+              ))}
+            </div>
           </div>
           <div className="grid gap-4 md:grid-cols-3">
             {integrationLinks.map((item) => {

--- a/satgate-landing/scripts/check_build_page.py
+++ b/satgate-landing/scripts/check_build_page.py
@@ -17,16 +17,25 @@ required_page_strings = [
     "satgate.issue",
     "satgate.pay",
     "satgate.verify",
+    "import os",
+    "os.getenv(\"SATGATE_API_KEY\")",
     "Economic Firewall for AI agents",
     "authority and evidence layer",
     "https://cloud.satgate.io/docs",
     "pip install satgate",
     "npm install @satgate/sdk",
     "issue/pay/verify API namespace is in private beta",
+    "# Install today (public packages):",
+    "Request access →",
+    "Works with:",
+    "OpenAI tools",
+    "Anthropic tools",
+    "Raw HTTP",
     "decision: \"denied\"",
     "budget_exhausted",
     "Node example",
     "HTTP example",
+    "YOUR_API_KEY",
 ]
 
 forbidden_page_patterns = [
@@ -38,6 +47,10 @@ forbidden_page_patterns = [
     r"wallet-native",
     r"when APIs become products",
     r"autonomous spend platform",
+    r"See proof model",
+    r"ISO 8601 duration support belongs",
+    r"Open developer docs",
+    r"Bearer \*\*\*",
 ]
 
 errors: list[str] = []

--- a/sdk/nodejs/package-lock.json
+++ b/sdk/nodejs/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "@satgate/client",
-  "version": "1.0.0",
+  "name": "@satgate/sdk",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@satgate/client",
-      "version": "1.0.0",
+      "name": "@satgate/sdk",
+      "version": "0.2.1",
       "license": "MIT",
       "dependencies": {
         "node-fetch": "^3.3.2"

--- a/sdk/nodejs/package.json
+++ b/sdk/nodejs/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@satgate/client",
-  "version": "1.0.0",
-  "description": "Node.js SDK for SatGate Gateway (OSS)",
+  "name": "@satgate/sdk",
+  "version": "0.2.1",
+  "description": "Node.js SDK for SatGate Gateway and SatGate Cloud private-beta APIs",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [
@@ -26,7 +26,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/satgate-io/satgate-gateway.git"
+    "url": "https://github.com/SatGate-io/satgate.git"
   },
   "homepage": "https://satgate.io",
   "dependencies": {

--- a/sdk/nodejs/src/errors.ts
+++ b/sdk/nodejs/src/errors.ts
@@ -19,6 +19,21 @@ export class AuthenticationError extends SatGateError {
   }
 }
 
+export class SatGateAuthError extends AuthenticationError {
+  public readonly docsUrl: string;
+
+  constructor(
+    message: string = 'This API namespace requires private beta access. Visit cloud.satgate.io/docs to request access.',
+    statusCode: number = 401,
+    docsUrl: string = 'https://cloud.satgate.io/docs'
+  ) {
+    super(message);
+    this.name = 'SatGateAuthError';
+    this.statusCode = statusCode;
+    this.docsUrl = docsUrl;
+  }
+}
+
 export class NotFoundError extends SatGateError {
   constructor(message: string = 'Resource not found') {
     super(message, 404);

--- a/sdk/nodejs/src/index.ts
+++ b/sdk/nodejs/src/index.ts
@@ -35,6 +35,15 @@
  * ```
  */
 
+// SatGate Cloud private-beta facade
+export {
+  SatGate,
+  SatGateOptions,
+  CapabilityRequest,
+  PayRequest,
+  SatGateReceipt,
+} from './private-beta';
+
 // Admin client
 export { SatGateClient, SatGateClientOptions } from './client';
 
@@ -79,6 +88,7 @@ export {
 export {
   SatGateError,
   AuthenticationError,
+  SatGateAuthError,
   NotFoundError,
   ValidationError,
   PaymentRequiredError,

--- a/sdk/nodejs/src/private-beta.ts
+++ b/sdk/nodejs/src/private-beta.ts
@@ -1,0 +1,131 @@
+import fetch, { Response } from 'node-fetch';
+import { SatGateAuthError, SatGateError } from './errors';
+
+const BETA_ACCESS_MESSAGE =
+  'This API namespace requires private beta access. Visit cloud.satgate.io/docs to request access.';
+
+export interface SatGateOptions {
+  apiKey?: string;
+  baseUrl?: string;
+  tenant?: string;
+  timeout?: number;
+}
+
+export type JsonValue = string | number | boolean | null | JsonObject | JsonValue[];
+export type JsonObject = { [key: string]: JsonValue };
+
+export interface CapabilityRequest {
+  [key: string]: unknown;
+  task: string;
+  agent: string;
+  allow: string[];
+  budgetUsd?: number;
+  budget_usd?: number;
+  expiresIn?: string;
+  expires_in?: string;
+}
+
+export interface PayRequest {
+  [key: string]: unknown;
+  upstream: string;
+  capability: unknown;
+  maxUsd?: number;
+  max_usd?: number;
+}
+
+export type SatGateReceipt = JsonObject & {
+  decision?: string;
+  evidencePackId?: string;
+  evidence_pack_id?: string;
+};
+
+export class SatGate {
+  private readonly apiKey?: string;
+  private readonly baseUrl: string;
+  private readonly tenant?: string;
+  private readonly timeout: number;
+
+  constructor(options: SatGateOptions = {}) {
+    this.apiKey = options.apiKey;
+    this.baseUrl = (options.baseUrl ?? 'https://api.satgate.io').replace(/\/$/, '');
+    this.tenant = options.tenant;
+    this.timeout = options.timeout ?? 30000;
+  }
+
+  async issue(request: CapabilityRequest): Promise<SatGateReceipt> {
+    return this.post<SatGateReceipt>('/v1/capabilities', this.toApiPayload(request) as JsonObject);
+  }
+
+  async pay(request: PayRequest): Promise<SatGateReceipt> {
+    return this.post<SatGateReceipt>('/v1/pay', this.toApiPayload(request) as JsonObject);
+  }
+
+  async verify(receipt: unknown): Promise<SatGateReceipt> {
+    return this.post<SatGateReceipt>('/v1/verify', { receipt: this.toApiPayload(receipt) });
+  }
+
+  private async post<T>(path: string, body: JsonObject): Promise<T> {
+    if (!this.apiKey) {
+      throw new SatGateAuthError(BETA_ACCESS_MESSAGE, 401);
+    }
+
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), this.timeout);
+    const headers: Record<string, string> = {
+      'Authorization': `Bearer ${this.apiKey}`,
+      'Content-Type': 'application/json',
+    };
+    if (this.tenant) {
+      headers['X-SatGate-Tenant'] = this.tenant;
+    }
+
+    let response: Response;
+    try {
+      response = await fetch(`${this.baseUrl}${path}`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify(body),
+        signal: controller.signal,
+      });
+    } catch (err: unknown) {
+      clearTimeout(timeoutId);
+      throw new SatGateError(`Request failed: ${err}`);
+    }
+    clearTimeout(timeoutId);
+
+    if ([401, 403, 404, 503].includes(response.status)) {
+      throw new SatGateAuthError(BETA_ACCESS_MESSAGE, response.status);
+    }
+
+    if (!response.ok) {
+      const errBody = await response.json().catch(() => ({})) as Record<string, unknown>;
+      throw new SatGateError(
+        (errBody.message as string) || (errBody.error as string) || `Request failed with status ${response.status}`,
+        response.status
+      );
+    }
+
+    if (response.status === 204) {
+      return {} as T;
+    }
+    return response.json() as Promise<T>;
+  }
+
+  private toApiPayload(value: unknown): JsonValue {
+    if (Array.isArray(value)) {
+      return value.map((item) => this.toApiPayload(item));
+    }
+    if (value && typeof value === 'object') {
+      const output: JsonObject = {};
+      for (const [key, val] of Object.entries(value as Record<string, unknown>)) {
+        output[this.toSnakeCase(key)] = this.toApiPayload(val);
+      }
+      return output;
+    }
+    return value as JsonValue;
+  }
+
+  private toSnakeCase(key: string): string {
+    return key.replace(/[A-Z]/g, (letter) => `_${letter.toLowerCase()}`);
+  }
+}

--- a/sdk/python/satgate/__init__.py
+++ b/sdk/python/satgate/__init__.py
@@ -38,6 +38,7 @@ A Python SDK for interacting with the SatGate OSS Gateway.
     )
 """
 
+from .private_beta import SatGate
 from .client import SatGateClient
 from .agent_client import (
     SatGateAgentClient,
@@ -76,6 +77,7 @@ from .delegation import (
 from .exceptions import (
     SatGateError,
     AuthenticationError,
+    SatGateAuthError,
     NotFoundError,
     PaymentRequiredError,
     PaymentFailedError,
@@ -84,8 +86,11 @@ from .exceptions import (
     DelegationError,
 )
 
-__version__ = "2.0.0"
+__version__ = "0.3.2"
 __all__ = [
+    # SatGate Cloud private-beta facade
+    "SatGate",
+
     # Admin client
     "SatGateClient",
     
@@ -124,6 +129,7 @@ __all__ = [
     # Exceptions
     "SatGateError",
     "AuthenticationError",
+    "SatGateAuthError",
     "NotFoundError",
     "PaymentRequiredError",
     "PaymentFailedError",

--- a/sdk/python/satgate/exceptions.py
+++ b/sdk/python/satgate/exceptions.py
@@ -13,6 +13,15 @@ class AuthenticationError(SatGateError):
     pass
 
 
+class SatGateAuthError(AuthenticationError):
+    """Raised when SatGate Cloud private-beta API access is missing."""
+
+    def __init__(self, message: str, status_code: int = 401, docs_url: str = "https://cloud.satgate.io/docs"):
+        super().__init__(message)
+        self.status_code = status_code
+        self.docs_url = docs_url
+
+
 class NotFoundError(SatGateError):
     """Raised when a resource is not found"""
     pass

--- a/sdk/python/satgate/private_beta.py
+++ b/sdk/python/satgate/private_beta.py
@@ -1,0 +1,113 @@
+"""Private-beta issue/pay/verify facade for SatGate Cloud."""
+
+from types import SimpleNamespace
+from typing import Any, Dict, Optional
+
+import requests
+
+from .exceptions import SatGateAuthError, SatGateError
+
+BETA_ACCESS_MESSAGE = (
+    "This API namespace requires private beta access. "
+    "Visit cloud.satgate.io/docs to request access."
+)
+
+
+class AttrDict(SimpleNamespace):
+    """Small response wrapper so examples can use receipt.foo attributes."""
+
+    @classmethod
+    def from_value(cls, value: Any) -> Any:
+        if isinstance(value, dict):
+            return cls(**{key: cls.from_value(val) for key, val in value.items()})
+        if isinstance(value, list):
+            return [cls.from_value(item) for item in value]
+        return value
+
+    def to_dict(self) -> Dict[str, Any]:
+        result: Dict[str, Any] = {}
+        for key, value in self.__dict__.items():
+            if isinstance(value, AttrDict):
+                result[key] = value.to_dict()
+            elif isinstance(value, list):
+                result[key] = [item.to_dict() if isinstance(item, AttrDict) else item for item in value]
+            else:
+                result[key] = value
+        return result
+
+
+class SatGate:
+    """SatGate Cloud issue/pay/verify client.
+
+    The public package installs today. The issue/pay/verify API namespace is
+    private beta; unauthenticated or non-beta credentials raise SatGateAuthError
+    with a docs CTA instead of a stack trace or mocked receipt.
+    """
+
+    def __init__(
+        self,
+        api_key: Optional[str] = None,
+        base_url: str = "https://api.satgate.io",
+        tenant: Optional[str] = None,
+        timeout: int = 30,
+    ):
+        self.api_key = api_key
+        self.base_url = base_url.rstrip("/")
+        self.tenant = tenant
+        self.timeout = timeout
+        self.session = requests.Session()
+        self.session.headers.update({"Content-Type": "application/json"})
+        if api_key:
+            self.session.headers.update({"Authorization": f"Bearer {api_key}"})
+        if tenant:
+            self.session.headers.update({"X-SatGate-Tenant": tenant})
+
+    def issue(self, **payload: Any) -> AttrDict:
+        """Issue a scoped capability for an agent task."""
+        return self._post("/v1/capabilities", payload)
+
+    def pay(self, **payload: Any) -> AttrDict:
+        """Route a value-bearing call under a scoped capability."""
+        return self._post("/v1/pay", self._serialize(payload))
+
+    def verify(self, receipt: Any) -> AttrDict:
+        """Verify a SatGate receipt and return proof metadata."""
+        payload = receipt.to_dict() if hasattr(receipt, "to_dict") else receipt
+        return self._post("/v1/verify", {"receipt": self._serialize(payload)})
+
+    def _post(self, path: str, payload: Dict[str, Any]) -> AttrDict:
+        if not self.api_key:
+            raise SatGateAuthError(BETA_ACCESS_MESSAGE, status_code=401)
+
+        try:
+            response = self.session.post(
+                f"{self.base_url}{path}",
+                json=payload,
+                timeout=self.timeout,
+            )
+        except requests.RequestException as exc:
+            raise SatGateError(f"Request failed: {exc}") from exc
+
+        if response.status_code in {401, 403, 404, 503}:
+            raise SatGateAuthError(BETA_ACCESS_MESSAGE, status_code=response.status_code)
+
+        if response.status_code >= 400:
+            try:
+                body = response.json()
+                message = body.get("message") or body.get("error") or response.text
+            except Exception:
+                message = response.text
+            raise SatGateError(f"API error {response.status_code}: {message}")
+
+        if not response.content:
+            return AttrDict()
+        return AttrDict.from_value(response.json())
+
+    def _serialize(self, value: Any) -> Any:
+        if isinstance(value, AttrDict):
+            return value.to_dict()
+        if isinstance(value, dict):
+            return {key: self._serialize(val) for key, val in value.items()}
+        if isinstance(value, list):
+            return [self._serialize(item) for item in value]
+        return value

--- a/sdk/python/setup.py
+++ b/sdk/python/setup.py
@@ -5,13 +5,13 @@ with open("README.md", "r", encoding="utf-8") as f:
 
 setup(
     name="satgate",
-    version="1.0.0",
+    version="0.3.2",
     author="SatGate Team",
     author_email="team@satgate.io",
-    description="Python SDK for SatGate Gateway (OSS)",
+    description="Python SDK for SatGate Gateway and SatGate Cloud private-beta APIs",
     long_description=long_description,
     long_description_content_type="text/markdown",
-    url="https://github.com/satgate-io/satgate-gateway",
+    url="https://github.com/SatGate-io/satgate",
     packages=find_packages(),
     classifiers=[
         "Development Status :: 4 - Beta",


### PR DESCRIPTION
## Summary
- add Python and Node `SatGate` issue/pay/verify private-beta facades
- return a structured `SatGateAuthError` with the beta-access docs CTA instead of mocked receipts or stack traces
- tighten `/build` install/CTA/runtime-chip copy and regression guards
- update README so the GitHub landing page mirrors the hero sample and looks alive

## Test Plan
- `python3 -m compileall sdk/python/satgate`
- Python no-key + invalid-key `SatGate.issue(...)` raises `SatGateAuthError`
- `cd sdk/nodejs && npm run build && npm test -- --runInBand`
- Node no-key + invalid-key `SatGate.issue(...)` raises `SatGateAuthError`
- `cd satgate-landing && npm run test:build-page`
- `cd satgate-landing && npx eslint app/build/page.tsx`
- `cd satgate-landing && npm run build`
- rendered `.next/server/app/build.html` scan confirms runtime chips, no ISO note, no duplicate docs CTA, no stale proof-model hero CTA

## Notes
This does not publish PyPI/npm packages by itself. It makes the repo/release payload ready for `satgate==0.3.2` and `@satgate/sdk@0.2.1`; package publishing still requires registry credentials.
