### PR TITLE
docs: align SDK package readmes with build primitive

### DIFF
--- a/sdk/nodejs/README.md
+++ b/sdk/nodejs/README.md
@@ -1,209 +1,74 @@
-# satgate-sdk
+# @satgate/sdk
 
-Official Node.js SDK for the [SatGate](https://github.com/SatGate-io/satgate) OSS Gateway.
+Official Node.js SDK for SatGate: the Economic Firewall for AI agents.
 
-## Installation
+## Install
 
 ```bash
-npm install satgate-sdk
+npm install @satgate/sdk
 ```
 
-## Quick Start
+## Build agents with issue/pay/verify
 
-### Admin Client
+The public package installs today. The `issue/pay/verify` API namespace is in private beta, so calls without beta access raise a structured error instead of returning mocked receipts.
 
-The `SatGateClient` provides direct access to gateway admin operations.
+```ts
+import { SatGate } from "@satgate/sdk";
 
-```typescript
-import { SatGateClient } from 'satgate-sdk';
+const satgate = new SatGate({ apiKey: process.env.SATGATE_API_KEY });
 
-const client = new SatGateClient({
-  url: 'http://localhost:8080',
-  token: 'your-admin-token',
+const capability = await satgate.issue({
+  task: "compare supplier prices",
+  agent: "procurement-agent",
+  allow: ["mcp:browser.search", "api:supplier.quote"],
+  budgetUsd: 25,
+  expiresIn: "1h",
 });
 
-// Check gateway health
-const healthy = await client.health();
-console.log('Gateway healthy:', healthy);
-
-// Mint a new capability token
-const token = await client.tokens.mint({
-  scope: 'api:read',
-  duration: '1h',
+const receipt = await satgate.pay({
+  upstream: "https://api.example.com/search",
+  capability,
+  maxUsd: 4.20,
 });
-console.log('Token:', token.token);
-console.log('Signature:', token.signature);
 
-// Validate a token
-const result = await client.tokens.validate(token.token);
-console.log('Valid:', result.valid);
-
-// Delegate a token with additional restrictions
-const child = await client.tokens.delegate({
-  parentToken: token.token,
-  caveats: ['scope = api:read'],
-});
-console.log('Child signature:', child.signature);
-
-// Ping with a capability token
-const ping = await client.ping(token.token);
-console.log('Ping:', ping);
-
-// Ban a compromised token
-await client.governance.ban(token.signature, 'Compromised credentials');
-
-// Get governance graph (token lineage, stats)
-const graph = await client.governance.getGraph();
-console.log('Active tokens:', graph.stats.active);
-
-// Reset governance data
-await client.governance.reset();
+const verified = await satgate.verify(receipt);
+console.log(verified.decision, verified.evidencePackId);
 ```
 
-### Agent Client
+Without private-beta access:
 
-The `SatGateAgentClient` is designed for AI agents — it automatically
-mints tokens, caches them, and handles L402 payment challenges.
-
-```typescript
-import { SatGateAgentClient } from 'satgate-sdk';
-
-// With admin token (auto-mints capability tokens)
-const client = new SatGateAgentClient({
-  gatewayUrl: 'http://localhost:8080',
-  adminToken: 'your-admin-token',
-  scope: 'api:read',
-  duration: '1h',
-});
-
-// Or with a pre-existing capability token
-const client2 = new SatGateAgentClient({
-  gatewayUrl: 'http://localhost:8080',
-  token: 'your-capability-token',
-});
-
-// Or via environment variables
-// SATGATE_ADMIN_TOKEN=your-admin-token
-// SATGATE_TOKEN=your-capability-token (alternative)
-const client3 = new SatGateAgentClient({
-  gatewayUrl: 'http://localhost:8080',
-});
-
-// Make requests — token handling is automatic
-const response = await client.get('/api/data');
-console.log(response.data);
-
-// Ping to verify the token
-const pingResult = await client.ping();
-console.log(pingResult);
-
-// Delegate a child token for a worker
-const childToken = await client.delegate({
-  caveats: ['scope = api:read'],
-});
+```text
+SatGateAuthError: This API namespace requires private beta access. Visit cloud.satgate.io/docs to request access.
 ```
 
-## Token Delegation
+Works with: MCP · OpenAI tools · Anthropic tools · LangChain · CrewAI · Raw HTTP
 
-### Fluent Delegation Builder
+## OSS Gateway client
 
-```typescript
-import { SatGateClient, delegate, Caveats, DelegationPatterns } from 'satgate-sdk';
+The package also includes the lower-level OSS gateway clients:
 
-const client = new SatGateClient({
-  url: 'http://localhost:8080',
-  token: 'admin-token',
+```ts
+import { SatGateClient, SatGateAgentClient } from "@satgate/sdk";
+
+const admin = new SatGateClient({
+  url: "http://localhost:8080",
+  token: "your-admin-token",
 });
-const root = await client.tokens.mint({ scope: 'api:*', duration: '24h' });
 
-// Fluent builder pattern
-const teamToken = await delegate(root.token)
-  .withScope('api:read')
-  .withExpiry(24 * 3600)
-  .forTeam('engineering')
-  .delegate(client);
+const token = await admin.tokens.mint({ scope: "api:read", duration: "1h" });
+const valid = await admin.tokens.validate(token.token);
 
-// Pre-built patterns
-const readOnlyToken = await DelegationPatterns.readOnly(root.token).delegate(client);
-const tempToken = await DelegationPatterns.temporary(root.token, 2).delegate(client);
-
-// Agent swarm token
-const swarmToken = await DelegationPatterns.agentSwarm(
-  root.token,
-  'ai-agents',
-  { budget: 500, requestsPerMinute: 5000 }
-).delegate(client);
-```
-
-### Caveat Builders
-
-```typescript
-import { Caveats } from 'satgate-sdk';
-
-const caveats = [
-  Caveats.scope('api:read'),
-  Caveats.expires(3600),
-  Caveats.routes(['/api/*', '/health']),
-  Caveats.rateLimit(100, 60),
-  Caveats.methods(['GET', 'POST']),
-  Caveats.team('engineering'),
-];
-
-const token = await client.tokens.delegate({
-  parentToken: root.token,
-  caveats,
+const agent = new SatGateAgentClient({
+  gatewayUrl: "http://localhost:8080",
+  token: token.token,
 });
+
+const response = await agent.get("/api/data");
+console.log(valid.valid, response.status);
 ```
 
-## OSS Gateway Endpoints
+## Docs
 
-This SDK targets the SatGate OSS gateway endpoints:
-
-| Method | Path | Auth | Description |
-|--------|------|------|-------------|
-| `POST` | `/api/capability/mint` | X-Admin-Token | Mint a new capability token |
-| `POST` | `/api/capability/validate` | — | Validate a token |
-| `POST` | `/api/capability/delegate` | — | Delegate a token with caveats |
-| `GET` | `/api/capability/ping` | Bearer token | Verify a token is valid |
-| `GET` | `/api/capability/admin` | Bearer token | Admin-scope verification |
-| `POST` | `/api/governance/ban` | X-Admin-Token | Ban a token |
-| `GET` | `/api/governance/graph` | — | Get token lineage graph |
-| `POST` | `/api/governance/reset` | X-Admin-Token | Reset governance data |
-| `GET` | `/health` | — | Health check |
-
-## Error Handling
-
-```typescript
-import {
-  SatGateClient,
-  AuthenticationError,
-  NotFoundError,
-  SatGateError,
-} from 'satgate-sdk';
-
-try {
-  const client = new SatGateClient({
-    url: 'http://localhost:8080',
-    token: 'invalid-token',
-  });
-  await client.tokens.mint();
-} catch (error) {
-  if (error instanceof AuthenticationError) {
-    console.error('Invalid admin token!');
-  } else if (error instanceof SatGateError) {
-    console.error('API error:', error.message);
-  }
-}
-```
-
-## TypeScript Support
-
-This package includes full TypeScript type definitions:
-
-```typescript
-import type { Token, TokenInfo, GraphData, DelegateRequest } from 'satgate-sdk';
-```
-
-## License
-
-MIT License
+- Developer docs: https://cloud.satgate.io/docs
+- Build page: https://satgate.io/build
+- Repository: https://github.com/SatGate-io/satgate

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -1,196 +1,75 @@
-# SatGate Gateway Python SDK
+# satgate
 
-Official Python client for the [SatGate](https://github.com/SatGate-io/satgate) OSS Gateway.
+Official Python SDK for SatGate: the Economic Firewall for AI agents.
 
-## Installation
+## Install
 
 ```bash
 pip install satgate
 ```
 
-## Quick Start
+## Build agents with issue/pay/verify
 
-### Admin Client
-
-The `SatGateClient` provides direct access to gateway admin operations.
+The public package installs today. The `issue/pay/verify` API namespace is in private beta, so calls without beta access raise a structured error instead of returning mocked receipts.
 
 ```python
-from satgate import SatGateClient
+import os
+from satgate import SatGate
 
-client = SatGateClient(
+satgate = SatGate(api_key=os.getenv("SATGATE_API_KEY"))
+
+capability = satgate.issue(
+    task="research market prices",
+    agent="research-agent",
+    allow=["mcp:web.search", "api:prices.read"],
+    budget_usd=25,
+    expires_in="1h",
+)
+
+receipt = satgate.pay(
+    upstream="https://api.example.com/search",
+    capability=capability,
+    max_usd=4.20,
+)
+
+verified = satgate.verify(receipt)
+print(verified.decision, verified.evidence_pack_id)
+```
+
+Without private-beta access:
+
+```text
+SatGateAuthError: This API namespace requires private beta access. Visit cloud.satgate.io/docs to request access.
+```
+
+Works with: MCP · OpenAI tools · Anthropic tools · LangChain · CrewAI · Raw HTTP
+
+## OSS Gateway client
+
+The package also includes lower-level OSS gateway clients:
+
+```python
+from satgate import SatGateClient, SatGateAgentClient
+
+admin = SatGateClient(
     base_url="http://localhost:8080",
-    admin_token="your-admin-token"
-)
-
-# Check gateway health
-if client.health():
-    print("Gateway is healthy!")
-
-# Mint a new capability token
-token = client.tokens.mint(scope="api:read", duration="1h")
-print(f"Token: {token.token}")
-print(f"Signature: {token.signature}")
-
-# Validate a token
-result = client.tokens.validate(token.token)
-print(f"Valid: {result['valid']}")
-
-# Delegate a token with additional restrictions
-child = client.tokens.delegate(
-    parent_token=token.token,
-    caveats=["scope = api:read"]
-)
-print(f"Child token: {child.signature}")
-
-# Ban a compromised token
-client.governance.ban(token.signature, reason="Compromised")
-
-# Get governance graph (token lineage, stats)
-graph = client.governance.get_graph()
-print(f"Active tokens: {graph['stats']['active']}")
-
-# Reset governance data
-client.governance.reset()
-```
-
-### Agent Client
-
-The `SatGateAgentClient` is designed for AI agents — it automatically
-mints tokens, caches them, and handles L402 payment challenges.
-
-```python
-from satgate import SatGateAgentClient
-
-# With admin token (auto-mints capability tokens)
-client = SatGateAgentClient(
-    gateway_url="http://localhost:8080",
     admin_token="your-admin-token",
-    scope="api:read",
-    duration="1h"
 )
 
-# Or with a pre-existing capability token
-client = SatGateAgentClient(
+token = admin.tokens.mint(scope="api:read", duration="1h")
+valid = admin.tokens.validate(token.token)
+
+agent = SatGateAgentClient(
     gateway_url="http://localhost:8080",
-    token="your-capability-token"
+    token=token.token,
 )
 
-# Or via environment variables
-# export SATGATE_ADMIN_TOKEN=your-admin-token
-# export SATGATE_TOKEN=your-capability-token (alternative)
-client = SatGateAgentClient(gateway_url="http://localhost:8080")
-
-# Make requests — token handling is automatic
-response = client.get("/api/data")
-print(response.json())
-
-# Ping the gateway to verify your token
-result = client.ping()
-print(result)  # {"status": "ok", "message": "Token validated successfully", ...}
-
-# Delegate a child token for a worker agent
-child_token = client.delegate(caveats=["scope = api:read"])
+response = agent.get("/api/data")
+print(valid["valid"], response.status_code)
 ```
 
-## Token Delegation
+## Docs
 
-### Fluent Delegation Builder
-
-```python
-from satgate import SatGateClient, delegate, Caveats, DelegationPatterns
-
-client = SatGateClient(base_url="http://localhost:8080", admin_token="admin-token")
-root = client.tokens.mint(scope="api:*", duration="24h")
-
-# Fluent builder pattern
-team_token = (delegate(root.token)
-    .with_scope('api:read')
-    .with_expiry(seconds=24 * 3600)
-    .for_team('engineering')
-    .delegate(client))
-
-# Pre-built patterns
-read_only = DelegationPatterns.read_only(root.token).delegate(client)
-temp_token = DelegationPatterns.temporary(root.token, hours=2).delegate(client)
-
-# Agent swarm token
-swarm_token = DelegationPatterns.agent_swarm(
-    root.token,
-    swarm_id='ai-agents',
-    budget=500,
-    requests_per_minute=5000,
-).delegate(client)
-```
-
-### Caveat Builders
-
-```python
-from satgate import Caveats
-
-caveats = [
-    Caveats.scope('api:read'),
-    Caveats.expires(seconds=3600),
-    Caveats.routes(['/api/*', '/health']),
-    Caveats.rate_limit(100, period=60),
-    Caveats.methods(['GET', 'POST']),
-    Caveats.team('engineering'),
-]
-
-child = client.tokens.delegate(parent_token=root.token, caveats=caveats)
-```
-
-## OSS Gateway Endpoints
-
-This SDK targets the SatGate OSS gateway endpoints:
-
-| Method | Path | Auth | Description |
-|--------|------|------|-------------|
-| `POST` | `/api/capability/mint` | X-Admin-Token | Mint a new capability token |
-| `POST` | `/api/capability/validate` | — | Validate a token |
-| `POST` | `/api/capability/delegate` | — | Delegate a token with caveats |
-| `GET` | `/api/capability/ping` | Bearer token | Verify a token is valid |
-| `GET` | `/api/capability/admin` | Bearer token | Admin-scope verification |
-| `POST` | `/api/governance/ban` | X-Admin-Token | Ban a token |
-| `GET` | `/api/governance/graph` | — | Get token lineage graph |
-| `POST` | `/api/governance/reset` | X-Admin-Token | Reset governance data |
-| `GET` | `/health` | — | Health check |
-
-## Error Handling
-
-```python
-from satgate import (
-    SatGateClient,
-    AuthenticationError,
-    NotFoundError,
-    SatGateError,
-    PaymentRequiredError,
-)
-
-try:
-    client = SatGateClient(base_url="http://localhost:8080", admin_token="invalid")
-    client.tokens.mint()
-except AuthenticationError:
-    print("Invalid admin token!")
-except SatGateError as e:
-    print(f"API error: {e}")
-```
-
-## LangChain Integration
-
-See the [LangChain Integration Guide](../../docs/guides/langchain-integration.md) for detailed examples.
-
-```python
-from satgate.langchain import SatGateTool
-
-tool = SatGateTool(
-    name="data_query",
-    description="Query the protected data API",
-    gateway_url="http://localhost:8080",
-    admin_token="your-admin-token",
-    endpoint="/api/data/query",
-)
-```
-
-## License
-
-MIT License
+- Developer docs: https://cloud.satgate.io/docs
+- Build page: https://satgate.io/build
+- Repository: https://github.com/SatGate-io/satgate


### PR DESCRIPTION
## Summary
- align Python and Node package READMEs with the new issue/pay/verify developer primitive
- document the exact private-beta `SatGateAuthError`
- keep lower-level OSS gateway client examples, but stop leading package consumers into legacy/wallet-first framing

## Test Plan
- `cd sdk/nodejs && npm run build && npm test -- --runInBand`
- `cd sdk/python && python3 setup.py --version`
- `git diff --check`
