### PR TITLE
docs: add runnable SDK primitive examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,11 @@ The public packages install today; the `issue/pay/verify` API namespace is in pr
 SatGateAuthError: This API namespace requires private beta access. Visit cloud.satgate.io/docs to request access.
 ```
 
+Runnable examples:
+
+- `examples/python/issue_pay_verify.py`
+- `examples/node/issue-pay-verify.mjs`
+
 Works with: MCP · OpenAI tools · Anthropic tools · LangChain · CrewAI · Raw HTTP
 
 ---

--- a/examples/node/issue-pay-verify.mjs
+++ b/examples/node/issue-pay-verify.mjs
@@ -1,0 +1,41 @@
+#!/usr/bin/env node
+/**
+ * Minimal SatGate issue/pay/verify private-beta example.
+ *
+ * Run from sdk/nodejs after building local SDK source:
+ *
+ *   npm install
+ *   npm run build
+ *   SATGATE_API_KEY=sg_live_... node ../../examples/node/issue-pay-verify.mjs
+ *
+ * Without a beta key this exits cleanly with SatGateAuthError and the docs CTA.
+ */
+
+import { SatGate, SatGateAuthError } from '../../sdk/nodejs/dist/index.js';
+
+const satgate = new SatGate({ apiKey: process.env.SATGATE_API_KEY });
+
+try {
+  const capability = await satgate.issue({
+    task: 'research market prices',
+    agent: 'research-agent',
+    allow: ['https://api.example.com/search'],
+    budgetUsd: 2.00,
+    expiresIn: '10m',
+  });
+
+  const receipt = await satgate.pay({
+    upstream: 'https://api.example.com/search',
+    capability,
+    maxUsd: 0.25,
+  });
+
+  const verified = await satgate.verify(receipt);
+  console.log(verified.decision, verified.evidencePackId ?? verified.evidence_pack_id);
+} catch (err) {
+  if (err instanceof SatGateAuthError || err?.name === 'SatGateAuthError') {
+    console.error(`SatGateAuthError: ${err.message}`);
+    process.exit(1);
+  }
+  throw err;
+}

--- a/examples/python/issue_pay_verify.py
+++ b/examples/python/issue_pay_verify.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+"""Minimal SatGate issue/pay/verify private-beta example.
+
+Run from the repo root against local SDK source:
+
+    PYTHONPATH=sdk/python SATGATE_API_KEY=sg_live_... python3 examples/python/issue_pay_verify.py
+
+Without a beta key this exits cleanly with SatGateAuthError and the docs CTA.
+"""
+
+import os
+
+from satgate import SatGate, SatGateAuthError
+
+
+def main() -> int:
+    satgate = SatGate(api_key=os.getenv("SATGATE_API_KEY"))
+
+    try:
+        capability = satgate.issue(
+            task="research market prices",
+            agent="research-agent",
+            allow=["https://api.example.com/search"],
+            budget_usd=2.00,
+            expires_in="10m",
+        )
+
+        receipt = satgate.pay(
+            upstream="https://api.example.com/search",
+            capability=capability,
+            max_usd=0.25,
+        )
+
+        verified = satgate.verify(receipt)
+        print(verified.decision, verified.evidence_pack_id)
+        return 0
+    except SatGateAuthError as exc:
+        print(f"SatGateAuthError: {exc}")
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- Add runnable Python and Node issue/pay/verify examples
- Link examples from the root README so the SDK CTA path has concrete repo artifacts
- Examples fail honestly without beta access via the structured SatGateAuthError docs CTA

## Test Plan
- `PYTHONPATH=sdk/python python3 examples/python/issue_pay_verify.py` → clean SatGateAuthError without beta key
- `cd sdk/nodejs && npm install --silent && npm run build --silent && node ../../examples/node/issue-pay-verify.mjs` → clean SatGateAuthError without beta key
- `python3 -m py_compile examples/python/issue_pay_verify.py`
- `cd sdk/nodejs && npm test -- --runInBand --silent`

## Note
This closes the GitHub repo credibility gap. Public npm/PyPI package readiness still requires publishing the already-built release artifacts with registry credentials.
