### PR TITLE
chore: align Node SDK version to 0.3.2

### DIFF
--- a/sdk/nodejs/package-lock.json
+++ b/sdk/nodejs/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@satgate/sdk",
-  "version": "0.2.1",
+  "version": "0.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@satgate/sdk",
-      "version": "0.2.1",
+      "version": "0.3.2",
       "license": "MIT",
       "dependencies": {
         "node-fetch": "^3.3.2"

--- a/sdk/nodejs/package.json
+++ b/sdk/nodejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@satgate/sdk",
-  "version": "0.2.1",
+  "version": "0.3.2",
   "description": "Node.js SDK for SatGate Gateway and SatGate Cloud private-beta APIs",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -46,6 +46,3 @@
     "node": ">=18.0.0"
   }
 }
-
-
-


### PR DESCRIPTION
## Summary
- Align `@satgate/sdk` package version with PyPI `satgate==0.3.2`
- Updates package-lock metadata only; no runtime code changes

## Test Plan
- `cd sdk/nodejs && npm ci`
- `npm run build`
- `npm test`
- `npm pack --json` confirmed tarball version `0.3.2`
