### PR TITLE
docs: align SDK examples around issue pay verify

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,7 +286,7 @@ routes:
 | Language | Package | Docs |
 |----------|---------|------|
 | Python | `pip install satgate` | [README](sdk/python/README.md) |
-| JavaScript | `npm install satgate-sdk` | [README](sdk/nodejs/README.md) |
+| JavaScript | `npm install @satgate/sdk` | [README](sdk/nodejs/README.md) |
 
 ## MCP Proxy (NEW)
 

--- a/docs/QUICK_START.md
+++ b/docs/QUICK_START.md
@@ -2,6 +2,10 @@
 
 Get SatGate running in under 2 minutes.
 
+## Cloud developer primitive
+
+For Cloud/private-beta application code, prefer the three-call primitive: `issue` a scoped capability, `pay` upstream with a max budget, then `verify` the receipt. The local gateway quickstart below preserves the OSS token endpoints for compatibility.
+
 ## 1. Download
 
 ```bash
@@ -83,9 +87,9 @@ SatGate starts on port **8080**.
 # Public route — no auth needed
 curl http://localhost:8080/health
 
-# Mint a capability token
+# Mint a capability token through the OSS gateway compatibility endpoint
 TOKEN=$(curl -s -X POST http://localhost:8080/api/capability/mint \
-  -H "Authorization: Bearer my-admin-token" \
+  -H "X-Admin-Token: $ADMIN_TOKEN" \
   -H "Content-Type: application/json" \
   -d '{}' | jq -r '.token')
 

--- a/docs/api/overview.md
+++ b/docs/api/overview.md
@@ -1,5 +1,8 @@
 # API Overview
 
+Lower-level gateway API reference. Application SDK examples should use `issue`, `pay`, and `verify` where available: issue a scoped capability, pay upstream with a max budget, then verify the receipt.
+
+
 SatGate exposes two API groups on port **8080** (same port as the proxy):
 
 ## Capability APIs (`/api/capability/`)

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -2,6 +2,10 @@
 
 Get SatGate running in under 2 minutes.
 
+## Cloud developer primitive
+
+For Cloud/private-beta application code, prefer the three-call primitive: `issue` a scoped capability, `pay` upstream with a max budget, then `verify` the receipt. The local gateway quickstart below preserves the OSS token endpoints for compatibility.
+
 ## 1. Download
 
 ```bash
@@ -83,9 +87,9 @@ SatGate starts on port **8080**.
 # Public route — no auth needed
 curl http://localhost:8080/health
 
-# Mint a capability token
+# Mint a capability token through the OSS gateway compatibility endpoint
 TOKEN=$(curl -s -X POST http://localhost:8080/api/capability/mint \
-  -H "Authorization: Bearer my-admin-token" \
+  -H "X-Admin-Token: $ADMIN_TOKEN" \
   -H "Content-Type: application/json" \
   -d '{}' | jq -r '.token')
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -71,7 +71,7 @@ SatGate Gateway is an enterprise API gateway that provides:
 |----------|---------|---------------|
 | Go | `github.com/satgate-io/satgate-go` | [Go SDK](sdks/go.md) |
 | Python | `satgate` | [Python SDK](sdks/python.md) |
-| Node.js | `satgate-sdk` | [Node.js SDK](sdks/nodejs.md) |
+| Node.js | `@satgate/sdk` | [Node.js SDK](sdks/nodejs.md) |
 
 ## Architecture Overview
 

--- a/docs/sdks/agent-nodejs.md
+++ b/docs/sdks/agent-nodejs.md
@@ -14,7 +14,7 @@ const client = new SatGateAgentClient({
   adminToken: 'your-admin-token',
 });
 
-// Tokens are minted and managed automatically
+// Compatibility path: OSS gateway capability tokens are managed automatically
 const response = await client.get('/api/data');
 console.log(response.data);
 ```

--- a/docs/sdks/agent-python.md
+++ b/docs/sdks/agent-python.md
@@ -14,7 +14,7 @@ client = SatGateAgentClient(
     admin_token="your-admin-token",
 )
 
-# Tokens are minted and managed automatically
+# Compatibility path: OSS gateway capability tokens are managed automatically
 response = client.get("/api/data")
 print(response.json())
 ```

--- a/docs/sdks/index.md
+++ b/docs/sdks/index.md
@@ -2,17 +2,19 @@
 
 SatGate provides official SDKs for Python and Node.js/TypeScript.
 
+For application developers, the default SatGate primitive is `issue`, `pay`, `verify`: issue a scoped capability, pay an upstream call with a caller-supplied max budget, then verify the receipt. The lower-level clients below remain available for OSS gateway compatibility.
+
 ## Available SDKs
 
 | SDK | Package | Status |
 |-----|---------|--------|
-| [Python](python.md) | `pip install satgate` | ✅ v2.0.0 |
+| [Python](python.md) | `pip install satgate` | ✅ v0.3.2 |
 | [Node.js/TypeScript](nodejs.md) | `npm install @satgate/sdk` | ✅ |
 | [Go](go.md) | Import `pkg/` directly | ✅ Native |
 
 ## Agent SDKs
 
-Built on top of the base SDKs, these provide automatic token management and L402 payment handling for AI agents:
+Built on top of the base SDKs, these provide compatibility token management and paid-rail handling for AI agents:
 
 | SDK | Included In | Description |
 |-----|------------|-------------|

--- a/docs/sdks/nodejs.md
+++ b/docs/sdks/nodejs.md
@@ -8,12 +8,49 @@ Official Node.js/TypeScript client for SatGate Gateway.
 npm install @satgate/sdk
 ```
 
-## Two Clients
+## Build agents with issue/pay/verify
+
+For application developers, SatGate's Stripe-like primitive is three calls:
+
+1. **Issue** a scoped capability for one task.
+2. **Pay** an upstream call with a caller-supplied max budget.
+3. **Verify** the returned receipt and Evidence Pack metadata.
+
+```typescript
+import { SatGate } from '@satgate/sdk';
+
+const satgate = new SatGate({ apiKey: process.env.SATGATE_API_KEY });
+
+const capability = await satgate.issue({
+  task: 'summarize vendor invoice',
+  agent: 'invoice-agent',
+  allow: ['POST /v1/invoices/*'],
+  budgetUsd: 0.25,
+  expiresIn: '10m',
+});
+
+const receipt = await satgate.pay({
+  upstream: 'https://api.vendor.test/v1/invoices/42',
+  capability,
+  maxUsd: 0.10,
+});
+
+const verified = await satgate.verify(receipt);
+console.log(verified.decision, verified.evidencePackId ?? verified.evidence_pack_id);
+```
+
+The public package installs today. The `issue/pay/verify` API namespace is in private beta; non-beta credentials raise `SatGateAuthError` with a docs CTA instead of returning mocked success.
+
+---
+
+## Compatibility: OSS Gateway clients
 
 | Client | For | Auth |
 |--------|-----|------|
-| `SatGateClient` | **Operators** — mint tokens, ban tokens, manage governance | `X-Admin-Token` header |
-| `SatGateAgentClient` | **AI Agents** — make API calls with automatic token & payment handling | Auto-mints tokens, handles L402 |
+| `SatGateClient` | **Operators** — lower-level capability token and governance endpoints | `X-Admin-Token` header |
+| `SatGateAgentClient` | **AI Agents** — compatibility client for existing gateway token and paid-rail flows | Auto-mints tokens, handles L402 |
+
+Use these when targeting the self-hosted OSS gateway's existing token endpoints. New Cloud examples should lead with `issue/pay/verify`.
 
 ---
 

--- a/docs/sdks/python.md
+++ b/docs/sdks/python.md
@@ -8,20 +8,56 @@ Official Python client for SatGate Gateway.
 pip install satgate
 ```
 
-## Two Clients
+## Build agents with issue/pay/verify
 
-SatGate provides two clients for different use cases:
+For application developers, SatGate's Stripe-like primitive is three calls:
+
+1. **Issue** a scoped capability for one task.
+2. **Pay** an upstream call with a caller-supplied max budget.
+3. **Verify** the returned receipt and Evidence Pack metadata.
+
+```python
+import os
+from satgate import SatGate
+
+satgate = SatGate(api_key=os.getenv("SATGATE_API_KEY"))
+
+capability = satgate.issue(
+    task="summarize vendor invoice",
+    agent="invoice-agent",
+    allow=["POST /v1/invoices/*"],
+    budget_usd=0.25,
+    expires_in="10m",
+)
+
+receipt = satgate.pay(
+    upstream="https://api.vendor.test/v1/invoices/42",
+    capability=capability,
+    max_usd=0.10,
+)
+
+verified = satgate.verify(receipt)
+print(verified.decision, getattr(verified, "evidence_pack_id", None))
+```
+
+The public package installs today. The `issue/pay/verify` API namespace is in private beta; non-beta credentials raise `SatGateAuthError` with a docs CTA instead of returning mocked success.
+
+---
+
+## Compatibility: OSS Gateway clients
 
 | Client | For | Auth |
 |--------|-----|------|
-| `SatGateClient` | **Operators** — mint tokens, ban tokens, manage governance | `X-Admin-Token` header |
-| `SatGateAgentClient` | **AI Agents** — make API calls with automatic token & payment handling | Auto-mints tokens, handles L402 |
+| `SatGateClient` | **Operators** — lower-level capability token and governance endpoints | `X-Admin-Token` header |
+| `SatGateAgentClient` | **AI Agents** — compatibility client for existing gateway token and paid-rail flows | Auto-mints tokens, handles L402 |
+
+Use these when targeting the self-hosted OSS gateway's existing token endpoints. New Cloud examples should lead with `issue/pay/verify`.
 
 ---
 
 ## Admin Client (`SatGateClient`)
 
-For operators managing tokens and governance.
+For operators managing compatibility token endpoints and governance.
 
 ```python
 from satgate import SatGateClient

--- a/examples/python/issue_pay_verify.py
+++ b/examples/python/issue_pay_verify.py
@@ -32,7 +32,7 @@ def main() -> int:
         )
 
         verified = satgate.verify(receipt)
-        print(verified.decision, verified.evidence_pack_id)
+        print(verified.decision, getattr(verified, "evidence_pack_id", getattr(verified, "evidencePackId", None)))
         return 0
     except SatGateAuthError as exc:
         print(f"SatGateAuthError: {exc}")

--- a/satgate-landing/app/build/page.tsx
+++ b/satgate-landing/app/build/page.tsx
@@ -17,7 +17,7 @@ import {
 export const metadata: Metadata = {
   title: "Build Agents That Can Spend Safely",
   description:
-    "Issue scoped capabilities, route paid calls, and verify receipts with SatGate's developer surface for agent authority, payment context, and Evidence Pack proof.",
+    "Issue scoped capabilities, pay upstream with max budgets, and verify receipts with SatGate's developer surface for agent authority, payment context, and Evidence Pack proof.",
   keywords: [
     "SatGate build",
     "AI agent capabilities",
@@ -33,7 +33,7 @@ export const metadata: Metadata = {
   openGraph: {
     title: "Build agents that can spend safely",
     description:
-      "Capabilities in. Receipts out. Rails abstracted. Build agents with scoped authority, paid-call routing, and verifiable receipts.",
+      "Capabilities in. Receipts out. Rails abstracted. Build agents with scoped authority, upstream payments with max budgets, and verifiable receipts.",
     url: "https://satgate.io/build",
     type: "website",
   },
@@ -41,7 +41,7 @@ export const metadata: Metadata = {
     card: "summary_large_image",
     title: "Build agents that can spend safely",
     description:
-      "Issue capabilities, route paid calls, and verify receipts with SatGate's rail-neutral developer primitive.",
+      "Issue scoped capabilities, pay upstream with max budgets, and verify receipts with SatGate's rail-neutral developer primitive.",
   },
 };
 
@@ -92,8 +92,8 @@ const installCommands = String.raw`# Install today (public packages):
 pip install satgate
 npm install @satgate/sdk`;
 
-const curlExample = String.raw`curl https://api.satgate.io/v1/capabilities \
-  -H "Authorization: Bearer YOUR_API_KEY" \
+const curlExample = String.raw`curl https://api.satgate.io/v1/issue \
+  -H "Authorization: Bearer $SATGATE_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
     "agent": "research-agent",
@@ -104,9 +104,14 @@ const curlExample = String.raw`curl https://api.satgate.io/v1/capabilities \
   }'
 
 curl https://api.satgate.io/v1/pay \
-  -H "Authorization: Bearer YOUR_API_KEY" \
+  -H "Authorization: Bearer $SATGATE_API_KEY" \
   -H "Content-Type: application/json" \
-  -d '{"capability":"cap_...","upstream":"https://api.example.com/search","max_usd":4.20}'`;
+  -d '{"capability":"cap_...","upstream":"https://api.example.com/search","max_usd":4.20}'
+
+curl https://api.satgate.io/v1/verify \
+  -H "Authorization: Bearer $SATGATE_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"receipt":"rcpt_..."}'`;
 
 const primitives = [
   {
@@ -117,15 +122,15 @@ const primitives = [
   },
   {
     icon: Route,
-    title: "Route paid calls",
+    title: "Pay upstream with max budget",
     label: "satgate.pay",
-    body: "Let the agent reach MCP tools, APIs, or paid rails through SatGate while policy is enforced before value moves.",
+    body: "Let the agent reach MCP tools, APIs, or paid rails through SatGate while a caller-supplied max budget and policy are enforced before value moves.",
   },
   {
     icon: ReceiptText,
     title: "Verify receipts",
     label: "satgate.verify",
-    body: "Return a signed decision receipt that can feed an Evidence Pack for audits, incidents, billing review, or revocation proof.",
+    body: "Verify the receipt returned by pay, then attach or fetch Evidence Pack proof for audits, incidents, billing review, or revocation proof.",
   },
 ];
 
@@ -209,7 +214,7 @@ export default function BuildPage() {
               Build agents that can spend safely
             </h1>
             <p className="mt-6 max-w-3xl text-xl leading-8 text-gray-300">
-              Issue scoped capabilities, route paid calls, and return verifiable receipts your principal can trust.
+              Issue scoped capabilities, pay upstream with max budgets, and return verifiable receipts your principal can trust.
             </p>
             <p className="mt-5 max-w-3xl text-lg leading-8 text-gray-400">
               SatGate is the <strong className="font-semibold text-white">Economic Firewall for AI agents</strong>. This is the developer surface: <strong className="font-semibold text-white">Capabilities in. Receipts out. Rails abstracted.</strong>

--- a/satgate-landing/public/llms.txt
+++ b/satgate-landing/public/llms.txt
@@ -172,11 +172,22 @@ agent.run("Buy the latest stock report")
 
 ### Node.js
 ```javascript
-npm install satgate-sdk
+npm install @satgate/sdk
 
-import { SatGateClient } from 'satgate-sdk';
-const client = new SatGateClient();
-const data = await client.get('https://api.example.com/premium');
+import { SatGate } from '@satgate/sdk';
+const satgate = new SatGate({ apiKey: process.env.SATGATE_API_KEY });
+const capability = await satgate.issue({
+  task: 'fetch premium report',
+  agent: 'research-agent',
+  allow: ['GET /premium'],
+  budgetUsd: 1.00,
+});
+const receipt = await satgate.pay({
+  upstream: 'https://api.example.com/premium',
+  capability,
+  maxUsd: 0.25,
+});
+await satgate.verify(receipt);
 ```
 
 ### cURL
@@ -211,7 +222,7 @@ curl -H "Authorization: L402 <macaroon>:<preimage>" \
 - Cloud: https://cloud.satgate.io/cloud/login
 - GitHub: https://github.com/SatGate-io/satgate
 - Python SDK: https://pypi.org/project/satgate/
-- Node.js SDK: https://www.npmjs.com/package/satgate-sdk
+- Node.js SDK: https://www.npmjs.com/package/@satgate/sdk
 
 ## Contact
 - Email: contact@satgate.io

--- a/satgate-landing/scripts/check_build_page.py
+++ b/satgate-landing/scripts/check_build_page.py
@@ -12,7 +12,7 @@ required_page_strings = [
     "Build agents that can spend safely",
     "Capabilities in. Receipts out. Rails abstracted.",
     "Issue scoped capabilities",
-    "Route paid calls",
+    "Pay upstream with max budget",
     "Verify receipts",
     "satgate.issue",
     "satgate.pay",
@@ -35,7 +35,10 @@ required_page_strings = [
     "budget_exhausted",
     "Node example",
     "HTTP example",
-    "YOUR_API_KEY",
+    "SATGATE_API_KEY",
+    "https://api.satgate.io/v1/issue",
+    "https://api.satgate.io/v1/pay",
+    "https://api.satgate.io/v1/verify",
 ]
 
 forbidden_page_patterns = [
@@ -51,6 +54,8 @@ forbidden_page_patterns = [
     r"ISO 8601 duration support belongs",
     r"Open developer docs",
     r"Bearer \*\*\*",
+    r"Route paid calls",
+    r"/v1/capabilities",
 ]
 
 errors: list[str] = []

--- a/sdk/nodejs/README.md
+++ b/sdk/nodejs/README.md
@@ -43,7 +43,7 @@ SatGateAuthError: This API namespace requires private beta access. Visit cloud.s
 
 Works with: MCP · OpenAI tools · Anthropic tools · LangChain · CrewAI · Raw HTTP
 
-## OSS Gateway client
+## Compatibility: lower-level OSS Gateway client
 
 The package also includes the lower-level OSS gateway clients:
 

--- a/sdk/nodejs/src/__tests__/private-beta.test.ts
+++ b/sdk/nodejs/src/__tests__/private-beta.test.ts
@@ -1,0 +1,96 @@
+import fetch from 'node-fetch';
+import { SatGate, SatGateAuthError } from '../index';
+
+jest.mock('node-fetch', () => jest.fn());
+
+const mockedFetch = fetch as unknown as jest.Mock;
+
+describe('SatGate issue/pay/verify primitive facade', () => {
+  beforeEach(() => {
+    mockedFetch.mockReset();
+  });
+
+  it('throws a clear beta-access error without credentials', async () => {
+    const satgate = new SatGate();
+
+    await expect(satgate.issue({
+      task: 'summarize vendor invoice',
+      agent: 'invoice-agent',
+      allow: ['POST /v1/invoices/*'],
+      budgetUsd: 0.25,
+      expiresIn: '10m',
+    })).rejects.toThrow(SatGateAuthError);
+
+    await expect(satgate.issue({
+      task: 'summarize vendor invoice',
+      agent: 'invoice-agent',
+      allow: ['POST /v1/invoices/*'],
+    })).rejects.toThrow('cloud.satgate.io/docs');
+    expect(mockedFetch).not.toHaveBeenCalled();
+  });
+
+  it('falls back to the early capabilities endpoint when /v1/issue is absent', async () => {
+    mockedFetch
+      .mockResolvedValueOnce({ ok: false, status: 404, json: async () => ({}) })
+      .mockResolvedValueOnce({ ok: true, status: 200, json: async () => ({ id: 'cap_compat' }) });
+
+    const satgate = new SatGate({ apiKey: 'sg_test', baseUrl: 'https://api.example.test' });
+    const capability = await satgate.issue({
+      task: 'summarize vendor invoice',
+      agent: 'invoice-agent',
+      allow: ['POST /v1/invoices/*'],
+    });
+
+    expect(mockedFetch).toHaveBeenNthCalledWith(1, 'https://api.example.test/v1/issue', expect.any(Object));
+    expect(mockedFetch).toHaveBeenNthCalledWith(2, 'https://api.example.test/v1/capabilities', expect.any(Object));
+    expect(capability.id).toBe('cap_compat');
+  });
+
+  it('posts copy-pasteable issue/pay/verify payloads with primitive endpoint names', async () => {
+    mockedFetch
+      .mockResolvedValueOnce({ ok: true, status: 200, json: async () => ({ id: 'cap_123' }) })
+      .mockResolvedValueOnce({ ok: true, status: 200, json: async () => ({ receiptId: 'rcpt_123' }) })
+      .mockResolvedValueOnce({ ok: true, status: 200, json: async () => ({ decision: 'allow', evidencePackId: 'ep_123' }) });
+
+    const satgate = new SatGate({ apiKey: 'sg_test', baseUrl: 'https://api.example.test', tenant: 'tenant_123' });
+    const capability = await satgate.issue({
+      task: 'summarize vendor invoice',
+      agent: 'invoice-agent',
+      allow: ['POST /v1/invoices/*'],
+      budgetUsd: 0.25,
+      expiresIn: '10m',
+    });
+    const receipt = await satgate.pay({
+      upstream: 'https://api.vendor.test/v1/invoices/42',
+      capability,
+      maxUsd: 0.10,
+    });
+    await satgate.verify(receipt);
+
+    expect(mockedFetch).toHaveBeenNthCalledWith(1, 'https://api.example.test/v1/issue', expect.objectContaining({
+      method: 'POST',
+      headers: expect.objectContaining({
+        Authorization: 'Bearer sg_test',
+        'Content-Type': 'application/json',
+        'X-SatGate-Tenant': 'tenant_123',
+      }),
+      body: JSON.stringify({
+        task: 'summarize vendor invoice',
+        agent: 'invoice-agent',
+        allow: ['POST /v1/invoices/*'],
+        budget_usd: 0.25,
+        expires_in: '10m',
+      }),
+    }));
+    expect(mockedFetch).toHaveBeenNthCalledWith(2, 'https://api.example.test/v1/pay', expect.objectContaining({
+      body: JSON.stringify({
+        upstream: 'https://api.vendor.test/v1/invoices/42',
+        capability: { id: 'cap_123' },
+        max_usd: 0.10,
+      }),
+    }));
+    expect(mockedFetch).toHaveBeenNthCalledWith(3, 'https://api.example.test/v1/verify', expect.objectContaining({
+      body: JSON.stringify({ receipt: { receipt_id: 'rcpt_123' } }),
+    }));
+  });
+});

--- a/sdk/nodejs/src/index.ts
+++ b/sdk/nodejs/src/index.ts
@@ -1,38 +1,34 @@
 /**
- * SatGate Gateway Node.js SDK (OSS)
+ * SatGate Node.js SDK
  *
- * ## Admin Client (for operators)
- * 
+ * ## Developer primitive: issue/pay/verify
+ *
  * @example
  * ```typescript
- * import { SatGateClient } from '@satgate/sdk';
+ * import { SatGate } from '@satgate/sdk';
  *
- * const client = new SatGateClient({
- *   url: 'http://localhost:8080',
- *   token: 'your-admin-token'
+ * const satgate = new SatGate({ apiKey: process.env.SATGATE_API_KEY });
+ * const capability = await satgate.issue({
+ *   task: 'summarize vendor invoice',
+ *   agent: 'invoice-agent',
+ *   allow: ['POST /v1/invoices/*'],
+ *   budgetUsd: 0.25,
+ *   expiresIn: '10m',
  * });
+ * const receipt = await satgate.pay({
+ *   upstream: 'https://api.vendor.test/v1/invoices/42',
+ *   capability,
+ *   maxUsd: 0.10,
+ * });
+ * const verified = await satgate.verify(receipt);
+ * console.log(verified.decision, verified.evidencePackId ?? verified.evidence_pack_id);
+ * ```
  *
- * // Mint a new token
- * const token = await client.tokens.mint({ scope: 'api:*', duration: '1h' });
- * console.log('Token:', token.token);
- * ```
- * 
- * ## Agent Client (for AI agents)
- * 
- * @example
- * ```typescript
- * import { SatGateAgentClient } from '@satgate/sdk';
- * 
- * // With admin token (auto-mints capability tokens)
- * const client = new SatGateAgentClient({
- *   gatewayUrl: 'http://localhost:8080',
- *   adminToken: 'your-admin-token'
- * });
- * 
- * // Make requests - token management is automatic
- * const response = await client.get('/api/data');
- * console.log(response.data);
- * ```
+ * ## Compatibility: lower-level OSS Gateway clients
+ *
+ * SatGateClient and SatGateAgentClient preserve existing self-hosted gateway token,
+ * delegation, and paid-rail APIs. New Cloud/private-beta app examples should lead
+ * with issue/pay/verify.
  */
 
 // SatGate Cloud private-beta facade
@@ -81,19 +77,17 @@ export {
   delegate,
   parseCaveats,
   isMoreRestrictive,
-  DelegationNode,
 } from './delegation';
 
 // Errors
 export {
   SatGateError,
   AuthenticationError,
-  SatGateAuthError,
   NotFoundError,
-  ValidationError,
   PaymentRequiredError,
   PaymentFailedError,
   BudgetExceededError,
   TokenExpiredError,
   DelegationError,
+  SatGateAuthError,
 } from './errors';

--- a/sdk/nodejs/src/private-beta.ts
+++ b/sdk/nodejs/src/private-beta.ts
@@ -53,7 +53,15 @@ export class SatGate {
   }
 
   async issue(request: CapabilityRequest): Promise<SatGateReceipt> {
-    return this.post<SatGateReceipt>('/v1/capabilities', this.toApiPayload(request) as JsonObject);
+    try {
+      return await this.post<SatGateReceipt>('/v1/issue', this.toApiPayload(request) as JsonObject);
+    } catch (err) {
+      if (err instanceof SatGateAuthError && err.statusCode === 404) {
+        // Compatibility fallback for early private-beta clients and gateways.
+        return this.post<SatGateReceipt>('/v1/capabilities', this.toApiPayload(request) as JsonObject);
+      }
+      throw err;
+    }
   }
 
   async pay(request: PayRequest): Promise<SatGateReceipt> {

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -44,7 +44,7 @@ SatGateAuthError: This API namespace requires private beta access. Visit cloud.s
 
 Works with: MCP · OpenAI tools · Anthropic tools · LangChain · CrewAI · Raw HTTP
 
-## OSS Gateway client
+## Compatibility: lower-level OSS Gateway client
 
 The package also includes lower-level OSS gateway clients:
 

--- a/sdk/python/satgate/__init__.py
+++ b/sdk/python/satgate/__init__.py
@@ -1,41 +1,30 @@
 """
-SatGate Gateway Python SDK
+SatGate Python SDK
 
-A Python SDK for interacting with the SatGate OSS Gateway.
+Developer primitive: issue/pay/verify.
 
-## Admin Client (for operators)
+    import os
+    from satgate import SatGate
 
-    from satgate import SatGateClient
-    
-    client = SatGateClient(
-        base_url="http://localhost:8080",
-        admin_token="your-admin-token"
+    satgate = SatGate(api_key=os.getenv("SATGATE_API_KEY"))
+    capability = satgate.issue(
+        task="summarize vendor invoice",
+        agent="invoice-agent",
+        allow=["POST /v1/invoices/*"],
+        budget_usd=0.25,
+        expires_in="10m",
     )
-    
-    # Mint a new token
-    token = client.tokens.mint(scope="api:*", duration="1h")
-    print(f"Token: {token.token}")
-
-## Agent Client (for AI agents)
-
-    from satgate import SatGateAgentClient
-    
-    client = SatGateAgentClient(
-        gateway_url="http://localhost:8080",
-        admin_token="your-admin-token"
+    receipt = satgate.pay(
+        upstream="https://api.vendor.test/v1/invoices/42",
+        capability=capability,
+        max_usd=0.10,
     )
-    
-    # Make requests - token management is automatic
-    response = client.get("/api/data")
+    verified = satgate.verify(receipt)
+    print(verified.decision, getattr(verified, "evidence_pack_id", None))
 
-## With a pre-existing token
-
-    from satgate import SatGateAgentClient
-    
-    client = SatGateAgentClient(
-        gateway_url="http://localhost:8080",
-        token="your-capability-token"
-    )
+Compatibility: SatGateClient and SatGateAgentClient preserve existing OSS Gateway
+token, delegation, and paid-rail APIs. New Cloud/private-beta app examples should
+lead with issue/pay/verify.
 """
 
 from .private_beta import SatGate

--- a/sdk/python/satgate/private_beta.py
+++ b/sdk/python/satgate/private_beta.py
@@ -63,11 +63,20 @@ class SatGate:
             self.session.headers.update({"X-SatGate-Tenant": tenant})
 
     def issue(self, **payload: Any) -> AttrDict:
-        """Issue a scoped capability for an agent task."""
-        return self._post("/v1/capabilities", payload)
+        """Issue a scoped capability for an agent task.
+
+        `/v1/issue` is the primitive endpoint. `/v1/capabilities` remains a
+        compatibility fallback for early private-beta clients.
+        """
+        try:
+            return self._post("/v1/issue", payload)
+        except SatGateAuthError as exc:
+            if exc.status_code != 404:
+                raise
+            return self._post("/v1/capabilities", payload)
 
     def pay(self, **payload: Any) -> AttrDict:
-        """Route a value-bearing call under a scoped capability."""
+        """Pay an upstream call under a scoped capability with a caller-supplied max budget."""
         return self._post("/v1/pay", self._serialize(payload))
 
     def verify(self, receipt: Any) -> AttrDict:

--- a/sdk/python/tests/test_issue_pay_verify.py
+++ b/sdk/python/tests/test_issue_pay_verify.py
@@ -1,0 +1,105 @@
+import pytest
+
+from satgate import SatGate, SatGateAuthError
+
+
+class FakeResponse:
+    def __init__(self, status_code=200, body=None):
+        self.status_code = status_code
+        self._body = body or {}
+        self.content = b"{}"
+        self.text = ""
+
+    def json(self):
+        return self._body
+
+
+class RecordingSession:
+    def __init__(self):
+        self.headers = {}
+        self.calls = []
+        self.responses = [
+            FakeResponse(body={"id": "cap_123"}),
+            FakeResponse(body={"receipt_id": "rcpt_123"}),
+            FakeResponse(body={"decision": "allow", "evidence_pack_id": "ep_123"}),
+        ]
+
+    def post(self, url, json, timeout):
+        self.calls.append({"url": url, "json": json, "timeout": timeout})
+        return self.responses.pop(0)
+
+
+def test_issue_without_credentials_returns_docs_cta_without_network():
+    satgate = SatGate()
+
+    with pytest.raises(SatGateAuthError) as exc:
+        satgate.issue(
+            task="summarize vendor invoice",
+            agent="invoice-agent",
+            allow=["POST /v1/invoices/*"],
+            budget_usd=0.25,
+            expires_in="10m",
+        )
+
+    assert "cloud.satgate.io/docs" in str(exc.value)
+
+
+def test_issue_falls_back_to_early_capabilities_endpoint_on_404():
+    satgate = SatGate(api_key="sg_test", base_url="https://api.example.test")
+    session = RecordingSession()
+    session.responses = [FakeResponse(status_code=404), FakeResponse(body={"id": "cap_compat"})]
+    satgate.session = session
+
+    capability = satgate.issue(
+        task="summarize vendor invoice",
+        agent="invoice-agent",
+        allow=["POST /v1/invoices/*"],
+    )
+
+    assert [call["url"] for call in session.calls] == [
+        "https://api.example.test/v1/issue",
+        "https://api.example.test/v1/capabilities",
+    ]
+    assert capability.id == "cap_compat"
+
+
+def test_issue_pay_verify_use_primitive_endpoints_and_copy_paste_payloads():
+    satgate = SatGate(api_key="sg_test", base_url="https://api.example.test", tenant="tenant_123")
+    session = RecordingSession()
+    satgate.session = session
+
+    capability = satgate.issue(
+        task="summarize vendor invoice",
+        agent="invoice-agent",
+        allow=["POST /v1/invoices/*"],
+        budget_usd=0.25,
+        expires_in="10m",
+    )
+    receipt = satgate.pay(
+        upstream="https://api.vendor.test/v1/invoices/42",
+        capability=capability,
+        max_usd=0.10,
+    )
+    verified = satgate.verify(receipt)
+
+    assert session.calls[0] == {
+        "url": "https://api.example.test/v1/issue",
+        "json": {
+            "task": "summarize vendor invoice",
+            "agent": "invoice-agent",
+            "allow": ["POST /v1/invoices/*"],
+            "budget_usd": 0.25,
+            "expires_in": "10m",
+        },
+        "timeout": 30,
+    }
+    assert session.calls[1]["url"] == "https://api.example.test/v1/pay"
+    assert session.calls[1]["json"] == {
+        "upstream": "https://api.vendor.test/v1/invoices/42",
+        "capability": {"id": "cap_123"},
+        "max_usd": 0.10,
+    }
+    assert session.calls[2]["url"] == "https://api.example.test/v1/verify"
+    assert session.calls[2]["json"] == {"receipt": {"receipt_id": "rcpt_123"}}
+    assert verified.decision == "allow"
+    assert verified.evidence_pack_id == "ep_123"


### PR DESCRIPTION
## Summary
- Align Python/Node SDK docs, README snippets, landing `/build`, generated `llms.txt`, and quickstarts around `issue`, `pay`, `verify`
- Add primitive facade regression tests for Python and Node, including `/v1/issue` with `/v1/capabilities` compatibility fallback
- Fix stale copy-paste hazards: malformed curl auth headers, stale `satgate-sdk` package name, and `/build` HTTP sample missing `verify`

## Compatibility
- Existing `SatGateClient`, `SatGateAgentClient`, token/delegation helpers, and OSS gateway examples remain documented as compatibility paths
- `SatGate.issue()` now uses `/v1/issue` first and falls back to `/v1/capabilities` on 404 for early private-beta/gateway compatibility

## Verification
- `PYTHONPATH=. pytest -q` in `sdk/python` → 3 passed
- `python3 -m py_compile satgate/*.py tests/*.py` in `sdk/python`
- `npm run build` in `sdk/nodejs`
- `npm test -- --runInBand` in `sdk/nodejs` → 2 suites / 4 tests passed
- `npm run test:build-page` in `satgate-landing`
- `npm run build` in `satgate-landing`
- Local rendered `/build` smoke against `next start`: required issue/pay/verify strings present; stale `Bearer ***` and `Route paid calls` absent
- Docs snippet sanity check: balanced fences and no `Bearer ***`, `YOUR_API_KEY`, or `satgate-sdk` in touched docs/samples
