### PR TITLE
feat: consolidate demos into sandbox

### DIFF
--- a/satgate-landing/app/build/page.tsx
+++ b/satgate-landing/app/build/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import Link from "next/link";
 import {
+  ArrowLeft,
   ArrowRight,
   BadgeCheck,
   Braces,
@@ -202,6 +203,12 @@ export default function BuildPage() {
   return (
     <main className="min-h-screen overflow-x-hidden bg-black text-gray-100 font-sans">
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }} />
+
+      <div className="mx-auto max-w-6xl px-6 pt-8">
+        <Link href="/" className="inline-flex items-center gap-2 text-sm font-medium text-gray-500 transition hover:text-white">
+          <ArrowLeft size={16} /> Back to Home
+        </Link>
+      </div>
 
       <section className="relative overflow-hidden border-b border-gray-900">
         <div className="absolute inset-0 bg-[radial-gradient(circle_at_20%_0%,rgba(56,189,248,0.18),transparent_34%),radial-gradient(circle_at_85%_10%,rgba(168,85,247,0.18),transparent_32%),radial-gradient(circle_at_55%_80%,rgba(16,185,129,0.10),transparent_34%)]" />

--- a/satgate-landing/app/capability-auth/page.tsx
+++ b/satgate-landing/app/capability-auth/page.tsx
@@ -1,5 +1,5 @@
 import Link from 'next/link';
-import { ArrowRight, BadgeCheck, KeyRound, Layers3, ShieldCheck, TimerReset, WalletCards } from 'lucide-react';
+import { ArrowLeft, ArrowRight, BadgeCheck, KeyRound, Layers3, ShieldCheck, TimerReset, WalletCards } from 'lucide-react';
 
 export const metadata = {
   title: 'Capability-Based Authorization for AI Agents',
@@ -65,6 +65,12 @@ export default function CapabilityAuthPage() {
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(softwareJsonLd) }} />
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(faqJsonLd) }} />
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbJsonLd) }} />
+
+      <div className="mx-auto max-w-6xl px-6 pt-8">
+        <Link href="/" className="inline-flex items-center gap-2 text-sm font-medium text-gray-500 transition hover:text-white">
+          <ArrowLeft size={16} /> Back to Home
+        </Link>
+      </div>
 
       <section className="relative overflow-hidden border-b border-gray-900">
         <div className="absolute inset-0 bg-[radial-gradient(circle_at_25%_0%,rgba(34,211,238,0.18),transparent_32%),radial-gradient(circle_at_80%_15%,rgba(16,185,129,0.14),transparent_34%)]" />

--- a/satgate-landing/app/components/HomeClient.tsx
+++ b/satgate-landing/app/components/HomeClient.tsx
@@ -28,10 +28,10 @@ const LandingPage = () => {
 
           {/* Desktop menu */}
           <div className="hidden xl:flex gap-6 text-sm font-medium text-gray-400">
-            <Link href="/protect" className="hover:text-white transition">Live Demo</Link>
             <Link href="/govern" className="hover:text-white transition">Enterprise</Link>
             <Link href="/mcp-gateway" className="hover:text-white transition">MCP Gateway</Link>
             <Link href="/build" className="hover:text-white transition">Build</Link>
+            <Link href="/sandbox" className="hover:text-white transition">Sandbox</Link>
             <Link href="/capability-auth" className="hover:text-white transition">Capability Auth</Link>
             <Link href="/agent-control-plane" className="hover:text-white transition">Control Plane</Link>
             <Link href="/pricing" className="hover:text-white transition">Pricing</Link>
@@ -62,13 +62,6 @@ const LandingPage = () => {
         >
           <div className="bg-black/95 backdrop-blur-xl border-t border-gray-800 px-4 py-4 space-y-1">
             <Link
-              href="/protect"
-              onClick={() => setMobileMenuOpen(false)}
-              className="block text-gray-400 hover:text-white hover:bg-gray-800/50 transition py-3 px-4 rounded-lg"
-            >
-              Live Demo
-            </Link>
-            <Link
               href="/govern"
               onClick={() => setMobileMenuOpen(false)}
               className="block text-gray-400 hover:text-white hover:bg-gray-800/50 transition py-3 px-4 rounded-lg"
@@ -88,6 +81,13 @@ const LandingPage = () => {
               className="block text-gray-400 hover:text-white hover:bg-gray-800/50 transition py-3 px-4 rounded-lg"
             >
               Build
+            </Link>
+            <Link
+              href="/sandbox"
+              onClick={() => setMobileMenuOpen(false)}
+              className="block text-gray-400 hover:text-white hover:bg-gray-800/50 transition py-3 px-4 rounded-lg"
+            >
+              Sandbox
             </Link>
             <Link
               href="/capability-auth"
@@ -191,7 +191,7 @@ const LandingPage = () => {
                 Build with SatGate <ArrowRight size={16} />
               </Link>
               <Link href="/sandbox" className="border border-purple-700/50 bg-purple-900/20 px-8 py-3 rounded-lg font-bold hover:bg-purple-900/40 transition flex items-center gap-2 text-purple-300">
-                <Play size={16} /> See a Demo
+                <Play size={16} /> Open Sandbox
               </Link>
               <Link href="/agent-control-plane" className="border border-cyan-700/50 bg-cyan-900/15 px-8 py-3 rounded-lg font-bold hover:bg-cyan-900/30 transition flex items-center gap-2 text-cyan-300">
                 Agent Control Plane <ArrowRight size={16} />
@@ -220,7 +220,7 @@ const LandingPage = () => {
                 <div className="w-3 h-3 rounded-full bg-red-500"></div>
                 <div className="w-3 h-3 rounded-full bg-yellow-500"></div>
                 <div className="w-3 h-3 rounded-full bg-green-500"></div>
-                <div className="text-xs text-gray-500 ml-2 font-mono">hero_demo.py - Live Demo</div>
+                <div className="text-xs text-gray-500 ml-2 font-mono">hero_demo.py - Sandbox Preview</div>
               </div>
               <video
                 autoPlay

--- a/satgate-landing/app/mcp-gateway/page.tsx
+++ b/satgate-landing/app/mcp-gateway/page.tsx
@@ -1,5 +1,5 @@
 import Link from 'next/link';
-import { ArrowRight, Bot, Cable, CheckCircle2, Download, Eye, FileJson, Gauge, GitBranch, LockKeyhole, ReceiptText, ServerCog, ShieldCheck } from 'lucide-react';
+import { ArrowLeft, ArrowRight, Bot, Cable, CheckCircle2, Download, Eye, FileJson, Gauge, GitBranch, LockKeyhole, ReceiptText, ServerCog, ShieldCheck } from 'lucide-react';
 
 const policyTemplates = [
   {
@@ -137,6 +137,12 @@ export default function McpGatewayPage() {
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(faqJsonLd) }} />
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(datasetJsonLd) }} />
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbJsonLd) }} />
+
+      <div className="mx-auto max-w-6xl px-6 pt-8">
+        <Link href="/" className="inline-flex items-center gap-2 text-sm font-medium text-gray-500 transition hover:text-white">
+          <ArrowLeft size={16} /> Back to Home
+        </Link>
+      </div>
 
       <section className="relative overflow-hidden border-b border-gray-900">
         <div className="absolute inset-0 bg-[radial-gradient(circle_at_30%_0%,rgba(34,211,238,0.18),transparent_32%),radial-gradient(circle_at_80%_10%,rgba(168,85,247,0.15),transparent_34%)]" />

--- a/satgate-landing/app/pricing/page.tsx
+++ b/satgate-landing/app/pricing/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React, { useState } from 'react';
-import { Check, Zap, ArrowRight, ChevronDown, Menu, X } from 'lucide-react';
+import { Check, ChevronDown, Menu, X } from 'lucide-react';
 import Link from 'next/link';
 import Image from 'next/image';
 
@@ -129,9 +129,6 @@ const PricingPage = () => {
 
           {/* Desktop menu */}
           <div className="hidden md:flex gap-6 text-sm font-medium text-gray-400">
-            <Link href="/mint-demo" className="hover:text-white transition">Mint Demo</Link>
-            <Link href="/protect" className="hover:text-white transition">Control Demo</Link>
-            <Link href="/pay" className="hover:text-white transition">Charge Demo</Link>
             <Link href="/govern" className="hover:text-white transition">Enterprise</Link>
             <Link href="/pricing" className="text-white transition">Pricing</Link>
             <Link href="/roi-calculator" className="hover:text-white transition">ROI Calculator</Link>
@@ -157,9 +154,6 @@ const PricingPage = () => {
           }`}
         >
           <div className="bg-black/95 backdrop-blur-xl border-t border-gray-800 px-4 py-4 space-y-1">
-            <Link href="/mint-demo" onClick={() => setMobileMenuOpen(false)} className="block text-gray-400 hover:text-white hover:bg-gray-800/50 transition py-3 px-4 rounded-lg">Mint Demo</Link>
-            <Link href="/protect" onClick={() => setMobileMenuOpen(false)} className="block text-gray-400 hover:text-white hover:bg-gray-800/50 transition py-3 px-4 rounded-lg">Control Demo</Link>
-            <Link href="/pay" onClick={() => setMobileMenuOpen(false)} className="block text-gray-400 hover:text-white hover:bg-gray-800/50 transition py-3 px-4 rounded-lg">Charge Demo</Link>
             <Link href="/govern" onClick={() => setMobileMenuOpen(false)} className="block text-gray-400 hover:text-white hover:bg-gray-800/50 transition py-3 px-4 rounded-lg">Enterprise</Link>
             <Link href="/pricing" onClick={() => setMobileMenuOpen(false)} className="block text-white hover:bg-gray-800/50 transition py-3 px-4 rounded-lg">Pricing</Link>
             <Link href="/roi-calculator" onClick={() => setMobileMenuOpen(false)} className="block text-gray-400 hover:text-white hover:bg-gray-800/50 transition py-3 px-4 rounded-lg">ROI Calculator</Link>

--- a/satgate-landing/app/sandbox/page.tsx
+++ b/satgate-landing/app/sandbox/page.tsx
@@ -46,6 +46,59 @@ const BRAVO_RESPONSES = [
   '→ Market gap: identity-aware economic controls for autonomous agents.',
 ];
 
+const sandboxDemos = [
+  {
+    title: 'Mint Demo',
+    href: '/mint-demo',
+    icon: Key,
+    eyebrow: '1 · Issue authority',
+    body: 'Create scoped capability for an agent before it touches a tool, API, or paid resource.',
+  },
+  {
+    title: 'Capability Control Demo',
+    href: '/protect',
+    icon: Shield,
+    eyebrow: '2 · Control authority',
+    body: 'See scope, delegation, and revocation in the request path without making spend the center of the demo.',
+  },
+  {
+    title: 'Spend Control Demo',
+    href: '#spend-control-demo',
+    icon: DollarSign,
+    eyebrow: '3 · Constrain spend',
+    body: 'Run the budget-enforcement simulation and watch SatGate deny runaway agent spend before value moves.',
+  },
+  {
+    title: 'Paid-Rails Demo',
+    href: '/pay',
+    icon: Zap,
+    eyebrow: '4 · Govern rails',
+    body: 'Put paid-rail context behind policy and receipts without making L402/x402 the product center.',
+  },
+];
+
+function BudgetBar({ label, spent, limit, color }: { label: string; spent: number; limit: number; color: string }) {
+  if (limit === 0) return null;
+  const pct = Math.min((spent / limit) * 100, 100);
+  const exhausted = spent >= limit;
+  return (
+    <div className="bg-gray-800/50 border border-gray-700/50 rounded-lg p-3">
+      <div className="flex justify-between text-xs mb-1.5">
+        <span className="text-gray-400">{label}</span>
+        <span className={exhausted ? 'text-red-400 font-bold' : 'text-gray-300'}>
+          {spent}/{limit} credits {exhausted && '⛔'}
+        </span>
+      </div>
+      <div className="h-2 bg-gray-900 rounded-full overflow-hidden">
+        <div
+          className={`h-full rounded-full transition-all duration-500 ${exhausted ? 'bg-red-500' : color}`}
+          style={{ width: `${pct}%` }}
+        />
+      </div>
+    </div>
+  );
+}
+
 // ── Main Page ──────────────────────────────────────────────────────────────────
 
 export default function SandboxPage() {
@@ -282,42 +335,20 @@ export default function SandboxPage() {
     }
   };
 
-  // ── Budget Bar ─────────────────────────────────────────────────
-
-  const BudgetBar = ({ label, spent, limit, color }: { label: string; spent: number; limit: number; color: string }) => {
-    if (limit === 0) return null;
-    const pct = Math.min((spent / limit) * 100, 100);
-    const exhausted = spent >= limit;
-    return (
-      <div className="bg-gray-800/50 border border-gray-700/50 rounded-lg p-3">
-        <div className="flex justify-between text-xs mb-1.5">
-          <span className="text-gray-400">{label}</span>
-          <span className={exhausted ? 'text-red-400 font-bold' : 'text-gray-300'}>
-            {spent}/{limit} credits {exhausted && '⛔'}
-          </span>
-        </div>
-        <div className="h-2 bg-gray-900 rounded-full overflow-hidden">
-          <div
-            className={`h-full rounded-full transition-all duration-500 ${exhausted ? 'bg-red-500' : color}`}
-            style={{ width: `${pct}%` }}
-          />
-        </div>
-      </div>
-    );
-  };
-
   const webPageJsonLd = {
     '@context': 'https://schema.org',
     '@type': 'WebPage',
     name: 'SatGate Sandbox',
     url: 'https://satgate.io/sandbox',
-    description: 'Interactive sandbox for SatGate request-path enforcement: AI agent spend controls, scoped macaroons, kill switches, budgets, and API policy.',
+    description: 'Interactive SatGate sandbox for Mint, Capability Control, Spend Control, and Paid-Rails demos.',
     datePublished: '2026-04-12',
     dateModified: '2026-05-03',
     isPartOf: { '@type': 'WebSite', name: 'SatGate', url: 'https://satgate.io' },
     about: [
+      { '@type': 'Thing', name: 'SatGate demo sandbox' },
+      { '@type': 'Thing', name: 'capability control demo' },
       { '@type': 'Thing', name: 'AI agent spend control sandbox' },
-      { '@type': 'Thing', name: 'request-path economic policy' },
+      { '@type': 'Thing', name: 'paid-rail governance demo' },
       { '@type': 'Thing', name: 'macaroon capability verification' },
       { '@type': 'Thing', name: 'agent kill-switch revocation' },
       { '@type': 'Thing', name: 'runaway spend blocking simulation' },
@@ -331,15 +362,15 @@ export default function SandboxPage() {
     applicationCategory: 'DeveloperApplication',
     operatingSystem: 'Web',
     url: 'https://satgate.io/sandbox',
-    description: 'Interactive sandbox for SatGate request-path enforcement: AI agent spend controls, scoped macaroons, kill switches, budgets, and API policy.',
+    description: 'Interactive SatGate sandbox for Mint, Capability Control, Spend Control, and Paid-Rails demos.',
     publisher: { '@type': 'Organization', name: 'SatGate', url: 'https://satgate.io' },
     dateModified: '2026-05-03',
     featureList: [
-      'AI agent budget enforcement demo',
-      'Request-path economic policy decisions',
-      'Macaroon capability token verification',
-      'Agent kill-switch revocation',
-      'Runaway spend blocking simulation',
+      'Mint Demo',
+      'Capability Control Demo',
+      'Spend Control Demo',
+      'Paid-Rails Demo',
+      'Request-path policy decisions',
     ],
   };
 
@@ -360,7 +391,7 @@ export default function SandboxPage() {
       {
         '@type': 'Question',
         name: 'What does the SatGate sandbox demonstrate?',
-        acceptedAnswer: { '@type': 'Answer', text: 'The sandbox demonstrates SatGate enforcing economic policy in the request path: minting scoped credentials, verifying macaroons, revoking a rogue agent, and blocking runaway API spend when a budget is exhausted.' },
+        acceptedAnswer: { '@type': 'Answer', text: 'The sandbox collects the SatGate demo path: Mint for scoped authority, Capability Control for scope/delegation/revocation, Spend Control for budget enforcement, and Paid-Rails for governed payment context.' },
       },
       {
         '@type': 'Question',
@@ -390,7 +421,7 @@ export default function SandboxPage() {
           <h1 className="text-lg sm:text-xl font-bold flex items-center gap-2">
             <Shield className="text-purple-400" size={24} />
             <span className="bg-clip-text text-transparent bg-gradient-to-r from-purple-400 to-cyan-400">
-              Spend Control Demo
+              SatGate Sandbox
             </span>
           </h1>
           <Link
@@ -402,8 +433,35 @@ export default function SandboxPage() {
         </div>
       </div>
 
-      {/* Hero */}
+      {/* Demo Hub */}
       <div className="bg-gradient-to-b from-purple-950/20 to-transparent border-b border-gray-800/50">
+        <div className="max-w-6xl mx-auto px-4 sm:px-6 py-12 text-center">
+          <p className="mb-3 text-sm font-mono uppercase tracking-[0.22em] text-purple-300">Demo path</p>
+          <h2 className="text-3xl sm:text-5xl font-extrabold tracking-tight text-white mb-4">
+            Mint. Control. Constrain. Govern.
+          </h2>
+          <p className="mx-auto max-w-3xl text-lg leading-relaxed text-gray-400">
+            Start with scoped authority, then move through capability control, spend control, and paid-rail context. Each demo is a separate proof path.
+          </p>
+          <div className="mt-10 grid gap-4 md:grid-cols-2 lg:grid-cols-4 text-left">
+            {sandboxDemos.map(({ title, href, icon: Icon, eyebrow, body }) => (
+              <Link
+                key={title}
+                href={href}
+                className="group rounded-2xl border border-gray-800 bg-gray-950/80 p-5 transition hover:border-purple-500/60 hover:bg-purple-950/20"
+              >
+                <Icon className="mb-4 text-purple-300 transition group-hover:text-cyan-300" size={28} />
+                <p className="mb-2 text-xs font-mono uppercase tracking-wide text-gray-500">{eyebrow}</p>
+                <h3 className="mb-3 text-lg font-bold text-white">{title}</h3>
+                <p className="text-sm leading-relaxed text-gray-400">{body}</p>
+              </Link>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      {/* Spend Control Demo */}
+      <div id="spend-control-demo" className="bg-gradient-to-b from-purple-950/20 to-transparent border-b border-gray-800/50">
         <div className="max-w-4xl mx-auto px-4 sm:px-6 py-8 text-center">
           <h2 className="text-2xl sm:text-3xl font-bold mb-4">
             <span className="bg-clip-text text-transparent bg-gradient-to-r from-purple-400 via-cyan-400 to-purple-400">
@@ -557,7 +615,7 @@ export default function SandboxPage() {
           <h2 className="mb-8 text-center text-2xl font-bold text-white">SatGate sandbox questions</h2>
           <div className="grid gap-4 md:grid-cols-3">
             {[
-              ['What does the SatGate sandbox demonstrate?', 'The sandbox demonstrates SatGate enforcing economic policy in the request path: minting scoped credentials, verifying macaroons, revoking a rogue agent, and blocking runaway API spend when a budget is exhausted.'],
+              ['What does the SatGate sandbox demonstrate?', 'The sandbox collects the SatGate demo path: Mint for scoped authority, Capability Control for scope/delegation/revocation, Spend Control for budget enforcement, and Paid-Rails for governed payment context.'],
               ['How does SatGate stop unauthorized agent spend?', 'SatGate checks each agent request against identity, capability-token caveats, budget, policy, and revocation state before forwarding the request upstream.'],
               ['Is the sandbox for AI agent cost control or security?', 'Both. SatGate treats spend as an enforceable security boundary, combining scoped authority, revocation, audit, and budget limits into an economic firewall for AI agents.'],
             ].map(([question, answer]) => (

--- a/satgate-landing/app/tools/page.tsx
+++ b/satgate-landing/app/tools/page.tsx
@@ -1,5 +1,5 @@
 import Link from 'next/link';
-import { ArrowRight, BarChart3, Calculator, ClipboardList, Gauge, KeyRound, Megaphone, ShieldCheck, Wrench, Zap } from 'lucide-react';
+import { ArrowLeft, ArrowRight, BarChart3, Calculator, ClipboardList, Gauge, KeyRound, Megaphone, ShieldCheck, Wrench, Zap } from 'lucide-react';
 import ToolLeadCaptureCta from '../components/ToolLeadCaptureCta';
 
 export const metadata = {
@@ -208,6 +208,12 @@ export default function ToolsPage() {
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(itemListJsonLd) }} />
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbJsonLd) }} />
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(faqJsonLd) }} />
+
+      <div className="mx-auto max-w-6xl px-6 pt-8">
+        <Link href="/" className="inline-flex items-center gap-2 text-sm font-medium text-gray-500 transition hover:text-white">
+          <ArrowLeft size={16} /> Back to Home
+        </Link>
+      </div>
 
       <section className="relative overflow-hidden border-b border-gray-900">
         <div className="absolute inset-0 bg-[radial-gradient(circle_at_25%_0%,rgba(34,211,238,0.18),transparent_30%),radial-gradient(circle_at_80%_10%,rgba(168,85,247,0.14),transparent_32%)]" />

--- a/satgate-landing/package.json
+++ b/satgate-landing/package.json
@@ -11,7 +11,8 @@
     "seo:links": "python3 scripts/internal_link_audit.py",
     "seo:machine": "python3 scripts/seo_machine.py",
     "seo:check": "python3 scripts/seo_machine.py --check",
-    "test:build-page": "python3 scripts/check_build_page.py"
+    "test:build-page": "python3 scripts/check_build_page.py",
+    "test:demo-ia": "python3 scripts/check_demo_ia.py"
   },
   "dependencies": {
     "lucide-react": "^0.555.0",

--- a/satgate-landing/scripts/check_demo_ia.py
+++ b/satgate-landing/scripts/check_demo_ia.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+HOME = ROOT / "app" / "components" / "HomeClient.tsx"
+PRICING = ROOT / "app" / "pricing" / "page.tsx"
+SANDBOX = ROOT / "app" / "sandbox" / "page.tsx"
+BACK_LINK_PAGES = [
+    ROOT / "app" / "mcp-gateway" / "page.tsx",
+    ROOT / "app" / "build" / "page.tsx",
+    ROOT / "app" / "capability-auth" / "page.tsx",
+    ROOT / "app" / "tools" / "page.tsx",
+]
+
+errors: list[str] = []
+
+home = HOME.read_text()
+if "Live Demo" in home:
+    errors.append("homepage top nav still contains Live Demo")
+if 'href="/sandbox"' not in home or "Open Sandbox" not in home:
+    errors.append("homepage does not route demo CTA/nav to /sandbox")
+
+pricing = PRICING.read_text()
+for stale in ["Mint Demo", "Control Demo", "Charge Demo", 'href="/mint-demo"', 'href="/protect"', 'href="/pay"']:
+    if stale in pricing:
+        errors.append(f"pricing page still contains demo link/copy: {stale}")
+
+sandbox = SANDBOX.read_text()
+ordered = ["Mint Demo", "Capability Control Demo", "Spend Control Demo", "Paid-Rails Demo"]
+positions = []
+for label in ordered:
+    pos = sandbox.find(label)
+    if pos == -1:
+        errors.append(f"sandbox missing demo card: {label}")
+    positions.append(pos)
+if all(pos != -1 for pos in positions) and positions != sorted(positions):
+    errors.append("sandbox demo cards are not ordered Mint → Capability Control → Spend Control → Paid-Rails")
+for href in ["/mint-demo", "/protect", "#spend-control-demo", "/pay"]:
+    if href not in sandbox:
+        errors.append(f"sandbox missing demo href: {href}")
+
+for page in BACK_LINK_PAGES:
+    text = page.read_text()
+    if "Back to Home" not in text or 'href="/"' not in text:
+        errors.append(f"{page.relative_to(ROOT)} missing Back to Home link")
+
+if errors:
+    print("demo IA regression check failed:")
+    for error in errors:
+        print(f"- {error}")
+    sys.exit(1)
+
+print("demo IA regression check passed")


### PR DESCRIPTION
## Summary
- remove the homepage Live Demo nav item and point demo discovery at /sandbox
- remove demo links from /pricing so pricing stays conversion-focused
- turn /sandbox into the central Mint → Capability Control → Spend Control → Paid-Rails demo hub
- add Back to Home links to /mcp-gateway, /build, /capability-auth, and /tools
- add scripts/check_demo_ia.py regression coverage

## Verification
- npm run test:demo-ia
- npm run test:build-page
- npx eslint app/components/HomeClient.tsx app/pricing/page.tsx app/sandbox/page.tsx app/mcp-gateway/page.tsx app/build/page.tsx app/capability-auth/page.tsx app/tools/page.tsx (warnings only: existing unused vars/img warning)
- npm run build
- rendered local routes via Next start: /, /pricing, /sandbox, /mcp-gateway, /build, /capability-auth, /tools