### PR TITLE
fix: label demo hub clearly

### DIFF
--- a/satgate-landing/app/components/HomeClient.tsx
+++ b/satgate-landing/app/components/HomeClient.tsx
@@ -27,20 +27,14 @@ const LandingPage = () => {
           </Link>
 
           {/* Desktop menu */}
-          <div className="hidden xl:flex gap-6 text-sm font-medium text-gray-400">
+          <div className="hidden xl:flex items-center gap-5 text-sm font-medium text-gray-400">
             <Link href="/govern" className="hover:text-white transition">Enterprise</Link>
             <Link href="/mcp-gateway" className="hover:text-white transition">MCP Gateway</Link>
             <Link href="/build" className="hover:text-white transition">Build</Link>
-            <Link href="/sandbox" className="hover:text-white transition">Sandbox</Link>
-            <Link href="/capability-auth" className="hover:text-white transition">Capability Auth</Link>
-            <Link href="/agent-control-plane" className="hover:text-white transition">Control Plane</Link>
+            <Link href="/sandbox" className="hover:text-white transition">Demo</Link>
             <Link href="/pricing" className="hover:text-white transition">Pricing</Link>
-            <Link href="/tools" className="hover:text-white transition">Tools</Link>
-            <Link href="/integrations" className="hover:text-white transition">Integrations</Link>
-            <Link href="/blog" className="hover:text-white transition">Blog</Link>
             <a href="https://cloud.satgate.io/docs" target="_blank" rel="noopener noreferrer" className="hover:text-white transition">Docs</a>
-            <a href="https://github.com/SatGate-io/satgate" target="_blank" rel="noopener noreferrer" className="hover:text-white transition">GitHub</a>
-            <a href="https://cloud.satgate.io/cloud/login" target="_blank" rel="noopener noreferrer" className="text-purple-400 hover:text-purple-300 transition">Cloud →</a>
+            <a href="https://cloud.satgate.io/cloud/login" target="_blank" rel="noopener noreferrer" className="rounded-full border border-purple-500/40 px-3 py-1.5 text-purple-300 hover:border-purple-400 hover:text-purple-200 transition">Cloud →</a>
           </div>
 
           {/* Mobile menu button */}
@@ -87,7 +81,7 @@ const LandingPage = () => {
               onClick={() => setMobileMenuOpen(false)}
               className="block text-gray-400 hover:text-white hover:bg-gray-800/50 transition py-3 px-4 rounded-lg"
             >
-              Sandbox
+              Demo
             </Link>
             <Link
               href="/capability-auth"
@@ -191,7 +185,7 @@ const LandingPage = () => {
                 Build with SatGate <ArrowRight size={16} />
               </Link>
               <Link href="/sandbox" className="border border-purple-700/50 bg-purple-900/20 px-8 py-3 rounded-lg font-bold hover:bg-purple-900/40 transition flex items-center gap-2 text-purple-300">
-                <Play size={16} /> Open Sandbox
+                <Play size={16} /> See Demo
               </Link>
               <Link href="/agent-control-plane" className="border border-cyan-700/50 bg-cyan-900/15 px-8 py-3 rounded-lg font-bold hover:bg-cyan-900/30 transition flex items-center gap-2 text-cyan-300">
                 Agent Control Plane <ArrowRight size={16} />
@@ -220,7 +214,7 @@ const LandingPage = () => {
                 <div className="w-3 h-3 rounded-full bg-red-500"></div>
                 <div className="w-3 h-3 rounded-full bg-yellow-500"></div>
                 <div className="w-3 h-3 rounded-full bg-green-500"></div>
-                <div className="text-xs text-gray-500 ml-2 font-mono">hero_demo.py - Sandbox Preview</div>
+                <div className="text-xs text-gray-500 ml-2 font-mono">hero_demo.py - Demo Preview</div>
               </div>
               <video
                 autoPlay

--- a/satgate-landing/app/sandbox/layout.tsx
+++ b/satgate-landing/app/sandbox/layout.tsx
@@ -1,29 +1,29 @@
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
-  title: "SatGate Sandbox | Try AI Agent Budget Enforcement Free",
+  title: "SatGate Demo | Try AI Agent Budget Enforcement Free",
   alternates: { canonical: "https://satgate.io/sandbox" },
   description:
     "Try SatGate without signup. Test economic access control, AI agent budget enforcement, MCP tool governance, capability tokens, and request-path policy decisions live.",
   keywords: [
-    "SatGate sandbox",
-    "AI agent budget enforcement sandbox",
+    "SatGate demo",
+    "AI agent budget enforcement demo",
     "try economic firewall",
     "AI agent API governance demo",
-    "MCP governance sandbox",
+    "MCP governance demo",
     "capability token demo",
     "request-path policy enforcement",
   ],
   openGraph: {
-    title: "SatGate Sandbox | Try AI Agent Budget Enforcement Free",
+    title: "SatGate Demo | Try AI Agent Budget Enforcement Free",
     description:
-      "Interactive sandbox for economic access control, AI agent budgets, MCP governance, capability tokens, and request-path policy decisions.",
+      "Interactive demo for economic access control, AI agent budgets, MCP governance, capability tokens, and request-path policy decisions.",
     url: "https://satgate.io/sandbox",
     type: "website",
   },
   twitter: {
     card: "summary_large_image",
-    title: "SatGate Sandbox | Try AI Agent Budget Enforcement Free",
+    title: "SatGate Demo | Try AI Agent Budget Enforcement Free",
     description:
       "Test AI agent budget enforcement, MCP governance, and capability-token controls live.",
   },

--- a/satgate-landing/app/sandbox/page.tsx
+++ b/satgate-landing/app/sandbox/page.tsx
@@ -338,16 +338,16 @@ export default function SandboxPage() {
   const webPageJsonLd = {
     '@context': 'https://schema.org',
     '@type': 'WebPage',
-    name: 'SatGate Sandbox',
+    name: 'SatGate Demo',
     url: 'https://satgate.io/sandbox',
-    description: 'Interactive SatGate sandbox for Mint, Capability Control, Spend Control, and Paid-Rails demos.',
+    description: 'Interactive SatGate demo for Mint, Capability Control, Spend Control, and Paid-Rails.',
     datePublished: '2026-04-12',
     dateModified: '2026-05-03',
     isPartOf: { '@type': 'WebSite', name: 'SatGate', url: 'https://satgate.io' },
     about: [
-      { '@type': 'Thing', name: 'SatGate demo sandbox' },
+      { '@type': 'Thing', name: 'SatGate demo' },
       { '@type': 'Thing', name: 'capability control demo' },
-      { '@type': 'Thing', name: 'AI agent spend control sandbox' },
+      { '@type': 'Thing', name: 'AI agent spend control demo' },
       { '@type': 'Thing', name: 'paid-rail governance demo' },
       { '@type': 'Thing', name: 'macaroon capability verification' },
       { '@type': 'Thing', name: 'agent kill-switch revocation' },
@@ -358,11 +358,11 @@ export default function SandboxPage() {
   const softwareJsonLd = {
     '@context': 'https://schema.org',
     '@type': 'SoftwareApplication',
-    name: 'SatGate Sandbox',
+    name: 'SatGate Demo',
     applicationCategory: 'DeveloperApplication',
     operatingSystem: 'Web',
     url: 'https://satgate.io/sandbox',
-    description: 'Interactive SatGate sandbox for Mint, Capability Control, Spend Control, and Paid-Rails demos.',
+    description: 'Interactive SatGate demo for Mint, Capability Control, Spend Control, and Paid-Rails.',
     publisher: { '@type': 'Organization', name: 'SatGate', url: 'https://satgate.io' },
     dateModified: '2026-05-03',
     featureList: [
@@ -380,7 +380,7 @@ export default function SandboxPage() {
     itemListElement: [
       { '@type': 'ListItem', position: 1, name: 'Home', item: 'https://satgate.io' },
       { '@type': 'ListItem', position: 2, name: 'AI Agent Cost Control', item: 'https://satgate.io/ai-agent-cost-control' },
-      { '@type': 'ListItem', position: 3, name: 'SatGate Sandbox', item: 'https://satgate.io/sandbox' },
+      { '@type': 'ListItem', position: 3, name: 'SatGate Demo', item: 'https://satgate.io/sandbox' },
     ],
   };
 
@@ -390,8 +390,8 @@ export default function SandboxPage() {
     mainEntity: [
       {
         '@type': 'Question',
-        name: 'What does the SatGate sandbox demonstrate?',
-        acceptedAnswer: { '@type': 'Answer', text: 'The sandbox collects the SatGate demo path: Mint for scoped authority, Capability Control for scope/delegation/revocation, Spend Control for budget enforcement, and Paid-Rails for governed payment context.' },
+        name: 'What does the SatGate demo demonstrate?',
+        acceptedAnswer: { '@type': 'Answer', text: 'The demo page collects the SatGate demo path: Mint for scoped authority, Capability Control for scope/delegation/revocation, Spend Control for budget enforcement, and Paid-Rails for governed payment context.' },
       },
       {
         '@type': 'Question',
@@ -400,7 +400,7 @@ export default function SandboxPage() {
       },
       {
         '@type': 'Question',
-        name: 'Is the sandbox for AI agent cost control or security?',
+        name: 'Is the demo for AI agent cost control or security?',
         acceptedAnswer: { '@type': 'Answer', text: 'Both. SatGate treats spend as an enforceable security boundary, combining scoped authority, revocation, audit, and budget limits into an economic firewall for AI agents.' },
       },
     ],
@@ -421,7 +421,7 @@ export default function SandboxPage() {
           <h1 className="text-lg sm:text-xl font-bold flex items-center gap-2">
             <Shield className="text-purple-400" size={24} />
             <span className="bg-clip-text text-transparent bg-gradient-to-r from-purple-400 to-cyan-400">
-              SatGate Sandbox
+              SatGate Demo
             </span>
           </h1>
           <Link
@@ -436,7 +436,7 @@ export default function SandboxPage() {
       {/* Demo Hub */}
       <div className="bg-gradient-to-b from-purple-950/20 to-transparent border-b border-gray-800/50">
         <div className="max-w-6xl mx-auto px-4 sm:px-6 py-12 text-center">
-          <p className="mb-3 text-sm font-mono uppercase tracking-[0.22em] text-purple-300">Demo path</p>
+          <p className="mb-3 text-sm font-mono uppercase tracking-[0.22em] text-purple-300">Interactive demo</p>
           <h2 className="text-3xl sm:text-5xl font-extrabold tracking-tight text-white mb-4">
             Mint. Control. Constrain. Govern.
           </h2>
@@ -612,12 +612,12 @@ export default function SandboxPage() {
 
         <section className="mt-12 border-t border-gray-800 pt-10">
           <p className="mb-2 text-center text-xs font-mono uppercase tracking-wide text-purple-300">FAQ</p>
-          <h2 className="mb-8 text-center text-2xl font-bold text-white">SatGate sandbox questions</h2>
+          <h2 className="mb-8 text-center text-2xl font-bold text-white">SatGate demo questions</h2>
           <div className="grid gap-4 md:grid-cols-3">
             {[
-              ['What does the SatGate sandbox demonstrate?', 'The sandbox collects the SatGate demo path: Mint for scoped authority, Capability Control for scope/delegation/revocation, Spend Control for budget enforcement, and Paid-Rails for governed payment context.'],
+              ['What does the SatGate demo demonstrate?', 'The demo page collects the SatGate demo path: Mint for scoped authority, Capability Control for scope/delegation/revocation, Spend Control for budget enforcement, and Paid-Rails for governed payment context.'],
               ['How does SatGate stop unauthorized agent spend?', 'SatGate checks each agent request against identity, capability-token caveats, budget, policy, and revocation state before forwarding the request upstream.'],
-              ['Is the sandbox for AI agent cost control or security?', 'Both. SatGate treats spend as an enforceable security boundary, combining scoped authority, revocation, audit, and budget limits into an economic firewall for AI agents.'],
+              ['Is the demo for AI agent cost control or security?', 'Both. SatGate treats spend as an enforceable security boundary, combining scoped authority, revocation, audit, and budget limits into an economic firewall for AI agents.'],
             ].map(([question, answer]) => (
               <div key={question} className="rounded-xl border border-gray-800 bg-gray-900 p-5">
                 <h3 className="mb-2 font-bold text-white">{question}</h3>

--- a/satgate-landing/scripts/check_demo_ia.py
+++ b/satgate-landing/scripts/check_demo_ia.py
@@ -6,6 +6,7 @@ ROOT = Path(__file__).resolve().parents[1]
 HOME = ROOT / "app" / "components" / "HomeClient.tsx"
 PRICING = ROOT / "app" / "pricing" / "page.tsx"
 SANDBOX = ROOT / "app" / "sandbox" / "page.tsx"
+SANDBOX_LAYOUT = ROOT / "app" / "sandbox" / "layout.tsx"
 BACK_LINK_PAGES = [
     ROOT / "app" / "mcp-gateway" / "page.tsx",
     ROOT / "app" / "build" / "page.tsx",
@@ -18,8 +19,14 @@ errors: list[str] = []
 home = HOME.read_text()
 if "Live Demo" in home:
     errors.append("homepage top nav still contains Live Demo")
-if 'href="/sandbox"' not in home or "Open Sandbox" not in home:
-    errors.append("homepage does not route demo CTA/nav to /sandbox")
+if "Open Sandbox" in home or ">Sandbox<" in home:
+    errors.append("homepage still exposes Sandbox as public label")
+if 'href="/sandbox"' not in home or "See Demo" not in home or ">Demo</Link>" not in home:
+    errors.append("homepage does not route Demo nav/CTA to /sandbox")
+for crowded in ["Capability Auth", "Control Plane", "Tools", "Integrations", "Blog", "GitHub"]:
+    desktop_marker = f'>{crowded}</Link>' if crowded != "GitHub" else f'>{crowded}</a>'
+    if desktop_marker in home.split("{/* Mobile menu button */}", 1)[0]:
+        errors.append(f"desktop nav still includes crowded link: {crowded}")
 
 pricing = PRICING.read_text()
 for stale in ["Mint Demo", "Control Demo", "Charge Demo", 'href="/mint-demo"', 'href="/protect"', 'href="/pay"']:
@@ -27,18 +34,25 @@ for stale in ["Mint Demo", "Control Demo", "Charge Demo", 'href="/mint-demo"', '
         errors.append(f"pricing page still contains demo link/copy: {stale}")
 
 sandbox = SANDBOX.read_text()
+layout = SANDBOX_LAYOUT.read_text()
+for required in ["SatGate Demo", "Interactive demo"]:
+    if required not in sandbox and required not in layout:
+        errors.append(f"demo page missing required public label: {required}")
+for stale in ["SatGate Sandbox", "Demo path", "SatGate sandbox questions", "What does the SatGate sandbox", "Is the sandbox"]:
+    if stale in sandbox or stale in layout:
+        errors.append(f"demo page still contains stale sandbox label: {stale}")
 ordered = ["Mint Demo", "Capability Control Demo", "Spend Control Demo", "Paid-Rails Demo"]
 positions = []
 for label in ordered:
     pos = sandbox.find(label)
     if pos == -1:
-        errors.append(f"sandbox missing demo card: {label}")
+        errors.append(f"sandbox route missing demo card: {label}")
     positions.append(pos)
 if all(pos != -1 for pos in positions) and positions != sorted(positions):
-    errors.append("sandbox demo cards are not ordered Mint → Capability Control → Spend Control → Paid-Rails")
+    errors.append("demo cards are not ordered Mint → Capability Control → Spend Control → Paid-Rails")
 for href in ["/mint-demo", "/protect", "#spend-control-demo", "/pay"]:
     if href not in sandbox:
-        errors.append(f"sandbox missing demo href: {href}")
+        errors.append(f"sandbox route missing demo href: {href}")
 
 for page in BACK_LINK_PAGES:
     text = page.read_text()


### PR DESCRIPTION
## Summary
- change the homepage CTA from “Open Sandbox” to “See Demo”
- rename the public `/sandbox` page copy/metadata to “SatGate Demo” / “Interactive demo” while keeping the route stable
- rename the top-nav link to “Demo” and reduce desktop nav to the high-intent set: Enterprise, MCP Gateway, Build, Demo, Pricing, Docs, Cloud
- expand the demo IA regression guard to catch stale Sandbox labels and crowded desktop nav links

## Verification
- npm run test:demo-ia
- npm run test:build-page
- npx eslint app/components/HomeClient.tsx app/sandbox/page.tsx app/sandbox/layout.tsx scripts/check_demo_ia.py (warnings only: existing unused vars/img warning + Python file ignored by JS ESLint)
- npm run build
- local rendered copy verification for / and /sandbox
- Playwright viewport nav verification at 1280/1366/1440 desktop and 390 mobile
