### PR TITLE
feat: publish SatGate trust metadata

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -29,6 +29,7 @@ SatGate Gateway is an enterprise API gateway that provides:
 | Deploy to Kubernetes | [Helm Installation](guides/kubernetes.md) |
 | See the API reference | [API Reference](api/overview.md) |
 | Export Policy-to-Proof evidence | [Evidence Pack v1](reference/evidence-pack.md) |
+| Discover SatGate trust metadata | [SatGate Trust Metadata](reference/satgate-trust-metadata.md) |
 | Run in production | [Production Checklist](operations/production-checklist.md) |
 | **Enterprise: Economic Firewall** | [Economic Firewall Quickstart](getting-started/economic-firewall-quickstart.md) |
 | **Enterprise: Team Management** | [Team Management Guide](enterprise/TEAM_MANAGEMENT.md) |

--- a/docs/reference/satgate-trust-metadata.md
+++ b/docs/reference/satgate-trust-metadata.md
@@ -1,0 +1,133 @@
+# SatGate Trust Metadata
+
+SatGate publishes a small trust metadata artifact at:
+
+```text
+https://satgate.io/.well-known/satgate
+```
+
+This is the first stable machine-readable discovery surface for agent runtimes, API gateways, and upstream services that want to understand what a SatGate issuer accepts and how receipts can be verified.
+
+It is intentionally small. It does **not** make marketplace, reputation, endorsement, or compliance claims.
+
+## Schema version
+
+```json
+{
+  "schema_version": "satgate.trust_metadata.v1"
+}
+```
+
+Clients should treat unknown fields as optional and preserve forward compatibility. Breaking changes require a new `schema_version`.
+
+## Minimal fields
+
+- `metadata_url`: canonical URL for this metadata document.
+- `issuer`: SatGate issuer identity for the public artifact.
+- `capability_acceptance`: accepted capability/token formats, bearer schemes, required claims, caveats, and delegation-depth semantics.
+- `receipt_verification`: receipt and Evidence Pack formats, required receipt fields, supported decision labels, verification endpoint, and Evidence Pack schema URL.
+- `rails_adapters`: supported rails/adapters beneath SatGate authority and receipts.
+- `signing_key_discovery`: how to discover issuer signing keys for `issuer_kid` verification.
+- `docs`: human-readable links for builders and auditors.
+
+## Capability acceptance
+
+The public artifact currently declares acceptance for:
+
+- `satgate.capability.v1`
+- `macaroon-bearer`
+
+Required claims are deliberately minimal:
+
+- `issuer`
+- `subject`
+- `audience`
+- `scope`
+- `expires_at`
+- `policy_version`
+
+Supported caveats include scope, route, tool, budget, tenant, expiry, and delegation depth. Delegation depth is `policy_defined`; agents should not assume standing authority or unlimited subdelegation.
+
+## Receipt verification
+
+Receipts are the proof spine. A verifier should expect receipt-grade decisions to carry at least:
+
+- `receipt_id`
+- `evidence_pack_id`
+- `decision`
+- `decision_reason`
+- `policy_version`
+- `receipt_hash`
+- `signature`
+
+Decision labels are limited to:
+
+- `allowed`
+- `denied`
+- `delegated`
+- `revoked`
+- `paid`
+
+Evidence Packs use the public schema at:
+
+```text
+https://satgate.io/evidence-packs/evidence-pack.schema.v1.json
+```
+
+## Rails/adapters
+
+The artifact lists supported rails/adapters, not marketplaces:
+
+- `mcp`
+- `x402`
+- `l402`
+- `api_key_billing`
+- `enterprise_ledger`
+
+Rails sit below authority and receipt verification. SatGate proof is the receipt/Evidence Pack layer around the rail.
+
+## Signing key discovery
+
+`signing_key_discovery.mode` is `issuer_discovery`.
+
+Receipts reference an `issuer_kid`. Verifiers should resolve the issuer from the receipt or Evidence Pack, then discover issuer keys using the declared `jwks_url_template`:
+
+```text
+{issuer_id}/.well-known/jwks.json
+```
+
+Tenant or deployment issuers may publish their own JWKS endpoint. The marketing-site trust metadata artifact does not embed production tenant keys.
+
+## HTTP requirements
+
+The live path must return:
+
+- `200 OK`
+- `Content-Type: application/json`
+- `Cache-Control: public, max-age=3600`
+- `Access-Control-Allow-Origin: *`
+- valid JSON matching `satgate.trust_metadata.v1`
+
+## Verification
+
+```bash
+curl -i https://satgate.io/.well-known/satgate
+```
+
+Minimal JSON check:
+
+```bash
+python3 - <<'PY'
+import json, urllib.request
+url = 'https://satgate.io/.well-known/satgate'
+with urllib.request.urlopen(url, timeout=20) as r:
+    assert r.status == 200
+    assert 'application/json' in r.headers['content-type']
+    data = json.load(r)
+assert data['schema_version'] == 'satgate.trust_metadata.v1'
+assert 'satgate.capability.v1' in data['capability_acceptance']['accepted_formats']
+assert 'receipt_id' in data['receipt_verification']['required_receipt_fields']
+assert data['signing_key_discovery']['mode'] == 'issuer_discovery'
+print('satgate trust metadata ok')
+PY
+```

--- a/satgate-landing/app/.well-known/satgate/route.ts
+++ b/satgate-landing/app/.well-known/satgate/route.ts
@@ -1,0 +1,76 @@
+const metadata = {
+  schema_version: "satgate.trust_metadata.v1",
+  metadata_url: "https://satgate.io/.well-known/satgate",
+  issuer: {
+    name: "SatGate",
+    issuer_id: "https://satgate.io",
+    product: "Economic Firewall for AI agents",
+    contact: "contact@satgate.io",
+  },
+  capability_acceptance: {
+    accepted_formats: ["satgate.capability.v1", "macaroon-bearer"],
+    authorization_schemes: ["Bearer"],
+    required_claims: [
+      "issuer",
+      "subject",
+      "audience",
+      "scope",
+      "expires_at",
+      "policy_version",
+    ],
+    supported_caveats: [
+      "scope",
+      "route",
+      "tool",
+      "budget",
+      "tenant",
+      "expires_at",
+      "delegation_depth",
+    ],
+    delegation_depth: "policy_defined",
+  },
+  receipt_verification: {
+    receipt_format: "satgate.receipt.v1",
+    evidence_pack_format: "satgate.evidence_pack.v1",
+    required_receipt_fields: [
+      "receipt_id",
+      "evidence_pack_id",
+      "decision",
+      "decision_reason",
+      "policy_version",
+      "receipt_hash",
+      "signature",
+    ],
+    decisions: ["allowed", "denied", "delegated", "revoked", "paid"],
+    verification_endpoint: "https://api.satgate.io/v1/verify",
+    evidence_pack_schema_url: "https://satgate.io/evidence-packs/evidence-pack.schema.v1.json",
+  },
+  rails_adapters: {
+    supported: ["mcp", "x402", "l402", "api_key_billing", "enterprise_ledger"],
+    note: "Rails are adapters below SatGate authority and receipt verification; this metadata makes no marketplace or reputation claim.",
+  },
+  signing_key_discovery: {
+    mode: "issuer_discovery",
+    key_id_field: "issuer_kid",
+    jwks_url_template: "{issuer_id}/.well-known/jwks.json",
+    note: "Verify receipts against the issuer key referenced by issuer_kid. Tenant or deployment issuers may publish their own JWKS endpoint.",
+  },
+  docs: {
+    build: "https://satgate.io/build",
+    policy_to_proof: "https://satgate.io/policy-to-proof",
+    evidence_pack_reference: "https://github.com/SatGate-io/satgate/blob/main/docs/reference/evidence-pack.md",
+    api_docs: "https://cloud.satgate.io/docs",
+  },
+} as const;
+
+export const dynamic = "force-static";
+
+export function GET() {
+  return Response.json(metadata, {
+    headers: {
+      "Cache-Control": "public, max-age=3600",
+      "Access-Control-Allow-Origin": "*",
+      "X-Content-Type-Options": "nosniff",
+    },
+  });
+}

--- a/satgate-landing/app/build/page.tsx
+++ b/satgate-landing/app/build/page.tsx
@@ -139,6 +139,7 @@ const integrationLinks = [
   { title: "MCP Gateway", href: "/mcp-gateway", body: "Put SatGate in front of MCP tools and preserve a receipt per tool invocation." },
   { title: "Runtime integrations", href: "/integrations", body: "See current agent-client surfaces and where OpenAI, Anthropic, LangChain, and CrewAI adapters fit." },
   { title: "Developer docs", href: "https://cloud.satgate.io/docs", body: "Use the docs for setup details while issue/pay/verify API access is in private beta." },
+  { title: "Trust metadata", href: "/.well-known/satgate", body: "Discover SatGate capability acceptance, supported rails, issuer metadata, and receipt verification fields." },
 ];
 
 const runtimeChips = ["MCP", "OpenAI tools", "Anthropic tools", "LangChain", "CrewAI", "Raw HTTP"];
@@ -347,7 +348,7 @@ export default function BuildPage() {
             <p className="mb-3 text-sm font-mono uppercase tracking-[0.22em] text-emerald-300">Agent integrations</p>
             <h2 className="text-3xl font-bold text-white sm:text-4xl">Give every runtime bounded authority.</h2>
             <p className="mt-4 text-lg leading-8 text-gray-400">
-              The runtime changes. The contract stays the same: capability before action, receipt after decision.
+              The runtime changes. The contract stays the same: capability before action, receipt after decision. The machine-readable trust metadata lives at <Link href="/.well-known/satgate" className="text-cyan-300 hover:text-cyan-200">/.well-known/satgate</Link>.
             </p>
             <div className="mt-6 flex flex-wrap gap-2 text-sm text-gray-300">
               <span className="mr-1 py-1 text-gray-500">Works with:</span>

--- a/satgate-landing/package.json
+++ b/satgate-landing/package.json
@@ -13,7 +13,8 @@
     "seo:check": "python3 scripts/seo_machine.py --check",
     "test:build-page": "python3 scripts/check_build_page.py",
     "test:demo-ia": "python3 scripts/check_demo_ia.py",
-    "test:proof-spine": "python3 scripts/check_proof_spine.py"
+    "test:proof-spine": "python3 scripts/check_proof_spine.py",
+    "test:well-known": "python3 scripts/check_well_known_satgate.py"
   },
   "dependencies": {
     "lucide-react": "^0.555.0",

--- a/satgate-landing/scripts/check_well_known_satgate.py
+++ b/satgate-landing/scripts/check_well_known_satgate.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""Regression guard for SatGate /.well-known/satgate trust metadata."""
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+ROUTE = ROOT / "app" / ".well-known" / "satgate" / "route.ts"
+BUILD = ROOT / "app" / "build" / "page.tsx"
+DOC = ROOT.parent / "docs" / "reference" / "satgate-trust-metadata.md"
+DOC_INDEX = ROOT.parent / "docs" / "index.md"
+PACKAGE = ROOT / "package.json"
+
+REQUIRED_ROUTE_STRINGS = [
+    "schema_version: \"satgate.trust_metadata.v1\"",
+    "metadata_url: \"https://satgate.io/.well-known/satgate\"",
+    "capability_acceptance",
+    "accepted_formats",
+    "satgate.capability.v1",
+    "macaroon-bearer",
+    "receipt_verification",
+    "satgate.receipt.v1",
+    "satgate.evidence_pack.v1",
+    "receipt_id",
+    "evidence_pack_id",
+    "decision_reason",
+    "policy_version",
+    "rails_adapters",
+    "x402",
+    "l402",
+    "api_key_billing",
+    "enterprise_ledger",
+    "signing_key_discovery",
+    "jwks_url_template",
+    "Response.json",
+    "Cache-Control",
+    "public, max-age=3600",
+    "Access-Control-Allow-Origin",
+    "X-Content-Type-Options",
+]
+
+REQUIRED_BUILD_STRINGS = [
+    "Trust metadata",
+    "/.well-known/satgate",
+    "capability acceptance",
+    "receipt verification fields",
+]
+
+REQUIRED_DOC_STRINGS = [
+    "https://satgate.io/.well-known/satgate",
+    "satgate.trust_metadata.v1",
+    "Capability acceptance",
+    "Receipt verification",
+    "Signing key discovery",
+    "200 OK",
+    "Content-Type: application/json",
+]
+
+FORBIDDEN_ROUTE_PATTERNS = [
+    r"marketplace",
+    r"reputation",
+    r"endorsement",
+    r"rank(ing)?",
+    r"trust score",
+]
+
+errors: list[str] = []
+
+if not ROUTE.exists():
+    errors.append("missing /.well-known/satgate route")
+else:
+    route_text = ROUTE.read_text()
+    for needle in REQUIRED_ROUTE_STRINGS:
+        if needle not in route_text:
+            errors.append(f"route missing required string: {needle}")
+    for pattern in FORBIDDEN_ROUTE_PATTERNS:
+        # Permit the explicit disclaimer phrase "no marketplace or reputation claim".
+        text_without_disclaimer = route_text.replace("no marketplace or reputation claim", "")
+        if re.search(pattern, text_without_disclaimer, flags=re.IGNORECASE):
+            errors.append(f"route has forbidden claim language: {pattern}")
+
+build_text = BUILD.read_text() if BUILD.exists() else ""
+for needle in REQUIRED_BUILD_STRINGS:
+    if needle not in build_text:
+        errors.append(f"/build missing trust metadata string: {needle}")
+
+doc_text = DOC.read_text() if DOC.exists() else ""
+for needle in REQUIRED_DOC_STRINGS:
+    if needle not in doc_text:
+        errors.append(f"docs missing trust metadata string: {needle}")
+
+index_text = DOC_INDEX.read_text() if DOC_INDEX.exists() else ""
+if "reference/satgate-trust-metadata.md" not in index_text:
+    errors.append("docs index does not link satgate-trust-metadata reference")
+
+package_text = PACKAGE.read_text() if PACKAGE.exists() else ""
+if "test:well-known" not in package_text:
+    errors.append("package.json missing test:well-known script")
+
+if errors:
+    print("/.well-known/satgate regression check failed:")
+    for err in errors:
+        print(f"- {err}")
+    sys.exit(1)
+
+print("/.well-known/satgate regression check passed")


### PR DESCRIPTION
## Summary
- Adds `/.well-known/satgate` trust metadata JSON for capability acceptance, receipt verification, supported rails/adapters, issuer metadata, signing-key discovery, and docs links.
- Documents the minimal `satgate.trust_metadata.v1` schema in `docs/reference/satgate-trust-metadata.md` and links it from docs index and `/build`.
- Adds `npm run test:well-known` regression guard for route shape, headers, proof fields, docs links, and no marketplace/reputation claims.

## Verification
- `npm run test:well-known`
- `npm run test:build-page`
- `npm run test:proof-spine`
- `npm ci && npm run build`
- Local HTTP check against `/.well-known/satgate` asserted 200, valid JSON, `Content-Type: application/json`, `Cache-Control: public, max-age=3600`, `Access-Control-Allow-Origin: *`, `X-Content-Type-Options: nosniff`, and required schema fields.
