### PR TITLE
fix: harden SatGate trust metadata contract

### DIFF
--- a/docs/reference/satgate-trust-metadata.md
+++ b/docs/reference/satgate-trust-metadata.md
@@ -8,26 +8,38 @@ https://satgate.io/.well-known/satgate
 
 This is the first stable machine-readable discovery surface for agent runtimes, API gateways, and upstream services that want to understand what a SatGate issuer accepts and how receipts can be verified.
 
-It is intentionally small. It does **not** make marketplace, reputation, endorsement, or compliance claims.
+It is intentionally small. It does **not** make marketplace, reputation, endorsement, ranking, or compliance claims.
 
-## Schema version
+## Compatibility rule
+
+Treat this like a versioned API:
+
+- Clients should ignore unknown fields.
+- SatGate may add fields within `satgate.trust_metadata.v1`.
+- SatGate must not rename or remove existing v1 fields without a new `schema_version`.
+
+## Schema version and schema URL
 
 ```json
 {
-  "schema_version": "satgate.trust_metadata.v1"
+  "schema_version": "satgate.trust_metadata.v1",
+  "schema_url": "https://satgate.io/.well-known/satgate.schema.json",
+  "roles": ["issuer"]
 }
 ```
 
-Clients should treat unknown fields as optional and preserve forward compatibility. Breaking changes require a new `schema_version`.
+`roles` is present now so the issuer-side artifact does not paint us into a corner when upstream acceptor metadata exists later. The first public artifact is issuer-side only.
 
 ## Minimal fields
 
 - `metadata_url`: canonical URL for this metadata document.
-- `issuer`: SatGate issuer identity for the public artifact.
+- `schema_url`: JSON Schema URL for this version.
+- `roles`: metadata role list; currently `issuer` only.
+- `issuer`: SatGate issuer identity and key-discovery metadata for the public artifact.
 - `capability_acceptance`: accepted capability/token formats, bearer schemes, required claims, caveats, and delegation-depth semantics.
 - `receipt_verification`: receipt and Evidence Pack formats, required receipt fields, supported decision labels, verification endpoint, and Evidence Pack schema URL.
-- `rails_adapters`: supported rails/adapters beneath SatGate authority and receipts.
-- `signing_key_discovery`: how to discover issuer signing keys for `issuer_kid` verification.
+- `rails_adapters`: supported rails/adapters beneath SatGate authority and receipts, as structured objects.
+- `signing_key_discovery`: issuer-key discovery rule for `issuer_kid` verification.
 - `docs`: human-readable links for builders and auditors.
 
 ## Capability acceptance
@@ -60,7 +72,7 @@ Receipts are the proof spine. A verifier should expect receipt-grade decisions t
 - `receipt_hash`
 - `signature`
 
-Decision labels are limited to:
+Decision labels are a closed enum in v1:
 
 - `allowed`
 - `denied`
@@ -76,7 +88,17 @@ https://satgate.io/evidence-packs/evidence-pack.schema.v1.json
 
 ## Rails/adapters
 
-The artifact lists supported rails/adapters, not marketplaces:
+The artifact lists supported rails/adapters as an array of objects, not free strings:
+
+```json
+{
+  "id": "x402",
+  "type": "payment_rail",
+  "role": "external_paid_access"
+}
+```
+
+Current adapter IDs:
 
 - `mcp`
 - `x402`
@@ -88,15 +110,35 @@ Rails sit below authority and receipt verification. SatGate proof is the receipt
 
 ## Signing key discovery
 
-`signing_key_discovery.mode` is `issuer_discovery`.
+The `issuer` block exposes key discovery as:
 
-Receipts reference an `issuer_kid`. Verifiers should resolve the issuer from the receipt or Evidence Pack, then discover issuer keys using the declared `jwks_url_template`:
+```json
+{
+  "method": "jwks_uri",
+  "key_id_field": "issuer_kid",
+  "jwks_uri": "https://satgate.io/.well-known/jwks.json"
+}
+```
+
+`signing_key_discovery.mode` is `issuer_discovery` and keeps the general rule:
 
 ```text
 {issuer_id}/.well-known/jwks.json
 ```
 
-Tenant or deployment issuers may publish their own JWKS endpoint. The marketing-site trust metadata artifact does not embed production tenant keys.
+Receipts reference an `issuer_kid`. Verifiers should resolve the issuer from the receipt or Evidence Pack, then discover issuer keys using the issuer's JWKS URI. Tenant or deployment issuers may publish their own JWKS endpoint. The public `satgate.io` JWKS route currently publishes an empty `keys` array instead of placeholder production tenant keys.
+
+## Future acceptor-side metadata
+
+The mirror artifact is intentionally not shipped yet. The likely shape is either a future `roles: ["acceptor"]` profile in this schema or a companion `/.well-known/satgate-upstream` document advertising:
+
+- accepted capability formats
+- verification endpoint
+- accepted receipt decisions
+- rails/adapters the upstream settles on
+- issuer allowlist or key-discovery policy
+
+Do not add acceptor claims to the issuer artifact until an upstream actually accepts SatGate capabilities.
 
 ## HTTP requirements
 
@@ -106,6 +148,7 @@ The live path must return:
 - `Content-Type: application/json`
 - `Cache-Control: public, max-age=3600`
 - `Access-Control-Allow-Origin: *`
+- `X-Content-Type-Options: nosniff`
 - valid JSON matching `satgate.trust_metadata.v1`
 
 ## Verification
@@ -123,11 +166,17 @@ url = 'https://satgate.io/.well-known/satgate'
 with urllib.request.urlopen(url, timeout=20) as r:
     assert r.status == 200
     assert 'application/json' in r.headers['content-type']
+    assert r.headers['cache-control'] == 'public, max-age=3600'
+    assert r.headers['access-control-allow-origin'] == '*'
     data = json.load(r)
 assert data['schema_version'] == 'satgate.trust_metadata.v1'
+assert data['schema_url'] == 'https://satgate.io/.well-known/satgate.schema.json'
+assert data['roles'] == ['issuer']
 assert 'satgate.capability.v1' in data['capability_acceptance']['accepted_formats']
 assert 'receipt_id' in data['receipt_verification']['required_receipt_fields']
-assert data['signing_key_discovery']['mode'] == 'issuer_discovery'
+assert set(data['receipt_verification']['decisions']) == {'allowed','denied','delegated','revoked','paid'}
+assert isinstance(data['rails_adapters']['supported'][0], dict)
+assert data['issuer']['key_discovery']['method'] == 'jwks_uri'
 print('satgate trust metadata ok')
 PY
 ```

--- a/satgate-landing/app/.well-known/jwks.json/route.ts
+++ b/satgate-landing/app/.well-known/jwks.json/route.ts
@@ -1,0 +1,16 @@
+const jwks = {
+  keys: [],
+  note: "SatGate tenant or deployment issuers publish signing keys at their issuer-specific JWKS URI. The public satgate.io metadata issuer does not expose tenant receipt-signing keys here.",
+} as const;
+
+export const dynamic = "force-static";
+
+export function GET() {
+  return Response.json(jwks, {
+    headers: {
+      "Cache-Control": "public, max-age=3600",
+      "Access-Control-Allow-Origin": "*",
+      "X-Content-Type-Options": "nosniff",
+    },
+  });
+}

--- a/satgate-landing/app/.well-known/satgate.schema.json/route.ts
+++ b/satgate-landing/app/.well-known/satgate.schema.json/route.ts
@@ -1,0 +1,92 @@
+const schema = {
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://satgate.io/.well-known/satgate.schema.json",
+  title: "SatGate Trust Metadata v1",
+  type: "object",
+  required: [
+    "schema_version",
+    "metadata_url",
+    "schema_url",
+    "roles",
+    "issuer",
+    "capability_acceptance",
+    "receipt_verification",
+    "rails_adapters",
+    "signing_key_discovery",
+    "docs",
+  ],
+  properties: {
+    schema_version: { const: "satgate.trust_metadata.v1" },
+    metadata_url: { type: "string", format: "uri" },
+    schema_url: { type: "string", format: "uri" },
+    roles: { type: "array", items: { enum: ["issuer", "acceptor"] }, minItems: 1 },
+    issuer: {
+      type: "object",
+      required: ["name", "issuer_id", "product", "contact", "key_discovery"],
+      properties: {
+        name: { type: "string" },
+        issuer_id: { type: "string", format: "uri" },
+        product: { type: "string" },
+        contact: { type: "string" },
+        key_discovery: {
+          type: "object",
+          required: ["method", "key_id_field", "jwks_uri"],
+          properties: {
+            method: { const: "jwks_uri" },
+            key_id_field: { const: "issuer_kid" },
+            jwks_uri: { type: "string", format: "uri" },
+          },
+          additionalProperties: true,
+        },
+      },
+      additionalProperties: true,
+    },
+    capability_acceptance: { type: "object", additionalProperties: true },
+    receipt_verification: {
+      type: "object",
+      required: ["receipt_format", "evidence_pack_format", "required_receipt_fields", "decisions"],
+      properties: {
+        decisions: {
+          type: "array",
+          items: { enum: ["allowed", "denied", "delegated", "revoked", "paid"] },
+        },
+      },
+      additionalProperties: true,
+    },
+    rails_adapters: {
+      type: "object",
+      required: ["supported"],
+      properties: {
+        supported: {
+          type: "array",
+          items: {
+            type: "object",
+            required: ["id", "type", "role"],
+            properties: {
+              id: { type: "string" },
+              type: { type: "string" },
+              role: { type: "string" },
+            },
+            additionalProperties: true,
+          },
+        },
+      },
+      additionalProperties: true,
+    },
+    signing_key_discovery: { type: "object", additionalProperties: true },
+    docs: { type: "object", additionalProperties: true },
+  },
+  additionalProperties: true,
+} as const;
+
+export const dynamic = "force-static";
+
+export function GET() {
+  return Response.json(schema, {
+    headers: {
+      "Cache-Control": "public, max-age=3600",
+      "Access-Control-Allow-Origin": "*",
+      "X-Content-Type-Options": "nosniff",
+    },
+  });
+}

--- a/satgate-landing/app/.well-known/satgate/route.ts
+++ b/satgate-landing/app/.well-known/satgate/route.ts
@@ -1,11 +1,18 @@
 const metadata = {
   schema_version: "satgate.trust_metadata.v1",
   metadata_url: "https://satgate.io/.well-known/satgate",
+  schema_url: "https://satgate.io/.well-known/satgate.schema.json",
+  roles: ["issuer"],
   issuer: {
     name: "SatGate",
     issuer_id: "https://satgate.io",
     product: "Economic Firewall for AI agents",
     contact: "contact@satgate.io",
+    key_discovery: {
+      method: "jwks_uri",
+      key_id_field: "issuer_kid",
+      jwks_uri: "https://satgate.io/.well-known/jwks.json",
+    },
   },
   capability_acceptance: {
     accepted_formats: ["satgate.capability.v1", "macaroon-bearer"],
@@ -46,13 +53,19 @@ const metadata = {
     evidence_pack_schema_url: "https://satgate.io/evidence-packs/evidence-pack.schema.v1.json",
   },
   rails_adapters: {
-    supported: ["mcp", "x402", "l402", "api_key_billing", "enterprise_ledger"],
+    supported: [
+      { id: "mcp", type: "protocol", role: "tool_transport" },
+      { id: "x402", type: "payment_rail", role: "external_paid_access" },
+      { id: "l402", type: "payment_rail", role: "external_paid_access" },
+      { id: "api_key_billing", type: "billing_adapter", role: "existing_vendor_billing" },
+      { id: "enterprise_ledger", type: "ledger_adapter", role: "internal_chargeback" },
+    ],
     note: "Rails are adapters below SatGate authority and receipt verification; this metadata makes no marketplace or reputation claim.",
   },
   signing_key_discovery: {
     mode: "issuer_discovery",
     key_id_field: "issuer_kid",
-    jwks_url_template: "{issuer_id}/.well-known/jwks.json",
+    jwks_uri_template: "{issuer_id}/.well-known/jwks.json",
     note: "Verify receipts against the issuer key referenced by issuer_kid. Tenant or deployment issuers may publish their own JWKS endpoint.",
   },
   docs: {

--- a/satgate-landing/scripts/check_well_known_satgate.py
+++ b/satgate-landing/scripts/check_well_known_satgate.py
@@ -8,6 +8,8 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 ROUTE = ROOT / "app" / ".well-known" / "satgate" / "route.ts"
+SCHEMA_ROUTE = ROOT / "app" / ".well-known" / "satgate.schema.json" / "route.ts"
+JWKS_ROUTE = ROOT / "app" / ".well-known" / "jwks.json" / "route.ts"
 BUILD = ROOT / "app" / "build" / "page.tsx"
 DOC = ROOT.parent / "docs" / "reference" / "satgate-trust-metadata.md"
 DOC_INDEX = ROOT.parent / "docs" / "index.md"
@@ -16,6 +18,8 @@ PACKAGE = ROOT / "package.json"
 REQUIRED_ROUTE_STRINGS = [
     "schema_version: \"satgate.trust_metadata.v1\"",
     "metadata_url: \"https://satgate.io/.well-known/satgate\"",
+    "schema_url: \"https://satgate.io/.well-known/satgate.schema.json\"",
+    "roles: [\"issuer\"]",
     "capability_acceptance",
     "accepted_formats",
     "satgate.capability.v1",
@@ -32,8 +36,12 @@ REQUIRED_ROUTE_STRINGS = [
     "l402",
     "api_key_billing",
     "enterprise_ledger",
+    "type: \"payment_rail\"",
+    "role: \"external_paid_access\"",
+    "key_discovery",
+    "jwks_uri: \"https://satgate.io/.well-known/jwks.json\"",
     "signing_key_discovery",
-    "jwks_url_template",
+    "jwks_uri_template",
     "Response.json",
     "Cache-Control",
     "public, max-age=3600",
@@ -56,6 +64,9 @@ REQUIRED_DOC_STRINGS = [
     "Signing key discovery",
     "200 OK",
     "Content-Type: application/json",
+    "schema_url",
+    "jwks_uri",
+    "array of objects",
 ]
 
 FORBIDDEN_ROUTE_PATTERNS = [
@@ -80,6 +91,27 @@ else:
         text_without_disclaimer = route_text.replace("no marketplace or reputation claim", "")
         if re.search(pattern, text_without_disclaimer, flags=re.IGNORECASE):
             errors.append(f"route has forbidden claim language: {pattern}")
+
+
+for path, label in [(SCHEMA_ROUTE, "schema route"), (JWKS_ROUTE, "JWKS route")]:
+    if not path.exists():
+        errors.append(f"missing {label}: {path.relative_to(ROOT)}")
+    else:
+        text = path.read_text()
+        for needle in ["Response.json", "Cache-Control", "Access-Control-Allow-Origin", "X-Content-Type-Options"]:
+            if needle not in text:
+                errors.append(f"{label} missing required HTTP/header string: {needle}")
+
+if SCHEMA_ROUTE.exists():
+    schema_text = SCHEMA_ROUTE.read_text()
+    for needle in ["SatGate Trust Metadata v1", "schema_version", "rails_adapters", "supported", "id", "type", "role"]:
+        if needle not in schema_text:
+            errors.append(f"schema route missing required schema string: {needle}")
+
+if JWKS_ROUTE.exists():
+    jwks_text = JWKS_ROUTE.read_text()
+    if "keys: []" not in jwks_text:
+        errors.append("JWKS route should currently expose an empty keys array rather than placeholder signing keys")
 
 build_text = BUILD.read_text() if BUILD.exists() else ""
 for needle in REQUIRED_BUILD_STRINGS:


### PR DESCRIPTION
## Summary
- Hardens `/.well-known/satgate` before the contract ossifies: adds `schema_url`, explicit `roles: ["issuer"]`, issuer `key_discovery.jwks_uri`, and structured rail adapter objects.
- Adds live JSON routes for `/.well-known/satgate.schema.json` and `/.well-known/jwks.json` with the same CORS/cache/nosniff hygiene.
- Updates docs to codify additive-only v1 compatibility, closed decision enum, structured rails, issuer JWKS discovery, and the future acceptor-side metadata sketch.
- Extends `npm run test:well-known` guard to catch schema/JWKS/header/contract drift.

## Verification
- `npm run test:well-known`
- `npm run test:build-page`
- `npm run test:proof-spine`
- `npm ci && npm run build`
- Local HTTP checks for `/.well-known/satgate`, `/.well-known/satgate.schema.json`, and `/.well-known/jwks.json`: 200, valid JSON, `Content-Type: application/json`, `Cache-Control: public, max-age=3600`, `Access-Control-Allow-Origin: *`, `X-Content-Type-Options: nosniff`.
