### PR TITLE
fix: polish SatGate trust metadata contract

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -30,6 +30,7 @@ SatGate Gateway is an enterprise API gateway that provides:
 | See the API reference | [API Reference](api/overview.md) |
 | Export Policy-to-Proof evidence | [Evidence Pack v1](reference/evidence-pack.md) |
 | Discover SatGate trust metadata | [SatGate Trust Metadata](reference/satgate-trust-metadata.md) |
+| Sketch upstream acceptor metadata | [Acceptor Metadata Draft](reference/acceptor.md) |
 | Run in production | [Production Checklist](operations/production-checklist.md) |
 | **Enterprise: Economic Firewall** | [Economic Firewall Quickstart](getting-started/economic-firewall-quickstart.md) |
 | **Enterprise: Team Management** | [Team Management Guide](enterprise/TEAM_MANAGEMENT.md) |

--- a/docs/reference/acceptor.md
+++ b/docs/reference/acceptor.md
@@ -1,0 +1,78 @@
+# SatGate Acceptor Metadata Draft
+
+Status: **v0.0 draft — not yet on the wire**.
+
+This document reserves the mirror side of the SatGate trust metadata model before issuer-side `satgate.trust_metadata.v1` ossifies in downstream parsers. It is intentionally documentation-only until an upstream service actually accepts SatGate capabilities.
+
+## Purpose
+
+Issuer metadata answers: “What capabilities can this issuer mint, and how do I verify its receipts?”
+
+Acceptor metadata should answer: “What capabilities will this upstream accept, from which issuers, and on which rails can it settle?”
+
+## Candidate discovery path
+
+Two options are still open:
+
+- Same path, role-selected: `/.well-known/satgate` with `roles: ["acceptor"]` or `roles: ["issuer", "acceptor"]`.
+- Companion path: `/.well-known/satgate-upstream` for upstream-only services.
+
+The compatibility rule is the same: clients must ignore unknown fields, and breaking field changes require a new schema version.
+
+## Candidate fields
+
+```json
+{
+  "schema_version": "satgate.acceptor_metadata.v0",
+  "metadata_url": "https://api.example.com/.well-known/satgate",
+  "schema_url": "https://satgate.io/.well-known/satgate-acceptor.schema.json",
+  "roles": ["acceptor"],
+  "acceptor": {
+    "name": "Example API",
+    "acceptor_id": "https://api.example.com",
+    "verification_endpoint": "https://api.example.com/satgate/verify"
+  },
+  "accepted_capability_formats": [
+    "satgate.capability.v1",
+    "macaroon-bearer"
+  ],
+  "accepted_receipt_decisions": [
+    "allowed",
+    "delegated",
+    "paid"
+  ],
+  "trust_anchors": [
+    {
+      "issuer_id": "https://satgate.io",
+      "jwks_uri": "https://satgate.io/.well-known/jwks.json",
+      "status": "accepted"
+    }
+  ],
+  "rails_adapters": {
+    "accepted": [
+      { "id": "mcp", "type": "protocol", "role": "tool_transport", "status": "supported" },
+      { "id": "x402", "type": "payment_rail", "role": "external_paid_access", "status": "supported" }
+    ]
+  }
+}
+```
+
+## Field notes
+
+- `verification_endpoint`: optional upstream endpoint for online verification, replay checks, or policy-specific acceptance decisions. Offline signature checks should still use issuer JWKS discovery when possible.
+- `accepted_capability_formats`: subset of capability formats the upstream honors. An acceptor does not need to accept every format an issuer can emit.
+- `accepted_receipt_decisions`: subset of receipt decisions the upstream treats as acceptable evidence for entry. For example, a read-only upstream may accept `allowed` and reject `paid`.
+- `trust_anchors`: issuer origins the upstream accepts, optionally pinned to JWKS URIs or future certificate transparency/audit roots.
+- `rails_adapters.accepted`: rails the upstream can settle on or route through.
+
+## Non-goals
+
+- No marketplace, ranking, reputation, endorsement, or compliance claim.
+- No fake acceptor role in the public SatGate issuer artifact.
+- No requirement that SatGate stay in the request path after an upstream can verify receipts and capabilities directly.
+
+## Open questions
+
+- Whether acceptor metadata belongs under the same `satgate.trust_metadata.v1` schema or a sibling acceptor schema.
+- Whether `trust_anchors` should support key pinning, issuer catalogs, or both.
+- Whether online verification endpoints should be required for paid rails or only recommended for replay-sensitive routes.

--- a/docs/reference/satgate-trust-metadata.md
+++ b/docs/reference/satgate-trust-metadata.md
@@ -38,9 +38,11 @@ Treat this like a versioned API:
 - `issuer`: SatGate issuer identity and key-discovery metadata for the public artifact.
 - `capability_acceptance`: accepted capability/token formats, bearer schemes, required claims, caveats, and delegation-depth semantics.
 - `receipt_verification`: receipt and Evidence Pack formats, required receipt fields, supported decision labels, verification endpoint, and Evidence Pack schema URL.
-- `rails_adapters`: supported rails/adapters beneath SatGate authority and receipts, as structured objects.
+- `rails_adapters`: rail/protocol/billing adapter catalog beneath SatGate authority and receipts, as structured objects with explicit `status`.
 - `signing_key_discovery`: issuer-key discovery rule for `issuer_kid` verification.
-- `docs`: human-readable links for builders and auditors.
+- `docs`: human-readable links for builders, verifiers, and auditors.
+
+Human explanations belong in this document, not in prose-only `note` fields inside the machine artifact.
 
 ## Capability acceptance
 
@@ -66,6 +68,8 @@ Receipts are the proof spine. A verifier should expect receipt-grade decisions t
 
 - `receipt_id`
 - `evidence_pack_id`
+- `issuer`
+- `issuer_kid`
 - `decision`
 - `decision_reason`
 - `policy_version`
@@ -88,29 +92,32 @@ https://satgate.io/evidence-packs/evidence-pack.schema.v1.json
 
 ## Rails/adapters
 
-The artifact lists supported rails/adapters as an array of objects, not free strings:
+The artifact lists rail/protocol/billing adapters as an array of objects, not free strings:
 
 ```json
 {
   "id": "x402",
   "type": "payment_rail",
-  "role": "external_paid_access"
+  "role": "external_paid_access",
+  "status": "supported"
 }
 ```
 
-Current adapter IDs:
+Current adapter catalog:
 
-- `mcp`
-- `x402`
-- `l402`
-- `api_key_billing`
-- `enterprise_ledger`
+- `mcp`: `protocol` / `tool_transport` / `supported`
+- `x402`: `payment_rail` / `external_paid_access` / `supported`
+- `l402`: `payment_rail` / `external_paid_access` / `supported`
+- `api_key_billing`: `billing_adapter` / `existing_vendor_billing` / `supported`
+- `enterprise_ledger`: `ledger_adapter` / `internal_chargeback` / `supported`
+- `agentcore_payments`: `payment_rail` / `external_paid_access` / `planned`
+- `pay_sh`: `payment_rail` / `external_paid_access` / `planned`
 
-Rails sit below authority and receipt verification. SatGate proof is the receipt/Evidence Pack layer around the rail.
+Rails sit below authority and receipt verification. SatGate proof is the receipt/Evidence Pack layer around the rail. Marketing copy may mention planned rails, but the well-known artifact is canonical for whether a rail is currently supported or planned.
 
 ## Signing key discovery
 
-The `issuer` block exposes key discovery as:
+The `issuer` block exposes key discovery for the manifest publisher as:
 
 ```json
 {
@@ -120,36 +127,112 @@ The `issuer` block exposes key discovery as:
 }
 ```
 
-`signing_key_discovery.mode` is `issuer_discovery` and keeps the general rule:
+The federation rule is:
 
 ```text
 {issuer_id}/.well-known/jwks.json
 ```
 
-Receipts reference an `issuer_kid`. Verifiers should resolve the issuer from the receipt or Evidence Pack, then discover issuer keys using the issuer's JWKS URI. Tenant or deployment issuers may publish their own JWKS endpoint. The public `satgate.io` JWKS route currently publishes an empty `keys` array instead of placeholder production tenant keys.
+Receipts reference both an issuer and an `issuer_kid`. Verifiers must first authorize the issuer origin against configured trust anchors, then fetch that issuer's JWKS, select the key by `issuer_kid`, and verify the receipt signature. Tenant or deployment issuers may publish their own JWKS endpoint. The public `satgate.io` JWKS route currently publishes an empty `keys` array instead of placeholder production tenant keys.
+
+Do **not** treat the top-level `https://satgate.io/.well-known/jwks.json` as the universal key source for every receipt. It only represents the `https://satgate.io` issuer. Also do **not** trust any issuer URL found in a receipt until it matches an acceptor-configured trust anchor; otherwise an attacker can publish their own JWKS and sign their own fake receipt.
+
+## Reference verifier snippets
+
+These snippets show the discovery sequence only. Production verifiers must also canonicalize the signed payload, enforce expiry/replay checks, and verify the signature with the algorithm declared by the selected JWK.
+
+### Python
+
+```python
+import json
+from urllib.request import urlopen
+
+
+TRUSTED_ISSUERS = {"https://satgate.io"}
+
+
+def load_jwks_for_receipt(receipt: dict) -> dict:
+    issuer_id = receipt["issuer"].rstrip("/")
+    issuer_kid = receipt["issuer_kid"]
+    if issuer_id not in TRUSTED_ISSUERS:
+        raise PermissionError(f"untrusted receipt issuer: {issuer_id}")
+    jwks_url = issuer_id + "/.well-known/jwks.json"
+
+    with urlopen(jwks_url, timeout=10) as response:
+        jwks = json.load(response)
+
+    for key in jwks.get("keys", []):
+        if key.get("kid") == issuer_kid:
+            return key
+    raise LookupError(f"issuer key not found: {issuer_id} kid={issuer_kid}")
+
+
+def verify_receipt(receipt: dict) -> bool:
+    key = load_jwks_for_receipt(receipt)
+    # Verify receipt["signature"] over the canonical receipt payload with `key`.
+    # Keep this line explicit so implementers do not accidentally fetch satgate.io's empty JWKS for tenant receipts.
+    return bool(key)
+```
+
+### Node.js
+
+```ts
+type Receipt = {
+  issuer: string;
+  issuer_kid: string;
+  signature: string;
+};
+
+const trustedIssuers = new Set(["https://satgate.io"]);
+
+export async function loadJwksKeyForReceipt(receipt: Receipt) {
+  const issuer = receipt.issuer.replace(/\/$/, "");
+  if (!trustedIssuers.has(issuer)) throw new Error(`untrusted receipt issuer: ${issuer}`);
+  const jwksUrl = `${issuer}/.well-known/jwks.json`;
+  const response = await fetch(jwksUrl, { headers: { accept: "application/json" } });
+  if (!response.ok) throw new Error(`JWKS fetch failed: ${response.status}`);
+
+  const jwks = await response.json() as { keys?: Array<{ kid?: string }> };
+  const key = jwks.keys?.find((candidate) => candidate.kid === receipt.issuer_kid);
+  if (!key) throw new Error(`issuer key not found: ${receipt.issuer} kid=${receipt.issuer_kid}`);
+  return key;
+}
+
+export async function verifyReceipt(receipt: Receipt) {
+  const key = await loadJwksKeyForReceipt(receipt);
+  // Verify receipt.signature over the canonical receipt payload with `key`.
+  // Do not fetch satgate.io's empty JWKS unless receipt.issuer === "https://satgate.io".
+  return Boolean(key);
+}
+```
 
 ## Future acceptor-side metadata
 
-The mirror artifact is intentionally not shipped yet. The likely shape is either a future `roles: ["acceptor"]` profile in this schema or a companion `/.well-known/satgate-upstream` document advertising:
+The mirror artifact is intentionally not on the wire yet. A draft is tracked in [Acceptor Metadata Draft](acceptor.md). An acceptor needs to advertise at least:
 
-- accepted capability formats
-- verification endpoint
-- accepted receipt decisions
-- rails/adapters the upstream settles on
-- issuer allowlist or key-discovery policy
+- `verification_endpoint`
+- `accepted_capability_formats`
+- `accepted_receipt_decisions`
+- `trust_anchors` / issuer allowlist
+- rails/adapters it can settle on
 
 Do not add acceptor claims to the issuer artifact until an upstream actually accepts SatGate capabilities.
 
 ## HTTP requirements
 
-The live path must return:
+The live manifest path must return:
 
 - `200 OK`
 - `Content-Type: application/json`
 - `Cache-Control: public, max-age=3600`
 - `Access-Control-Allow-Origin: *`
 - `X-Content-Type-Options: nosniff`
+- `Vary: Accept-Encoding`
 - valid JSON matching `satgate.trust_metadata.v1`
+
+The schema path may use a longer cache TTL because it changes less often:
+
+- `https://satgate.io/.well-known/satgate.schema.json`: `Cache-Control: public, max-age=86400`
 
 ## Verification
 
@@ -168,14 +251,20 @@ with urllib.request.urlopen(url, timeout=20) as r:
     assert 'application/json' in r.headers['content-type']
     assert r.headers['cache-control'] == 'public, max-age=3600'
     assert r.headers['access-control-allow-origin'] == '*'
+    assert r.headers['x-content-type-options'] == 'nosniff'
+    assert 'Accept-Encoding' in r.headers.get('vary', '')
     data = json.load(r)
 assert data['schema_version'] == 'satgate.trust_metadata.v1'
 assert data['schema_url'] == 'https://satgate.io/.well-known/satgate.schema.json'
 assert data['roles'] == ['issuer']
 assert 'satgate.capability.v1' in data['capability_acceptance']['accepted_formats']
-assert 'receipt_id' in data['receipt_verification']['required_receipt_fields']
+assert {'receipt_id', 'issuer', 'issuer_kid'} <= set(data['receipt_verification']['required_receipt_fields'])
 assert set(data['receipt_verification']['decisions']) == {'allowed','denied','delegated','revoked','paid'}
 assert isinstance(data['rails_adapters']['supported'][0], dict)
+adapters = {adapter['id']: adapter for adapter in data['rails_adapters']['supported']}
+assert adapters['agentcore_payments']['status'] == 'planned'
+assert adapters['pay_sh']['status'] == 'planned'
+assert {adapter['status'] for adapter in adapters.values()} <= {'supported','planned'}
 assert data['issuer']['key_discovery']['method'] == 'jwks_uri'
 print('satgate trust metadata ok')
 PY

--- a/satgate-landing/app/.well-known/jwks.json/route.ts
+++ b/satgate-landing/app/.well-known/jwks.json/route.ts
@@ -1,6 +1,5 @@
 const jwks = {
   keys: [],
-  note: "SatGate tenant or deployment issuers publish signing keys at their issuer-specific JWKS URI. The public satgate.io metadata issuer does not expose tenant receipt-signing keys here.",
 } as const;
 
 export const dynamic = "force-static";
@@ -11,6 +10,7 @@ export function GET() {
       "Cache-Control": "public, max-age=3600",
       "Access-Control-Allow-Origin": "*",
       "X-Content-Type-Options": "nosniff",
+      "Vary": "Accept-Encoding",
     },
   });
 }

--- a/satgate-landing/app/.well-known/satgate.schema.json/route.ts
+++ b/satgate-landing/app/.well-known/satgate.schema.json/route.ts
@@ -2,6 +2,7 @@ const schema = {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://satgate.io/.well-known/satgate.schema.json",
   title: "SatGate Trust Metadata v1",
+  description: "Machine-readable discovery metadata for SatGate capability issuance, receipt verification, rail-adapter status, and issuer-key discovery.",
   type: "object",
   required: [
     "schema_version",
@@ -16,56 +17,108 @@ const schema = {
     "docs",
   ],
   properties: {
-    schema_version: { const: "satgate.trust_metadata.v1" },
-    metadata_url: { type: "string", format: "uri" },
-    schema_url: { type: "string", format: "uri" },
-    roles: { type: "array", items: { enum: ["issuer", "acceptor"] }, minItems: 1 },
+    schema_version: {
+      const: "satgate.trust_metadata.v1",
+      description: "Additive-only v1 schema identifier. Breaking changes require a new schema_version.",
+    },
+    metadata_url: {
+      type: "string",
+      format: "uri",
+      description: "Canonical URL for this metadata artifact.",
+    },
+    schema_url: {
+      type: "string",
+      format: "uri",
+      description: "Canonical JSON Schema URL for this metadata version.",
+    },
+    roles: {
+      type: "array",
+      description: "Metadata roles this artifact asserts. The public SatGate artifact is issuer-side only.",
+      items: { enum: ["issuer", "acceptor"] },
+      minItems: 1,
+      uniqueItems: true,
+    },
     issuer: {
       type: "object",
+      description: "Issuer identity and issuer JWKS discovery metadata for this artifact.",
       required: ["name", "issuer_id", "product", "contact", "key_discovery"],
       properties: {
-        name: { type: "string" },
-        issuer_id: { type: "string", format: "uri" },
-        product: { type: "string" },
-        contact: { type: "string" },
+        name: { type: "string", description: "Human-readable issuer name." },
+        issuer_id: { type: "string", format: "uri", description: "Origin-style issuer identifier." },
+        product: { type: "string", description: "Human-readable product/category descriptor." },
+        contact: { type: "string", description: "Operational contact for metadata consumers." },
         key_discovery: {
           type: "object",
+          description: "JWKS discovery location for this manifest publisher/issuer.",
           required: ["method", "key_id_field", "jwks_uri"],
           properties: {
-            method: { const: "jwks_uri" },
-            key_id_field: { const: "issuer_kid" },
-            jwks_uri: { type: "string", format: "uri" },
+            method: { const: "jwks_uri", description: "Key discovery uses a JSON Web Key Set endpoint." },
+            key_id_field: { const: "issuer_kid", description: "Receipt field that selects the signing key." },
+            jwks_uri: { type: "string", format: "uri", description: "JWKS URL for this issuer." },
           },
           additionalProperties: true,
         },
       },
       additionalProperties: true,
     },
-    capability_acceptance: { type: "object", additionalProperties: true },
+    capability_acceptance: {
+      type: "object",
+      description: "Capability/token formats, authorization schemes, required claims, caveats, and delegation-depth semantics accepted by this issuer profile.",
+      additionalProperties: true,
+    },
     receipt_verification: {
       type: "object",
+      description: "Receipt and Evidence Pack formats, required receipt fields, closed decision vocabulary, and verification endpoints.",
       required: ["receipt_format", "evidence_pack_format", "required_receipt_fields", "decisions"],
       properties: {
+        required_receipt_fields: {
+          type: "array",
+          description: "Receipt fields needed to identify the issuer, select the signing key, verify the decision, and bind the receipt to an Evidence Pack.",
+          items: {
+            enum: [
+              "receipt_id",
+              "evidence_pack_id",
+              "issuer",
+              "issuer_kid",
+              "decision",
+              "decision_reason",
+              "policy_version",
+              "receipt_hash",
+              "signature",
+            ],
+          },
+          uniqueItems: true,
+          allOf: [
+            { contains: { const: "issuer" } },
+            { contains: { const: "issuer_kid" } },
+          ],
+        },
         decisions: {
           type: "array",
+          description: "Closed v1 decision vocabulary emitted in SatGate receipts.",
           items: { enum: ["allowed", "denied", "delegated", "revoked", "paid"] },
+          uniqueItems: true,
         },
       },
       additionalProperties: true,
     },
     rails_adapters: {
       type: "object",
+      description: "Rail/protocol/billing adapters governed beneath SatGate authority and receipt verification.",
       required: ["supported"],
       properties: {
         supported: {
           type: "array",
+          description: "Known adapter catalog. Consumers should key on id and treat status=planned as not currently supported.",
+          uniqueItems: true,
           items: {
             type: "object",
-            required: ["id", "type", "role"],
+            required: ["id", "type", "role", "status"],
             properties: {
-              id: { type: "string" },
-              type: { type: "string" },
-              role: { type: "string" },
+              id: { type: "string", description: "Stable adapter identifier." },
+              type: { type: "string", description: "Adapter category, such as protocol, payment_rail, billing_adapter, or ledger_adapter." },
+              role: { type: "string", description: "Adapter role under SatGate authority/proof." },
+              status: { enum: ["supported", "planned"], description: "Current support status for this adapter id." },
             },
             additionalProperties: true,
           },
@@ -73,8 +126,22 @@ const schema = {
       },
       additionalProperties: true,
     },
-    signing_key_discovery: { type: "object", additionalProperties: true },
-    docs: { type: "object", additionalProperties: true },
+    signing_key_discovery: {
+      type: "object",
+      description: "General federation rule: verify receipts against the trusted issuer origin's JWKS selected by issuer_kid.",
+      required: ["mode", "key_id_field", "jwks_uri_template"],
+      properties: {
+        mode: { const: "issuer_discovery", description: "Keys are discovered from the trusted receipt issuer origin." },
+        key_id_field: { const: "issuer_kid", description: "Receipt field that selects the issuer signing key." },
+        jwks_uri_template: { const: "{issuer_id}/.well-known/jwks.json", description: "JWKS discovery template after the issuer_id has matched an acceptor trust anchor." },
+      },
+      additionalProperties: true,
+    },
+    docs: {
+      type: "object",
+      description: "Human-readable documentation links for builders, verifiers, and auditors.",
+      additionalProperties: true,
+    },
   },
   additionalProperties: true,
 } as const;
@@ -84,9 +151,10 @@ export const dynamic = "force-static";
 export function GET() {
   return Response.json(schema, {
     headers: {
-      "Cache-Control": "public, max-age=3600",
+      "Cache-Control": "public, max-age=86400",
       "Access-Control-Allow-Origin": "*",
       "X-Content-Type-Options": "nosniff",
+      "Vary": "Accept-Encoding",
     },
   });
 }

--- a/satgate-landing/app/.well-known/satgate/route.ts
+++ b/satgate-landing/app/.well-known/satgate/route.ts
@@ -42,6 +42,8 @@ const metadata = {
     required_receipt_fields: [
       "receipt_id",
       "evidence_pack_id",
+      "issuer",
+      "issuer_kid",
       "decision",
       "decision_reason",
       "policy_version",
@@ -54,24 +56,26 @@ const metadata = {
   },
   rails_adapters: {
     supported: [
-      { id: "mcp", type: "protocol", role: "tool_transport" },
-      { id: "x402", type: "payment_rail", role: "external_paid_access" },
-      { id: "l402", type: "payment_rail", role: "external_paid_access" },
-      { id: "api_key_billing", type: "billing_adapter", role: "existing_vendor_billing" },
-      { id: "enterprise_ledger", type: "ledger_adapter", role: "internal_chargeback" },
+      { id: "mcp", type: "protocol", role: "tool_transport", status: "supported" },
+      { id: "x402", type: "payment_rail", role: "external_paid_access", status: "supported" },
+      { id: "l402", type: "payment_rail", role: "external_paid_access", status: "supported" },
+      { id: "api_key_billing", type: "billing_adapter", role: "existing_vendor_billing", status: "supported" },
+      { id: "enterprise_ledger", type: "ledger_adapter", role: "internal_chargeback", status: "supported" },
+      { id: "agentcore_payments", type: "payment_rail", role: "external_paid_access", status: "planned" },
+      { id: "pay_sh", type: "payment_rail", role: "external_paid_access", status: "planned" },
     ],
-    note: "Rails are adapters below SatGate authority and receipt verification; this metadata makes no marketplace or reputation claim.",
   },
   signing_key_discovery: {
     mode: "issuer_discovery",
     key_id_field: "issuer_kid",
     jwks_uri_template: "{issuer_id}/.well-known/jwks.json",
-    note: "Verify receipts against the issuer key referenced by issuer_kid. Tenant or deployment issuers may publish their own JWKS endpoint.",
   },
   docs: {
     build: "https://satgate.io/build",
     policy_to_proof: "https://satgate.io/policy-to-proof",
     evidence_pack_reference: "https://github.com/SatGate-io/satgate/blob/main/docs/reference/evidence-pack.md",
+    trust_metadata_reference: "https://github.com/SatGate-io/satgate/blob/main/docs/reference/satgate-trust-metadata.md",
+    acceptor_metadata_draft: "https://github.com/SatGate-io/satgate/blob/main/docs/reference/acceptor.md",
     api_docs: "https://cloud.satgate.io/docs",
   },
 } as const;
@@ -84,6 +88,7 @@ export function GET() {
       "Cache-Control": "public, max-age=3600",
       "Access-Control-Allow-Origin": "*",
       "X-Content-Type-Options": "nosniff",
+      "Vary": "Accept-Encoding",
     },
   });
 }

--- a/satgate-landing/app/build/page.tsx
+++ b/satgate-landing/app/build/page.tsx
@@ -293,7 +293,10 @@ export default function BuildPage() {
             <h2 className="text-3xl font-bold text-white sm:text-4xl">Authority and evidence sit above the rail.</h2>
             <div className="mt-5 space-y-5 text-lg leading-8 text-gray-400">
               <p>
-                Payment rails change. The authority and evidence layer is the durable abstraction. SatGate can govern MCP tools, REST APIs, API-key billing, x402, L402, AgentCore Payments, Pay.sh, and enterprise ledgers without forcing your agent code to care which rail settled underneath.
+                Payment rails change. The authority and evidence layer is the durable abstraction. SatGate governs MCP tools, REST APIs, API-key billing, x402, L402, and enterprise ledgers today, and is designed to govern planned rails such as AgentCore Payments and Pay.sh without forcing your agent code to care which rail settled underneath.
+              </p>
+              <p>
+                The machine-readable <Link href="/.well-known/satgate" className="text-cyan-300 hover:text-cyan-200">/.well-known/satgate</Link> artifact is canonical for rail adapter status; marketing copy should defer to it when a rail is planned rather than already supported.
               </p>
               <p>
                 Humans and platforms deploy the policies. Agents consume capabilities. Upstreams receive verifiable proof that the action was authorized, bounded, and recorded.

--- a/satgate-landing/next.config.ts
+++ b/satgate-landing/next.config.ts
@@ -15,6 +15,12 @@ const nextConfig: NextConfig = {
   async headers() {
     return [
       {
+        source: "/.well-known/:path*",
+        headers: [
+          { key: "Vary", value: "Accept-Encoding" },
+        ],
+      },
+      {
         source: "/(.*)",
         headers: [
           { key: "X-Content-Type-Options", value: "nosniff" },

--- a/satgate-landing/scripts/check_well_known_satgate.py
+++ b/satgate-landing/scripts/check_well_known_satgate.py
@@ -12,6 +12,7 @@ SCHEMA_ROUTE = ROOT / "app" / ".well-known" / "satgate.schema.json" / "route.ts"
 JWKS_ROUTE = ROOT / "app" / ".well-known" / "jwks.json" / "route.ts"
 BUILD = ROOT / "app" / "build" / "page.tsx"
 DOC = ROOT.parent / "docs" / "reference" / "satgate-trust-metadata.md"
+ACCEPTOR_DOC = ROOT.parent / "docs" / "reference" / "acceptor.md"
 DOC_INDEX = ROOT.parent / "docs" / "index.md"
 PACKAGE = ROOT / "package.json"
 
@@ -29,6 +30,8 @@ REQUIRED_ROUTE_STRINGS = [
     "satgate.evidence_pack.v1",
     "receipt_id",
     "evidence_pack_id",
+    "issuer",
+    "issuer_kid",
     "decision_reason",
     "policy_version",
     "rails_adapters",
@@ -36,6 +39,10 @@ REQUIRED_ROUTE_STRINGS = [
     "l402",
     "api_key_billing",
     "enterprise_ledger",
+    "agentcore_payments",
+    "pay_sh",
+    "status: \"supported\"",
+    "status: \"planned\"",
     "type: \"payment_rail\"",
     "role: \"external_paid_access\"",
     "key_discovery",
@@ -47,6 +54,7 @@ REQUIRED_ROUTE_STRINGS = [
     "public, max-age=3600",
     "Access-Control-Allow-Origin",
     "X-Content-Type-Options",
+    "Vary",
 ]
 
 REQUIRED_BUILD_STRINGS = [
@@ -54,6 +62,7 @@ REQUIRED_BUILD_STRINGS = [
     "/.well-known/satgate",
     "capability acceptance",
     "receipt verification fields",
+    "canonical for rail adapter status",
 ]
 
 REQUIRED_DOC_STRINGS = [
@@ -67,6 +76,12 @@ REQUIRED_DOC_STRINGS = [
     "schema_url",
     "jwks_uri",
     "array of objects",
+    "Reference verifier snippets",
+    "Acceptor Metadata Draft",
+    "agentcore_payments",
+    "pay_sh",
+    "TRUSTED_ISSUERS",
+    "untrusted receipt issuer",
 ]
 
 FORBIDDEN_ROUTE_PATTERNS = [
@@ -87,10 +102,16 @@ else:
         if needle not in route_text:
             errors.append(f"route missing required string: {needle}")
     for pattern in FORBIDDEN_ROUTE_PATTERNS:
-        # Permit the explicit disclaimer phrase "no marketplace or reputation claim".
-        text_without_disclaimer = route_text.replace("no marketplace or reputation claim", "")
-        if re.search(pattern, text_without_disclaimer, flags=re.IGNORECASE):
+        if re.search(pattern, route_text, flags=re.IGNORECASE):
             errors.append(f"route has forbidden claim language: {pattern}")
+    if re.search(r"\bnote\s*:", route_text):
+        errors.append("route should not contain prose-only note fields; keep human explanations in docs")
+    if '"issuer_kid"' not in route_text or '"issuer"' not in route_text:
+        errors.append("route required_receipt_fields must include issuer and issuer_kid")
+    for planned_id in ["agentcore_payments", "pay_sh"]:
+        planned_pattern = rf'{{ id: "{planned_id}"[^}}]+status: "planned"'
+        if not re.search(planned_pattern, route_text):
+            errors.append(f"route must mark {planned_id} as planned, not supported")
 
 
 for path, label in [(SCHEMA_ROUTE, "schema route"), (JWKS_ROUTE, "JWKS route")]:
@@ -98,13 +119,13 @@ for path, label in [(SCHEMA_ROUTE, "schema route"), (JWKS_ROUTE, "JWKS route")]:
         errors.append(f"missing {label}: {path.relative_to(ROOT)}")
     else:
         text = path.read_text()
-        for needle in ["Response.json", "Cache-Control", "Access-Control-Allow-Origin", "X-Content-Type-Options"]:
+        for needle in ["Response.json", "Cache-Control", "Access-Control-Allow-Origin", "X-Content-Type-Options", "Vary"]:
             if needle not in text:
                 errors.append(f"{label} missing required HTTP/header string: {needle}")
 
 if SCHEMA_ROUTE.exists():
     schema_text = SCHEMA_ROUTE.read_text()
-    for needle in ["SatGate Trust Metadata v1", "schema_version", "rails_adapters", "supported", "id", "type", "role"]:
+    for needle in ["SatGate Trust Metadata v1", "description", "schema_version", "roles", "uniqueItems", "required_receipt_fields", "issuer_kid", "allOf", "contains", "rails_adapters", "supported", "id", "type", "role", "status", "planned", "public, max-age=86400"]:
         if needle not in schema_text:
             errors.append(f"schema route missing required schema string: {needle}")
 
@@ -112,20 +133,33 @@ if JWKS_ROUTE.exists():
     jwks_text = JWKS_ROUTE.read_text()
     if "keys: []" not in jwks_text:
         errors.append("JWKS route should currently expose an empty keys array rather than placeholder signing keys")
+    if re.search(r"\bnote\s*:", jwks_text):
+        errors.append("JWKS route should not contain prose-only note fields")
 
 build_text = BUILD.read_text() if BUILD.exists() else ""
 for needle in REQUIRED_BUILD_STRINGS:
     if needle not in build_text:
         errors.append(f"/build missing trust metadata string: {needle}")
+if "governs MCP tools, REST APIs, API-key billing, x402, L402, and enterprise ledgers today" not in build_text:
+    errors.append("/build should separate supported rails from planned rails")
+if "planned rails such as AgentCore Payments and Pay.sh" not in build_text:
+    errors.append("/build should call AgentCore Payments and Pay.sh planned rails")
 
 doc_text = DOC.read_text() if DOC.exists() else ""
 for needle in REQUIRED_DOC_STRINGS:
     if needle not in doc_text:
         errors.append(f"docs missing trust metadata string: {needle}")
 
+acceptor_text = ACCEPTOR_DOC.read_text() if ACCEPTOR_DOC.exists() else ""
+for needle in ["v0.0 draft", "verification_endpoint", "accepted_capability_formats", "trust_anchors", "rails_adapters", "not yet on the wire"]:
+    if needle not in acceptor_text:
+        errors.append(f"acceptor draft missing required string: {needle}")
+
 index_text = DOC_INDEX.read_text() if DOC_INDEX.exists() else ""
 if "reference/satgate-trust-metadata.md" not in index_text:
     errors.append("docs index does not link satgate-trust-metadata reference")
+if "reference/acceptor.md" not in index_text:
+    errors.append("docs index does not link acceptor metadata draft")
 
 package_text = PACKAGE.read_text() if PACKAGE.exists() else ""
 if "test:well-known" not in package_text:


### PR DESCRIPTION
## Summary
- add planned rail status for AgentCore Payments and Pay.sh in `/.well-known/satgate`
- require `issuer` and `issuer_kid` in receipt verification metadata
- remove prose-only note fields from machine artifacts; keep explanation in docs
- add trust-anchor-first JWKS verifier snippets for Python and Node
- add acceptor metadata draft before issuer-side parsers ossify
- add schema descriptions, `uniqueItems`, status enum, and stronger required receipt-field schema
- add `Vary: Accept-Encoding` and a longer cache TTL for the schema route

## Test Plan
- `npm run test:well-known`
- `npm run test:build-page`
- `npm run test:proof-spine`
- `npm run test:demo-ia`
- `npm run build`
- local HTTP verification of all three `.well-known` routes on `next start -p 3107`
