### PR TITLE
fix: align trust metadata header contract with live CDN

### DIFF
--- a/docs/reference/satgate-trust-metadata.md
+++ b/docs/reference/satgate-trust-metadata.md
@@ -227,12 +227,13 @@ The live manifest path must return:
 - `Cache-Control: public, max-age=3600`
 - `Access-Control-Allow-Origin: *`
 - `X-Content-Type-Options: nosniff`
-- `Vary: Accept-Encoding`
 - valid JSON matching `satgate.trust_metadata.v1`
 
-The schema path may use a longer cache TTL because it changes less often:
+The schema path uses a longer cache TTL because it changes less often:
 
 - `https://satgate.io/.well-known/satgate.schema.json`: `Cache-Control: public, max-age=86400`
+
+`Vary` is platform-managed by the CDN/framework and should not be treated as part of the SatGate metadata contract.
 
 ## Verification
 
@@ -252,7 +253,6 @@ with urllib.request.urlopen(url, timeout=20) as r:
     assert r.headers['cache-control'] == 'public, max-age=3600'
     assert r.headers['access-control-allow-origin'] == '*'
     assert r.headers['x-content-type-options'] == 'nosniff'
-    assert 'Accept-Encoding' in r.headers.get('vary', '')
     data = json.load(r)
 assert data['schema_version'] == 'satgate.trust_metadata.v1'
 assert data['schema_url'] == 'https://satgate.io/.well-known/satgate.schema.json'

--- a/satgate-landing/app/.well-known/jwks.json/route.ts
+++ b/satgate-landing/app/.well-known/jwks.json/route.ts
@@ -10,7 +10,6 @@ export function GET() {
       "Cache-Control": "public, max-age=3600",
       "Access-Control-Allow-Origin": "*",
       "X-Content-Type-Options": "nosniff",
-      "Vary": "Accept-Encoding",
     },
   });
 }

--- a/satgate-landing/app/.well-known/satgate.schema.json/route.ts
+++ b/satgate-landing/app/.well-known/satgate.schema.json/route.ts
@@ -154,7 +154,6 @@ export function GET() {
       "Cache-Control": "public, max-age=86400",
       "Access-Control-Allow-Origin": "*",
       "X-Content-Type-Options": "nosniff",
-      "Vary": "Accept-Encoding",
     },
   });
 }

--- a/satgate-landing/app/.well-known/satgate/route.ts
+++ b/satgate-landing/app/.well-known/satgate/route.ts
@@ -88,7 +88,6 @@ export function GET() {
       "Cache-Control": "public, max-age=3600",
       "Access-Control-Allow-Origin": "*",
       "X-Content-Type-Options": "nosniff",
-      "Vary": "Accept-Encoding",
     },
   });
 }

--- a/satgate-landing/next.config.ts
+++ b/satgate-landing/next.config.ts
@@ -15,12 +15,6 @@ const nextConfig: NextConfig = {
   async headers() {
     return [
       {
-        source: "/.well-known/:path*",
-        headers: [
-          { key: "Vary", value: "Accept-Encoding" },
-        ],
-      },
-      {
         source: "/(.*)",
         headers: [
           { key: "X-Content-Type-Options", value: "nosniff" },

--- a/satgate-landing/scripts/check_well_known_satgate.py
+++ b/satgate-landing/scripts/check_well_known_satgate.py
@@ -54,7 +54,6 @@ REQUIRED_ROUTE_STRINGS = [
     "public, max-age=3600",
     "Access-Control-Allow-Origin",
     "X-Content-Type-Options",
-    "Vary",
 ]
 
 REQUIRED_BUILD_STRINGS = [
@@ -119,7 +118,7 @@ for path, label in [(SCHEMA_ROUTE, "schema route"), (JWKS_ROUTE, "JWKS route")]:
         errors.append(f"missing {label}: {path.relative_to(ROOT)}")
     else:
         text = path.read_text()
-        for needle in ["Response.json", "Cache-Control", "Access-Control-Allow-Origin", "X-Content-Type-Options", "Vary"]:
+        for needle in ["Response.json", "Cache-Control", "Access-Control-Allow-Origin", "X-Content-Type-Options"]:
             if needle not in text:
                 errors.append(f"{label} missing required HTTP/header string: {needle}")
 


### PR DESCRIPTION
## Summary
- remove `Vary: Accept-Encoding` from the SatGate metadata contract after live Vercel verification showed the framework/CDN owns `Vary`
- keep the protocol/body changes from #110 intact: planned rail status, issuer/issuer_kid receipt fields, trust-anchor verifier docs, acceptor draft, schema descriptions
- document `Vary` as platform-managed instead of a SatGate contract requirement

## Test Plan
- `npm run test:well-known`
- `npm run build`
- live verification after #110 showed bodies/cache/CORS/nosniff correct, but `Vary` was CDN-managed, not controllable via route headers
