### PR TITLE
docs: codify trust metadata verifier guidance

### DIFF
--- a/docs/reference/acceptor.md
+++ b/docs/reference/acceptor.md
@@ -71,8 +71,37 @@ The compatibility rule is the same: clients must ignore unknown fields, and brea
 - No fake acceptor role in the public SatGate issuer artifact.
 - No requirement that SatGate stay in the request path after an upstream can verify receipts and capabilities directly.
 
+
+## Interop test plan draft
+
+The first non-SatGate acceptor verifying a SatGate-issued receipt is the point where this becomes a candidate standard rather than a vendor-only document. Before putting acceptor metadata on the wire, run an interop test with:
+
+1. **Issuer metadata fixture**: `satgate.trust_metadata.v1` with `roles: ["issuer"]`, required `issuer` / `issuer_kid` receipt fields, closed receipt decisions, and a JWKS URI under the issuer origin.
+2. **JWKS fixture**: one public key with stable `kid`; no placeholder keys.
+3. **Receipt fixture**: canonical signed `satgate.receipt.v1` containing `receipt_id`, `evidence_pack_id`, `issuer`, `issuer_kid`, `decision`, `decision_reason`, `policy_version`, `receipt_hash`, and `signature`.
+4. **Acceptor metadata fixture**: `roles: ["acceptor"]`, `accepted_capability_formats`, `accepted_receipt_decisions`, `trust_anchors`, and `rails_adapters.accepted`.
+5. **Verifier behavior**:
+   - reject receipts whose `issuer` is not in `trust_anchors`;
+   - fetch JWKS from the trusted issuer origin, not from SatGate's public manifest unless SatGate is the issuer;
+   - select the key by `issuer_kid`;
+   - verify the canonical receipt payload and fail closed on signature, expiry, replay, or decision-policy mismatch;
+   - on signature failure for a known trusted issuer, force-revalidate JWKS once before final rejection.
+
+Minimum passing behavior is offline signature verification plus issuer trust-anchor enforcement. Online `verification_endpoint` checks may be layered on for replay-sensitive or paid-rail flows.
+
+## Cache and freshness notes
+
+Protocol implementations should not assume HTTP caching is perfectly honest. Corporate proxies, hosted agent runtimes, and framework fetchers may serve stale bytes even when the issuer has deployed new metadata. Candidate v1.1 fields to evaluate:
+
+- `metadata_version`: monotonic manifest version for stale-cache detection.
+- `next_rotation_at`: advisory JWKS/key-rotation timestamp.
+- `refresh_after`: issuer-requested revalidation time separate from CDN TTL.
+
+These are not v0.0 requirements; they are reserved as implementation lessons from opaque fetcher caches.
+
 ## Open questions
 
 - Whether acceptor metadata belongs under the same `satgate.trust_metadata.v1` schema or a sibling acceptor schema.
 - Whether `trust_anchors` should support key pinning, issuer catalogs, or both.
 - Whether online verification endpoints should be required for paid rails or only recommended for replay-sensitive routes.
+- Whether stale-cache detection belongs in issuer metadata, acceptor metadata, JWKS metadata, or all three.

--- a/docs/reference/satgate-trust-metadata.md
+++ b/docs/reference/satgate-trust-metadata.md
@@ -9,6 +9,11 @@ https://satgate.io/.well-known/satgate
 This is the first stable machine-readable discovery surface for agent runtimes, API gateways, and upstream services that want to understand what a SatGate issuer accepts and how receipts can be verified.
 
 It is intentionally small. It does **not** make marketplace, reputation, endorsement, ranking, or compliance claims.
+## Contract boundary
+
+The metadata contract only asserts behavior the issuing surface controls end-to-end. Infrastructure-owned behavior — CDN cache internals, framework-managed `Vary` headers, corporate proxy behavior, hosted fetcher caches, and intermediary invalidation latency — must be documented as operational reality, not encoded as a normative SatGate guarantee.
+
+If a field can be stripped, rewritten, or contradicted by a layer outside the issuer's control, keep it out of the machine contract unless that layer is part of the verified issuance surface.
 
 ## Compatibility rule
 
@@ -136,6 +141,8 @@ The federation rule is:
 Receipts reference both an issuer and an `issuer_kid`. Verifiers must first authorize the issuer origin against configured trust anchors, then fetch that issuer's JWKS, select the key by `issuer_kid`, and verify the receipt signature. Tenant or deployment issuers may publish their own JWKS endpoint. The public `satgate.io` JWKS route currently publishes an empty `keys` array instead of placeholder production tenant keys.
 
 Do **not** treat the top-level `https://satgate.io/.well-known/jwks.json` as the universal key source for every receipt. It only represents the `https://satgate.io` issuer. Also do **not** trust any issuer URL found in a receipt until it matches an acceptor-configured trust anchor; otherwise an attacker can publish their own JWKS and sign their own fake receipt.
+
+Verifiers should respect the advertised JWKS TTL during normal operation, but on signature failure for a previously trusted issuer they should force a fresh JWKS fetch before rejecting the receipt. This handles key rotation without training implementations to ignore cache policy entirely. If the issuer remains trusted and the refreshed JWKS still lacks the `issuer_kid`, fail closed.
 
 ## Reference verifier snippets
 


### PR DESCRIPTION
## Summary
- codify the protocol boundary principle: the machine contract only asserts what the issuing surface controls end-to-end
- document JWKS force-revalidation on signature failure for trusted issuers
- add an acceptor interop test-plan draft
- capture stale-cache/freshness candidates for a future v1.1 (`metadata_version`, `next_rotation_at`, `refresh_after`)

## Test Plan
- `npm run test:well-known`
- `git diff --check`
