### PR TITLE
feat: add SatGate capability acceptance story

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -31,6 +31,7 @@ SatGate Gateway is an enterprise API gateway that provides:
 | Export Policy-to-Proof evidence | [Evidence Pack v1](reference/evidence-pack.md) |
 | Discover SatGate trust metadata | [SatGate Trust Metadata](reference/satgate-trust-metadata.md) |
 | Sketch upstream acceptor metadata | [Acceptor Metadata Draft](reference/acceptor.md) |
+| Accept SatGate capabilities upstream | [Accept SatGate Capabilities](reference/accept-satgate-capabilities.md) |
 | Run in production | [Production Checklist](operations/production-checklist.md) |
 | **Enterprise: Economic Firewall** | [Economic Firewall Quickstart](getting-started/economic-firewall-quickstart.md) |
 | **Enterprise: Team Management** | [Team Management Guide](enterprise/TEAM_MANAGEMENT.md) |

--- a/docs/reference/accept-satgate-capabilities.md
+++ b/docs/reference/accept-satgate-capabilities.md
@@ -1,0 +1,142 @@
+# Accept SatGate Capabilities
+
+Status: **acceptance story v0 — internal/mock example available; no public marketplace claim**.
+
+This page defines what an upstream API may honestly mean by **Accepts SatGate capabilities**.
+
+Acceptance means the upstream verifies a SatGate-scoped capability before execution and returns a SatGate-compatible receipt after the decision. It does **not** mean SatGate operates a marketplace, assigns network-wide reputation, endorses the upstream, or ranks the upstream against others.
+
+## Badge and copy
+
+### Badge
+
+```text
+Accepts SatGate capabilities
+```
+
+### One-line explanation
+
+```text
+Verifies scoped SatGate capabilities and returns SatGate-compatible receipts.
+```
+
+### Required disclaimer
+
+```text
+Acceptance means capability verification and receipt emission. It is not a marketplace listing, reputation score, ranking, or SatGate endorsement.
+```
+
+### Forbidden copy
+
+Do not use:
+
+- `SatGate trusted marketplace member`
+- `SatGate certified reputation score`
+- `SatGate endorsed API`
+- `Network-approved upstream`
+- `SatGate verified vendor`
+
+Those phrases overclaim. They imply reputation or endorsement, not capability acceptance.
+
+## Minimal integration checklist
+
+An upstream can claim **Accepts SatGate capabilities** only when it can demonstrate all of these:
+
+1. **Acceptor identity**: the upstream has a stable `acceptor_id` and contact path.
+2. **Capability input**: the upstream accepts `Authorization: Bearer <capability>` using `satgate.capability.v1` or `macaroon-bearer`.
+3. **Trust anchors**: the upstream checks the receipt/capability issuer against configured `trust_anchors` before JWKS discovery.
+4. **Issuer JWKS discovery**: the upstream fetches JWKS from `{issuer_id}/.well-known/jwks.json`, selected only after issuer trust-anchor validation.
+5. **Capability checks**: the upstream verifies signature, expiry, audience, route/tool scope, caveats, budget, and delegation depth before execution.
+6. **Bounded execution**: the upstream executes only the action authorized by the capability.
+7. **Receipt emission**: every accepted or rejected call returns a SatGate-compatible receipt with at least `receipt_id`, `evidence_pack_id`, `issuer`, `issuer_kid`, `acceptor_id`, `decision`, `decision_reason`, `policy_version`, `receipt_hash`, and `signature`.
+8. **Honest claim boundary**: public copy says acceptance means verification + receipts, not marketplace reputation.
+
+## Verification criteria
+
+A third-party reviewer should be able to reproduce these outcomes:
+
+### Positive path
+
+- Given a valid scoped capability for the upstream audience and route,
+- when the caller invokes the upstream with that capability,
+- then the upstream verifies issuer trust, verifies the capability, executes only the scoped action, and returns an `allowed` or `paid` receipt.
+
+### Negative path
+
+- Given an expired, wrong-audience, wrong-route, over-budget, or untrusted-issuer capability,
+- when the caller invokes the upstream,
+- then the upstream rejects before execution and returns a receipt-grade `denied` decision.
+
+### Receipt path
+
+Returned receipts must include:
+
+```json
+{
+  "receipt_id": "rcpt_...",
+  "evidence_pack_id": "ep_...",
+  "issuer": "https://satgate.io",
+  "issuer_kid": "kid_...",
+  "acceptor_id": "https://api.example.com",
+  "decision": "allowed",
+  "decision_reason": "capability_scope_audience_and_budget_ok",
+  "policy_version": "policy_...",
+  "receipt_hash": "sha256:...",
+  "signature": "ed25519:..."
+}
+```
+
+### Claim boundary
+
+The upstream must not claim marketplace membership, global trust, ranking, endorsement, certification, or network-wide reputation.
+
+## Mock/internal example
+
+Until a real upstream is ready, SatGate publishes a mock-only acceptor example:
+
+- Mock acceptor metadata: `/examples/mock-acceptor-metadata.v0.json`
+- Mock accepted receipt: `/examples/mock-accepted-satgate-receipt.v1.json`
+- Public explainer: `https://satgate.io/accept-satgate-capabilities`
+
+The mock proves the integration shape. It is not a live upstream, production acceptor, or public network adoption claim.
+
+The mock metadata separates `accepted_receipt_decisions` from `emitted_receipt_decisions`: `denied` can be emitted as rejection evidence, but it is not accepted as evidence for entry.
+
+## Example request shape
+
+```http
+POST /v1/research HTTP/1.1
+Host: api.example.com
+Authorization: Bearer cap_...
+Content-Type: application/json
+
+{
+  "query": "current supplier pricing"
+}
+```
+
+## Example response shape
+
+```json
+{
+  "result": {
+    "summary": "..."
+  },
+  "satgate_receipt": {
+    "receipt_id": "rcpt_mock_accept_001",
+    "evidence_pack_id": "ep_mock_accept_001",
+    "issuer": "https://satgate.io",
+    "issuer_kid": "satgate-mock-2026-05",
+    "acceptor_id": "https://api.internal.example/satgate-mock",
+    "decision": "allowed",
+    "decision_reason": "capability_scope_audience_and_budget_ok",
+    "policy_version": "policy_mock_acceptance_v0",
+    "receipt_hash": "sha256:mock_receipt_hash",
+    "signature": "ed25519:mock_signature_not_for_production"
+  }
+}
+```
+
+## Relationship to acceptor metadata
+
+The future acceptor-side metadata draft lives at [`acceptor.md`](acceptor.md). This page defines the public badge and minimum integration story. The acceptor metadata draft defines the future machine-readable shape.

--- a/docs/reference/acceptor.md
+++ b/docs/reference/acceptor.md
@@ -2,7 +2,7 @@
 
 Status: **v0.0 draft — not yet on the wire**.
 
-This document reserves the mirror side of the SatGate trust metadata model before issuer-side `satgate.trust_metadata.v1` ossifies in downstream parsers. It is intentionally documentation-only until an upstream service actually accepts SatGate capabilities.
+This document reserves the mirror side of the SatGate trust metadata model before issuer-side `satgate.trust_metadata.v1` ossifies in downstream parsers. It is intentionally documentation-only until an upstream service actually accepts SatGate capabilities. The public badge and integration story live in [Accept SatGate Capabilities](accept-satgate-capabilities.md).
 
 ## Purpose
 
@@ -41,6 +41,13 @@ The compatibility rule is the same: clients must ignore unknown fields, and brea
     "delegated",
     "paid"
   ],
+  "emitted_receipt_decisions": [
+    "allowed",
+    "denied",
+    "delegated",
+    "revoked",
+    "paid"
+  ],
   "trust_anchors": [
     {
       "issuer_id": "https://satgate.io",
@@ -61,7 +68,8 @@ The compatibility rule is the same: clients must ignore unknown fields, and brea
 
 - `verification_endpoint`: optional upstream endpoint for online verification, replay checks, or policy-specific acceptance decisions. Offline signature checks should still use issuer JWKS discovery when possible.
 - `accepted_capability_formats`: subset of capability formats the upstream honors. An acceptor does not need to accept every format an issuer can emit.
-- `accepted_receipt_decisions`: subset of receipt decisions the upstream treats as acceptable evidence for entry. For example, a read-only upstream may accept `allowed` and reject `paid`.
+- `accepted_receipt_decisions`: subset of receipt decisions the upstream treats as acceptable evidence for entry. Do not include `denied` here; denied receipts are evidence of rejection, not entry.
+- `emitted_receipt_decisions`: subset of receipt decisions the upstream can return after evaluating a capability, including `denied` when a request is rejected before execution.
 - `trust_anchors`: issuer origins the upstream accepts, optionally pinned to JWKS URIs or future certificate transparency/audit roots.
 - `rails_adapters.accepted`: rails the upstream can settle on or route through.
 

--- a/satgate-landing/app/accept-satgate-capabilities/page.tsx
+++ b/satgate-landing/app/accept-satgate-capabilities/page.tsx
@@ -1,0 +1,221 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { ArrowLeft, BadgeCheck, CheckCircle2, FileCheck2, KeyRound, ReceiptText, ShieldCheck, XCircle } from "lucide-react";
+
+export const metadata: Metadata = {
+  title: "Accept SatGate Capabilities",
+  description:
+    "Define what it means for an upstream API to accept SatGate-scoped capabilities: verify bounded authority, execute the allowed action, and return receipts without implying marketplace reputation.",
+  keywords: [
+    "SatGate capabilities",
+    "capability accepting API",
+    "agent capability verification",
+    "SatGate receipts",
+    "upstream API acceptance",
+    "AI agent authorization",
+  ],
+  alternates: { canonical: "https://satgate.io/accept-satgate-capabilities" },
+  openGraph: {
+    title: "Accept SatGate capabilities",
+    description:
+      "A precise upstream acceptance story: scoped capability verification in, receipt emission out. No marketplace, no reputation claim.",
+    url: "https://satgate.io/accept-satgate-capabilities",
+    type: "website",
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "Accept SatGate capabilities",
+    description: "Capability verification in. Receipt emission out. No network-wide reputation claim.",
+  },
+};
+
+const badgeCopy = [
+  {
+    label: "Badge text",
+    value: "Accepts SatGate capabilities",
+    body: "Use when an upstream verifies SatGate-scoped capabilities and returns SatGate-compatible receipts for accepted calls.",
+  },
+  {
+    label: "Short disclaimer",
+    value: "Capability verification + receipts only",
+    body: "The badge does not mean SatGate endorses the upstream, ranks it, audits its business, or provides network-wide reputation.",
+  },
+  {
+    label: "Machine signal",
+    value: "roles: [\"acceptor\"]",
+    body: "Future acceptor metadata should advertise accepted capability formats, trust anchors, verification behavior, and returned receipt formats.",
+  },
+];
+
+const checklist = [
+  "Publish or document the upstream acceptor identity and contact path.",
+  "Accept `Authorization: Bearer <capability>` using `satgate.capability.v1` or `macaroon-bearer`.",
+  "Verify issuer trust anchor before fetching issuer JWKS.",
+  "Verify signature, expiry, audience, route/tool scope, caveats, budget, and delegation depth before execution.",
+  "Execute only the action authorized by the capability.",
+  "Return a SatGate-compatible receipt for allowed, denied, paid, delegated, or revoked decisions.",
+  "Expose a test vector or mock endpoint before claiming real production acceptance.",
+];
+
+const criteria = [
+  { title: "Capability accepted", body: "A valid scoped capability for the upstream audience and route is accepted before execution." },
+  { title: "Capability denied", body: "An expired, wrong-audience, wrong-route, over-budget, or untrusted-issuer capability is rejected with a receipt-grade denial." },
+  { title: "Receipt returned", body: "Every allowed or denied call returns a receipt with `receipt_id`, `evidence_pack_id`, `issuer`, `issuer_kid`, `decision`, `decision_reason`, `policy_version`, `receipt_hash`, and `signature`." },
+  { title: "Trust remains bounded", body: "The upstream makes no marketplace, ranking, reputation, or endorsement claim. Acceptance proves verification behavior, not global trust." },
+];
+
+const mockReceipt = {
+  receipt_id: "rcpt_mock_accept_001",
+  evidence_pack_id: "ep_mock_accept_001",
+  issuer: "https://satgate.io",
+  issuer_kid: "satgate-mock-2026-05",
+  acceptor_id: "https://api.internal.example/satgate-mock",
+  decision: "allowed",
+  decision_reason: "capability_scope_audience_and_budget_ok",
+  policy_version: "policy_mock_acceptance_v0",
+  capability_hash: "sha256:mock_capability_hash",
+  receipt_hash: "sha256:mock_receipt_hash",
+  signature: "ed25519:mock_signature_not_for_production",
+  mock_only: true,
+};
+
+const jsonLd = {
+  "@context": "https://schema.org",
+  "@type": "TechArticle",
+  headline: "Accept SatGate capabilities",
+  description: metadata.description,
+  url: "https://satgate.io/accept-satgate-capabilities",
+  datePublished: "2026-05-13",
+  dateModified: "2026-05-13",
+  about: ["SatGate capabilities", "upstream API acceptance", "verifiable receipts"],
+};
+
+export default function AcceptSatGateCapabilitiesPage() {
+  return (
+    <main className="min-h-screen overflow-x-hidden bg-black text-gray-100 font-sans">
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }} />
+
+      <div className="mx-auto max-w-6xl px-6 pt-8">
+        <Link href="/" className="inline-flex items-center gap-2 text-sm font-medium text-gray-500 transition hover:text-white">
+          <ArrowLeft size={16} /> Back to Home
+        </Link>
+      </div>
+
+      <section className="relative overflow-hidden border-b border-gray-900">
+        <div className="absolute inset-0 bg-[radial-gradient(circle_at_15%_10%,rgba(56,189,248,0.18),transparent_30%),radial-gradient(circle_at_82%_15%,rgba(16,185,129,0.16),transparent_32%)]" />
+        <div className="relative mx-auto grid max-w-6xl gap-12 px-6 py-24 lg:grid-cols-[0.95fr_1.05fr] lg:items-center">
+          <div>
+            <div className="mb-6 inline-flex items-center gap-2 rounded-full border border-emerald-400/30 bg-emerald-400/10 px-4 py-2 text-sm font-semibold uppercase tracking-[0.22em] text-emerald-200">
+              <BadgeCheck size={16} /> Upstream acceptance
+            </div>
+            <h1 className="max-w-4xl text-5xl font-black tracking-tight text-white sm:text-6xl">
+              Accept SatGate capabilities without pretending there is a marketplace.
+            </h1>
+            <p className="mt-6 max-w-2xl text-xl leading-9 text-gray-300">
+              Acceptance means an upstream verifies SatGate-scoped authority before action and returns receipt-grade evidence after the decision. It does not mean SatGate ranks, endorses, or reputationally scores that upstream.
+            </p>
+            <div className="mt-8 flex flex-wrap gap-3">
+              <Link href="/build" className="rounded-full bg-white px-5 py-3 text-sm font-bold text-black transition hover:bg-cyan-100">Build with capabilities</Link>
+              <Link href="https://github.com/SatGate-io/satgate/blob/main/docs/reference/accept-satgate-capabilities.md" className="rounded-full border border-gray-700 px-5 py-3 text-sm font-bold text-white transition hover:border-cyan-400">Read the acceptance docs</Link>
+            </div>
+          </div>
+
+          <div className="rounded-3xl border border-gray-800 bg-gray-950/85 p-6 shadow-2xl shadow-cyan-500/10">
+            <div className="mb-4 flex items-center gap-2 text-emerald-200"><ShieldCheck size={20} /> Badge definition</div>
+            <div className="rounded-2xl border border-emerald-400/30 bg-emerald-400/10 p-5">
+              <div className="mb-3 inline-flex items-center gap-2 rounded-full bg-emerald-300 px-3 py-1 text-xs font-black uppercase tracking-[0.18em] text-black">
+                <BadgeCheck size={14} /> Accepts SatGate capabilities
+              </div>
+              <p className="text-sm leading-6 text-emerald-50">Verifies scoped SatGate capabilities and returns SatGate-compatible receipts. Acceptance means capability verification and receipt emission. No marketplace, ranking, reputation, or endorsement claim.</p>
+            </div>
+            <pre className="mt-5 max-w-full overflow-x-auto rounded-2xl bg-black p-5 text-xs leading-6 text-gray-300"><code>{JSON.stringify(mockReceipt, null, 2)}</code></pre>
+          </div>
+        </div>
+      </section>
+
+      <section className="mx-auto max-w-6xl px-6 py-20">
+        <div className="mb-10 max-w-3xl">
+          <p className="mb-3 text-sm font-mono uppercase tracking-[0.22em] text-cyan-300">Badge and copy</p>
+          <h2 className="text-3xl font-bold text-white sm:text-4xl">The badge says exactly one thing.</h2>
+        </div>
+        <div className="grid gap-6 md:grid-cols-3">
+          {badgeCopy.map((item) => (
+            <div key={item.label} className="rounded-2xl border border-gray-800 bg-gray-950 p-6">
+              <p className="mb-3 text-xs font-mono uppercase tracking-[0.18em] text-gray-500">{item.label}</p>
+              <h3 className="mb-3 text-xl font-bold text-white">{item.value}</h3>
+              <p className="leading-7 text-gray-400">{item.body}</p>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section className="border-y border-gray-900 bg-gray-950/60">
+        <div className="mx-auto grid max-w-6xl gap-10 px-6 py-20 lg:grid-cols-2">
+          <div>
+            <p className="mb-3 text-sm font-mono uppercase tracking-[0.22em] text-emerald-300">Minimal integration checklist</p>
+            <h2 className="mb-6 text-3xl font-bold text-white">Enough to prove acceptance. Not enough to claim reputation.</h2>
+            <div className="space-y-4">
+              {checklist.map((item) => (
+                <div key={item} className="flex gap-3 rounded-2xl border border-gray-800 bg-black p-4">
+                  <CheckCircle2 className="mt-1 shrink-0 text-emerald-300" size={18} />
+                  <p className="leading-7 text-gray-300">{item}</p>
+                </div>
+              ))}
+            </div>
+          </div>
+          <div>
+            <p className="mb-3 text-sm font-mono uppercase tracking-[0.22em] text-purple-300">Verification criteria</p>
+            <h2 className="mb-6 text-3xl font-bold text-white">A verifier should be able to reproduce these outcomes.</h2>
+            <div className="space-y-4">
+              {criteria.map((item) => (
+                <div key={item.title} className="rounded-2xl border border-gray-800 bg-black p-5">
+                  <div className="mb-2 flex items-center gap-2 text-white"><FileCheck2 className="text-purple-300" size={18} /><h3 className="font-bold">{item.title}</h3></div>
+                  <p className="leading-7 text-gray-400">{item.body}</p>
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="mx-auto max-w-6xl px-6 py-20">
+        <div className="grid gap-8 lg:grid-cols-[0.9fr_1.1fr] lg:items-start">
+          <div>
+            <p className="mb-3 text-sm font-mono uppercase tracking-[0.22em] text-red-300">No overclaiming</p>
+            <h2 className="text-3xl font-bold text-white sm:text-4xl">What the badge does not mean.</h2>
+            <div className="mt-6 space-y-4 text-lg leading-8 text-gray-400">
+              <p>It does not mean SatGate operates a directory of trusted APIs.</p>
+              <p>It does not mean the upstream is endorsed, ranked, audited, or safer than another upstream.</p>
+              <p>It means one integration path has evidence: scoped capability verification before execution and receipt emission after the decision.</p>
+            </div>
+          </div>
+          <div className="rounded-2xl border border-red-400/20 bg-red-400/5 p-6">
+            <div className="mb-4 flex items-center gap-2 text-red-200"><XCircle size={20} /> Forbidden badge copy</div>
+            <ul className="space-y-3 text-gray-300">
+              <li>“SatGate trusted marketplace member”</li>
+              <li>“SatGate certified reputation score”</li>
+              <li>“SatGate endorsed API”</li>
+              <li>“Network-approved upstream”</li>
+            </ul>
+          </div>
+        </div>
+      </section>
+
+      <section className="border-t border-gray-900 bg-gray-950/70">
+        <div className="mx-auto max-w-6xl px-6 py-16">
+          <div className="rounded-3xl border border-gray-800 bg-black p-8 md:flex md:items-center md:justify-between md:gap-8">
+            <div>
+              <p className="mb-2 text-sm font-mono uppercase tracking-[0.22em] text-cyan-300">Internal mock first</p>
+              <h2 className="text-3xl font-bold text-white">Use the mock acceptor until a real upstream is ready.</h2>
+              <p className="mt-3 max-w-2xl text-gray-400">The mock example is deliberately labeled internal: it proves the acceptance shape without claiming public network adoption.</p>
+            </div>
+            <div className="mt-6 flex flex-wrap gap-3 md:mt-0">
+              <Link href="/examples/mock-acceptor-metadata.v0.json" className="rounded-full border border-gray-700 px-5 py-3 text-sm font-bold text-white transition hover:border-cyan-400">Mock metadata</Link>
+              <Link href="/examples/mock-accepted-satgate-receipt.v1.json" className="rounded-full bg-cyan-300 px-5 py-3 text-sm font-bold text-black transition hover:bg-cyan-200">Mock receipt</Link>
+            </div>
+          </div>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/satgate-landing/app/build/page.tsx
+++ b/satgate-landing/app/build/page.tsx
@@ -140,6 +140,7 @@ const integrationLinks = [
   { title: "Runtime integrations", href: "/integrations", body: "See current agent-client surfaces and where OpenAI, Anthropic, LangChain, and CrewAI adapters fit." },
   { title: "Developer docs", href: "https://cloud.satgate.io/docs", body: "Use the docs for setup details while issue/pay/verify API access is in private beta." },
   { title: "Trust metadata", href: "/.well-known/satgate", body: "Discover SatGate capability acceptance, supported rails, issuer metadata, and receipt verification fields." },
+  { title: "Accept capabilities", href: "/accept-satgate-capabilities", body: "Show upstreams how to verify scoped SatGate capabilities and return receipts without claiming marketplace reputation." },
 ];
 
 const runtimeChips = ["MCP", "OpenAI tools", "Anthropic tools", "LangChain", "CrewAI", "Raw HTTP"];

--- a/satgate-landing/app/sitemap.ts
+++ b/satgate-landing/app/sitemap.ts
@@ -31,6 +31,7 @@ const staticRoutes: SitemapEntry[] = [
   { path: '/mcp-cost-control', lastModified: '2026-05-03', changeFrequency: 'monthly', priority: 0.85 },
   { path: '/agent-api-governance', lastModified: '2026-05-05', changeFrequency: 'weekly', priority: 0.9 },
   { path: '/build', lastModified: '2026-05-12', changeFrequency: 'weekly', priority: 0.95 },
+  { path: '/accept-satgate-capabilities', lastModified: '2026-05-13', changeFrequency: 'weekly', priority: 0.9 },
   { path: '/capability-auth', lastModified: '2026-05-08', changeFrequency: 'weekly', priority: 0.95 },
   { path: '/agent-control-plane', lastModified: '2026-05-05', changeFrequency: 'weekly', priority: 0.9 },
   { path: '/evidence-pack-demo', lastModified: '2026-05-10', changeFrequency: 'weekly', priority: 0.95 },

--- a/satgate-landing/package.json
+++ b/satgate-landing/package.json
@@ -14,7 +14,8 @@
     "test:build-page": "python3 scripts/check_build_page.py",
     "test:demo-ia": "python3 scripts/check_demo_ia.py",
     "test:proof-spine": "python3 scripts/check_proof_spine.py",
-    "test:well-known": "python3 scripts/check_well_known_satgate.py"
+    "test:well-known": "python3 scripts/check_well_known_satgate.py",
+    "test:acceptance-story": "python3 scripts/check_acceptance_story.py"
   },
   "dependencies": {
     "lucide-react": "^0.555.0",

--- a/satgate-landing/public/examples/mock-accepted-satgate-receipt.v1.json
+++ b/satgate-landing/public/examples/mock-accepted-satgate-receipt.v1.json
@@ -1,0 +1,14 @@
+{
+  "receipt_id": "rcpt_mock_accept_001",
+  "evidence_pack_id": "ep_mock_accept_001",
+  "issuer": "https://satgate.io",
+  "issuer_kid": "satgate-mock-2026-05",
+  "acceptor_id": "https://api.internal.example/satgate-mock",
+  "decision": "allowed",
+  "decision_reason": "capability_scope_audience_and_budget_ok",
+  "policy_version": "policy_mock_acceptance_v0",
+  "capability_hash": "sha256:mock_capability_hash",
+  "receipt_hash": "sha256:mock_receipt_hash",
+  "signature": "ed25519:mock_signature_not_for_production",
+  "mock_only": true
+}

--- a/satgate-landing/public/examples/mock-acceptor-metadata.v0.json
+++ b/satgate-landing/public/examples/mock-acceptor-metadata.v0.json
@@ -1,0 +1,58 @@
+{
+  "schema_version": "satgate.acceptor_metadata.v0",
+  "metadata_url": "https://api.internal.example/.well-known/satgate",
+  "roles": [
+    "acceptor"
+  ],
+  "status": "internal_mock_only",
+  "acceptor": {
+    "name": "Internal Mock Research API",
+    "acceptor_id": "https://api.internal.example/satgate-mock",
+    "verification_endpoint": "https://api.internal.example/satgate/verify"
+  },
+  "accepted_capability_formats": [
+    "satgate.capability.v1",
+    "macaroon-bearer"
+  ],
+  "accepted_receipt_decisions": [
+    "allowed",
+    "paid"
+  ],
+  "trust_anchors": [
+    {
+      "issuer_id": "https://satgate.io",
+      "jwks_uri": "https://satgate.io/.well-known/jwks.json",
+      "status": "accepted_for_mock"
+    }
+  ],
+  "rails_adapters": {
+    "accepted": [
+      {
+        "id": "mcp",
+        "type": "protocol",
+        "role": "tool_transport",
+        "status": "supported"
+      },
+      {
+        "id": "enterprise_ledger",
+        "type": "ledger_adapter",
+        "role": "internal_chargeback",
+        "status": "supported"
+      }
+    ]
+  },
+  "claims": {
+    "acceptance_means": "capability verification and receipt emission",
+    "acceptance_does_not_mean": [
+      "marketplace listing",
+      "reputation score",
+      "SatGate endorsement",
+      "network-wide trust"
+    ]
+  },
+  "emitted_receipt_decisions": [
+    "allowed",
+    "denied",
+    "paid"
+  ]
+}

--- a/satgate-landing/scripts/check_acceptance_story.py
+++ b/satgate-landing/scripts/check_acceptance_story.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""Regression guard for the SatGate upstream acceptance story."""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+REPO = ROOT.parent
+PAGE = ROOT / "app" / "accept-satgate-capabilities" / "page.tsx"
+DOC = REPO / "docs" / "reference" / "accept-satgate-capabilities.md"
+ACCEPTOR_DOC = REPO / "docs" / "reference" / "acceptor.md"
+DOC_INDEX = REPO / "docs" / "index.md"
+SITEMAP = ROOT / "app" / "sitemap.ts"
+BUILD = ROOT / "app" / "build" / "page.tsx"
+MOCK_METADATA = ROOT / "public" / "examples" / "mock-acceptor-metadata.v0.json"
+MOCK_RECEIPT = ROOT / "public" / "examples" / "mock-accepted-satgate-receipt.v1.json"
+
+errors: list[str] = []
+
+for path, label in [
+    (PAGE, "public acceptance page"),
+    (DOC, "acceptance docs page"),
+    (MOCK_METADATA, "mock acceptor metadata"),
+    (MOCK_RECEIPT, "mock accepted receipt"),
+]:
+    if not path.exists():
+        errors.append(f"missing {label}: {path}")
+
+page_text = PAGE.read_text() if PAGE.exists() else ""
+doc_text = DOC.read_text() if DOC.exists() else ""
+combined = page_text + "\n" + doc_text
+
+required_strings = [
+    "Accepts SatGate capabilities",
+    "capability verification and receipt emission",
+    "not a marketplace",
+    "No marketplace",
+    "not mean SatGate endorses",
+    "network-wide reputation",
+    "Minimal integration checklist",
+    "Verification criteria",
+    "mock acceptor",
+    "internal/mock",
+    "Authorization: Bearer <capability>",
+    "trust_anchors",
+    "issuer_kid",
+    "receipt_id",
+    "evidence_pack_id",
+    "acceptor_id",
+    "emitted_receipt_decisions",
+    "decision_reason",
+    "policy_version",
+]
+for needle in required_strings:
+    if needle not in combined:
+        errors.append(f"acceptance story missing required string: {needle}")
+
+# These are permitted only inside the explicit forbidden-copy section.
+for overclaim in [
+    "SatGate trusted marketplace member",
+    "SatGate certified reputation score",
+    "SatGate endorsed API",
+    "Network-approved upstream",
+]:
+    if overclaim not in combined:
+        errors.append(f"forbidden-copy example missing from guard/docs: {overclaim}")
+
+if "global trust" not in combined or "ranking" not in combined:
+    errors.append("acceptance story must explicitly reject global trust/ranking claims")
+
+if SITEMAP.exists() and "/accept-satgate-capabilities" not in SITEMAP.read_text():
+    errors.append("sitemap missing /accept-satgate-capabilities")
+if DOC_INDEX.exists() and "reference/accept-satgate-capabilities.md" not in DOC_INDEX.read_text():
+    errors.append("docs index missing acceptance docs link")
+if ACCEPTOR_DOC.exists() and "accept-satgate-capabilities.md" not in ACCEPTOR_DOC.read_text():
+    errors.append("acceptor draft does not link acceptance story")
+if BUILD.exists() and "/accept-satgate-capabilities" not in BUILD.read_text():
+    errors.append("/build does not link upstream acceptance story")
+
+if MOCK_METADATA.exists():
+    metadata = json.loads(MOCK_METADATA.read_text())
+    if metadata.get("status") != "internal_mock_only":
+        errors.append("mock acceptor metadata must be labeled internal_mock_only")
+    if metadata.get("roles") != ["acceptor"]:
+        errors.append("mock acceptor metadata must use roles: ['acceptor']")
+    if "trust_anchors" not in metadata:
+        errors.append("mock acceptor metadata missing trust_anchors")
+    claims = metadata.get("claims", {})
+    if claims.get("acceptance_means") != "capability verification and receipt emission":
+        errors.append("mock acceptor metadata must define honest acceptance_means")
+    for forbidden in ["marketplace listing", "reputation score", "SatGate endorsement", "network-wide trust"]:
+        if forbidden not in claims.get("acceptance_does_not_mean", []):
+            errors.append(f"mock acceptor metadata missing negative claim: {forbidden}")
+    if "denied" in metadata.get("accepted_receipt_decisions", []):
+        errors.append("mock acceptor metadata must not treat denied as accepted evidence for entry")
+    if "denied" not in metadata.get("emitted_receipt_decisions", []):
+        errors.append("mock acceptor metadata should list denied under emitted_receipt_decisions")
+
+if MOCK_RECEIPT.exists():
+    receipt = json.loads(MOCK_RECEIPT.read_text())
+    for field in ["receipt_id", "evidence_pack_id", "issuer", "issuer_kid", "acceptor_id", "decision", "decision_reason", "policy_version", "receipt_hash", "signature", "mock_only"]:
+        if field not in receipt:
+            errors.append(f"mock receipt missing field: {field}")
+    if receipt.get("mock_only") is not True:
+        errors.append("mock receipt must be labeled mock_only: true")
+
+if errors:
+    print("acceptance story regression check failed:")
+    for error in errors:
+        print(f"- {error}")
+    sys.exit(1)
+
+print("acceptance story regression check passed")


### PR DESCRIPTION
## Summary
- add `/accept-satgate-capabilities` public page defining the upstream acceptance story and badge copy
- add docs page with badge language, integration checklist, verification criteria, mock/internal example, and forbidden overclaims
- add mock acceptor metadata + mock receipt JSON fixtures
- link the story from `/build`, docs index, acceptor draft, and sitemap
- add `test:acceptance-story` regression guard to keep acceptance scoped to capability verification + receipt emission, not marketplace/reputation claims

## Test Plan
- `npm run test:acceptance-story`
- `npm run test:build-page`
- `npm run test:well-known`
- `npm run build`
- local `next start` smoke test for `/accept-satgate-capabilities` and both mock JSON examples

## Notes
- The mock example is explicitly internal/mock only.
- `accepted_receipt_decisions` excludes `denied`; `emitted_receipt_decisions` includes `denied` so rejection evidence is clear without treating denial as evidence for entry.
