### PR TITLE
feat: tighten SatGate acceptor metadata draft

### DIFF
--- a/docs/reference/accept-satgate-capabilities.md
+++ b/docs/reference/accept-satgate-capabilities.md
@@ -97,10 +97,11 @@ Until a real upstream is ready, SatGate publishes a mock-only acceptor example:
 - Mock acceptor metadata: `/examples/mock-acceptor-metadata.v0.json`
 - Mock accepted receipt: `/examples/mock-accepted-satgate-receipt.v1.json`
 - Public explainer: `https://satgate.io/accept-satgate-capabilities`
+- Acceptor JSON Schema: `https://satgate.io/.well-known/satgate-acceptor.schema.json`
 
 The mock proves the integration shape. It is not a live upstream, production acceptor, or public network adoption claim.
 
-The mock metadata separates `accepted_receipt_decisions` from `emitted_receipt_decisions`: `denied` can be emitted as rejection evidence, but it is not accepted as evidence for entry.
+The mock metadata separates `recognized_receipt_decisions` from `emitted_receipt_decisions`: `denied` can be emitted as rejection evidence, but it is not recognized as evidence for entry.
 
 ## Example request shape
 
@@ -139,4 +140,4 @@ Content-Type: application/json
 
 ## Relationship to acceptor metadata
 
-The future acceptor-side metadata draft lives at [`acceptor.md`](acceptor.md). This page defines the public badge and minimum integration story. The acceptor metadata draft defines the future machine-readable shape.
+The acceptor-side metadata draft lives at [`acceptor.md`](acceptor.md). The v0 schema lives at `https://satgate.io/.well-known/satgate-acceptor.schema.json`. This page defines the public badge and minimum integration story; the acceptor metadata draft and schema define the machine-readable shape.

--- a/docs/reference/acceptor.md
+++ b/docs/reference/acceptor.md
@@ -1,23 +1,23 @@
 # SatGate Acceptor Metadata Draft
 
-Status: **v0.0 draft — not yet on the wire**.
+Status: **v0.0 draft — mock schema on the wire; no public acceptor claim yet**.
 
-This document reserves the mirror side of the SatGate trust metadata model before issuer-side `satgate.trust_metadata.v1` ossifies in downstream parsers. It is intentionally documentation-only until an upstream service actually accepts SatGate capabilities. The public badge and integration story live in [Accept SatGate Capabilities](accept-satgate-capabilities.md).
+This document reserves the mirror side of the SatGate trust metadata model before issuer-side `satgate.trust_metadata.v1` ossifies in downstream parsers. The public badge and integration story live in [Accept SatGate Capabilities](accept-satgate-capabilities.md). The draft JSON Schema is published at `https://satgate.io/.well-known/satgate-acceptor.schema.json` so early implementers do not invent incompatible field names.
 
 ## Purpose
 
 Issuer metadata answers: “What capabilities can this issuer mint, and how do I verify its receipts?”
 
-Acceptor metadata should answer: “What capabilities will this upstream accept, from which issuers, and on which rails can it settle?”
+Acceptor metadata answers: “What capabilities will this upstream accept, from which issuers, which prior receipt decisions will it recognize, which decisions can it emit, and on which rails can it settle?”
 
 ## Candidate discovery path
 
 Two options are still open:
 
-- Same path, role-selected: `/.well-known/satgate` with `roles: ["acceptor"]` or `roles: ["issuer", "acceptor"]`.
+- Same path, role-selected: `/.well-known/satgate` with `roles: ["acceptor"]` or, for a future dual-role artifact, `roles: ["issuer", "acceptor"]`. The v0 acceptor schema requires `acceptor` and leaves issuer validation to the issuer schema.
 - Companion path: `/.well-known/satgate-upstream` for upstream-only services.
 
-The compatibility rule is the same: clients must ignore unknown fields, and breaking field changes require a new schema version.
+The compatibility rule is the same: clients must ignore unknown fields, and breaking field changes require a new schema version. For v0, the schema keeps `additionalProperties: true` while closing the fields most likely to drift: role, claim boundary, trust-anchor status, and receipt decision sets.
 
 ## Candidate fields
 
@@ -27,6 +27,7 @@ The compatibility rule is the same: clients must ignore unknown fields, and brea
   "metadata_url": "https://api.example.com/.well-known/satgate",
   "schema_url": "https://satgate.io/.well-known/satgate-acceptor.schema.json",
   "roles": ["acceptor"],
+  "status": "active",
   "acceptor": {
     "name": "Example API",
     "acceptor_id": "https://api.example.com",
@@ -36,16 +37,13 @@ The compatibility rule is the same: clients must ignore unknown fields, and brea
     "satgate.capability.v1",
     "macaroon-bearer"
   ],
-  "accepted_receipt_decisions": [
+  "recognized_receipt_decisions": [
     "allowed",
-    "delegated",
     "paid"
   ],
   "emitted_receipt_decisions": [
     "allowed",
     "denied",
-    "delegated",
-    "revoked",
     "paid"
   ],
   "trust_anchors": [
@@ -60,25 +58,44 @@ The compatibility rule is the same: clients must ignore unknown fields, and brea
       { "id": "mcp", "type": "protocol", "role": "tool_transport", "status": "supported" },
       { "id": "x402", "type": "payment_rail", "role": "external_paid_access", "status": "supported" }
     ]
+  },
+  "claims": {
+    "acceptance_means": "capability verification and receipt emission",
+    "acceptance_does_not_mean": [
+      "marketplace listing",
+      "reputation score",
+      "SatGate endorsement",
+      "network-wide trust",
+      "ranking",
+      "certification"
+    ]
   }
 }
 ```
 
 ## Field notes
 
-- `verification_endpoint`: optional upstream endpoint for online verification, replay checks, or policy-specific acceptance decisions. Offline signature checks should still use issuer JWKS discovery when possible.
+- `schema_url`: canonical v0 JSON Schema. v0 is intentionally permissive, but it closes field names and enums that would otherwise fragment.
+- `status`: artifact lifecycle. Closed v0 values are `internal_mock_only`, `draft`, `active`, `deprecated`, and `revoked`.
+- `verification_endpoint`: optional upstream endpoint for online verification, replay checks, or policy-specific acceptance decisions. Offline signature checks should still use issuer JWKS discovery when possible; do not require an online verifier for simple read-only flows.
 - `accepted_capability_formats`: subset of capability formats the upstream honors. An acceptor does not need to accept every format an issuer can emit.
-- `accepted_receipt_decisions`: subset of receipt decisions the upstream treats as acceptable evidence for entry. Do not include `denied` here; denied receipts are evidence of rejection, not entry.
-- `emitted_receipt_decisions`: subset of receipt decisions the upstream can return after evaluating a capability, including `denied` when a request is rejected before execution.
-- `trust_anchors`: issuer origins the upstream accepts, optionally pinned to JWKS URIs or future certificate transparency/audit roots.
-- `rails_adapters.accepted`: rails the upstream can settle on or route through.
+- `recognized_receipt_decisions`: prior receipt decisions the upstream recognizes as acceptable evidence for entry. Do not include `denied` here; denied receipts are evidence of rejection, not entry.
+- `emitted_receipt_decisions`: receipt decisions the upstream can return after evaluating a capability. Acceptor v0 emits a subset of the issuer decision space: `allowed`, `denied`, and `paid`.
+- `trust_anchors`: issuer origins the upstream accepts, optionally pinned to JWKS URIs or future certificate transparency/audit roots. The issuer must match a trust anchor before any JWKS fetch. If `jwks_uri` is omitted, verifiers use `{issuer_id}/.well-known/jwks.json`; if present, it must be HTTPS unless a local test explicitly allows otherwise. Closed v0 statuses are `accepted`, `provisional`, `revoked`, `deprecated`, and `accepted_for_mock`; `accepted_for_mock` is reserved for examples.
+- `rails_adapters.accepted`: rails the upstream will settle via or route through. The verb is deliberately different from issuer-side `rails_adapters.supported`: issuers can **support** rails for minting/routing; acceptors **accept** rails for settlement or upstream access.
+- `claims`: machine-readable claim boundary. Parsers should see that acceptance means capability verification and receipt emission, not marketplace listing, reputation score, endorsement, network-wide trust, ranking, or certification.
+
+## Decision-space note
+
+Issuer-side receipt metadata currently defines the closed decision vocabulary `allowed`, `denied`, `delegated`, `revoked`, and `paid`.
+
+Acceptor v0 intentionally emits a subset: `allowed`, `denied`, and `paid`. Delegation and revocation remain issuer-side authority lifecycle primitives unless a future acceptor profile explicitly defines upstream delegation or upstream revocation semantics.
 
 ## Non-goals
 
-- No marketplace, ranking, reputation, endorsement, or compliance claim.
+- No marketplace, ranking, reputation, endorsement, certification, or compliance claim.
 - No fake acceptor role in the public SatGate issuer artifact.
 - No requirement that SatGate stay in the request path after an upstream can verify receipts and capabilities directly.
-
 
 ## Interop test plan draft
 
@@ -86,8 +103,8 @@ The first non-SatGate acceptor verifying a SatGate-issued receipt is the point w
 
 1. **Issuer metadata fixture**: `satgate.trust_metadata.v1` with `roles: ["issuer"]`, required `issuer` / `issuer_kid` receipt fields, closed receipt decisions, and a JWKS URI under the issuer origin.
 2. **JWKS fixture**: one public key with stable `kid`; no placeholder keys.
-3. **Receipt fixture**: canonical signed `satgate.receipt.v1` containing `receipt_id`, `evidence_pack_id`, `issuer`, `issuer_kid`, `decision`, `decision_reason`, `policy_version`, `receipt_hash`, and `signature`.
-4. **Acceptor metadata fixture**: `roles: ["acceptor"]`, `accepted_capability_formats`, `accepted_receipt_decisions`, `trust_anchors`, and `rails_adapters.accepted`.
+3. **Receipt fixture**: canonical signed `satgate.receipt.v1` containing `receipt_id`, `evidence_pack_id`, `issuer`, `issuer_kid`, `acceptor_id`, `decision`, `decision_reason`, `policy_version`, `receipt_hash`, and `signature`.
+4. **Acceptor metadata fixture**: `roles: ["acceptor"]`, `schema_url`, `status`, `accepted_capability_formats`, `recognized_receipt_decisions`, `emitted_receipt_decisions`, `trust_anchors`, `rails_adapters.accepted`, and `claims`.
 5. **Verifier behavior**:
    - reject receipts whose `issuer` is not in `trust_anchors`;
    - fetch JWKS from the trusted issuer origin, not from SatGate's public manifest unless SatGate is the issuer;

--- a/docs/reference/satgate-trust-metadata.md
+++ b/docs/reference/satgate-trust-metadata.md
@@ -215,13 +215,15 @@ export async function verifyReceipt(receipt: Receipt) {
 
 ## Future acceptor-side metadata
 
-The mirror artifact is intentionally not on the wire yet. A draft is tracked in [Acceptor Metadata Draft](acceptor.md). An acceptor needs to advertise at least:
+The mirror artifact is still draft, but a permissive v0 schema is on the wire at `https://satgate.io/.well-known/satgate-acceptor.schema.json` to prevent early implementers from inventing incompatible field names. The draft is tracked in [Acceptor Metadata Draft](acceptor.md). An acceptor needs to advertise at least:
 
-- `verification_endpoint`
+- optional `verification_endpoint` for online verification/replay-sensitive flows
 - `accepted_capability_formats`
-- `accepted_receipt_decisions`
-- `trust_anchors` / issuer allowlist
-- rails/adapters it can settle on
+- `recognized_receipt_decisions`
+- `emitted_receipt_decisions`
+- `trust_anchors` / issuer allowlist with a closed trust-anchor status enum
+- rails/adapters it can settle on under `rails_adapters.accepted`
+- machine-readable claim boundaries under `claims`
 
 Do not add acceptor claims to the issuer artifact until an upstream actually accepts SatGate capabilities.
 

--- a/satgate-landing/app/.well-known/satgate-acceptor.schema.json/route.ts
+++ b/satgate-landing/app/.well-known/satgate-acceptor.schema.json/route.ts
@@ -1,0 +1,148 @@
+const schema = {
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://satgate.io/.well-known/satgate-acceptor.schema.json",
+  title: "SatGate Acceptor Metadata v0",
+  description:
+    "Draft machine-readable metadata for upstream APIs that accept SatGate-scoped capabilities and emit SatGate-compatible receipts. v0 is intentionally permissive but closes core enums before third-party drift.",
+  type: "object",
+  required: [
+    "schema_version",
+    "metadata_url",
+    "schema_url",
+    "roles",
+    "status",
+    "acceptor",
+    "accepted_capability_formats",
+    "recognized_receipt_decisions",
+    "emitted_receipt_decisions",
+    "trust_anchors",
+    "rails_adapters",
+    "claims",
+  ],
+  properties: {
+    schema_version: {
+      const: "satgate.acceptor_metadata.v0",
+      description: "Draft acceptor metadata schema. Breaking changes require a new schema_version.",
+    },
+    metadata_url: { type: "string", format: "uri", description: "Canonical URL for this acceptor metadata artifact." },
+    schema_url: { const: "https://satgate.io/.well-known/satgate-acceptor.schema.json" },
+    roles: {
+      type: "array",
+      items: { enum: ["acceptor", "issuer"] },
+      minItems: 1,
+      uniqueItems: true,
+      contains: { const: "acceptor" },
+      description: "Acceptor v0 artifacts must assert acceptor. Dual-role artifacts are reserved for same-path deployments and must still satisfy issuer schemas separately.",
+    },
+    status: {
+      enum: ["internal_mock_only", "draft", "active", "deprecated", "revoked"],
+      description: "Artifact lifecycle status. internal_mock_only is not a production acceptor claim.",
+    },
+    acceptor: {
+      type: "object",
+      required: ["name", "acceptor_id"],
+      properties: {
+        name: { type: "string" },
+        acceptor_id: { type: "string", format: "uri", description: "Stable upstream acceptor identity bound into returned receipts." },
+        verification_endpoint: { type: "string", format: "uri" },
+      },
+      additionalProperties: true,
+    },
+    accepted_capability_formats: {
+      type: "array",
+      items: { enum: ["satgate.capability.v1", "macaroon-bearer"] },
+      minItems: 1,
+      uniqueItems: true,
+      description: "Capability formats this upstream accepts as request authority.",
+    },
+    recognized_receipt_decisions: {
+      type: "array",
+      items: { enum: ["allowed", "paid"] },
+      minItems: 1,
+      uniqueItems: true,
+      description: "Prior receipt decisions this acceptor recognizes as acceptable evidence for entry. denied is intentionally excluded.",
+    },
+    emitted_receipt_decisions: {
+      type: "array",
+      items: { enum: ["allowed", "denied", "paid"] },
+      minItems: 1,
+      uniqueItems: true,
+      description: "Receipt decisions this acceptor can emit after evaluating a capability. Acceptor v0 emits a subset of the issuer decision space.",
+    },
+    trust_anchors: {
+      type: "array",
+      minItems: 1,
+      items: {
+        type: "object",
+        required: ["issuer_id", "status"],
+        properties: {
+          issuer_id: { type: "string", format: "uri" },
+          jwks_uri: { type: "string", format: "uri", description: "Optional explicit JWKS pin. If omitted, verifiers use {issuer_id}/.well-known/jwks.json after trust-anchor validation." },
+          status: {
+            enum: ["accepted", "provisional", "revoked", "deprecated", "accepted_for_mock"],
+            description: "Closed trust-anchor lifecycle state. accepted_for_mock is reserved for examples only.",
+          },
+        },
+        additionalProperties: true,
+      },
+    },
+    rails_adapters: {
+      type: "object",
+      required: ["accepted"],
+      properties: {
+        accepted: {
+          type: "array",
+          description: "Rails this upstream will settle via or route through. Acceptor metadata uses accepted; issuer metadata uses supported.",
+          items: {
+            type: "object",
+            required: ["id", "type", "role", "status"],
+            properties: {
+              id: { type: "string" },
+              type: { type: "string" },
+              role: { type: "string" },
+              status: { enum: ["supported", "planned", "deprecated"] },
+            },
+            additionalProperties: true,
+          },
+        },
+      },
+      additionalProperties: true,
+    },
+    claims: {
+      type: "object",
+      required: ["acceptance_means", "acceptance_does_not_mean"],
+      properties: {
+        acceptance_means: { const: "capability verification and receipt emission" },
+        acceptance_does_not_mean: {
+          type: "array",
+          allOf: [
+            { contains: { const: "marketplace listing" } },
+            { contains: { const: "reputation score" } },
+            { contains: { const: "SatGate endorsement" } },
+            { contains: { const: "network-wide trust" } },
+            { contains: { const: "ranking" } },
+            { contains: { const: "certification" } },
+          ],
+          items: {
+            enum: ["marketplace listing", "reputation score", "SatGate endorsement", "network-wide trust", "ranking", "certification"],
+          },
+          uniqueItems: true,
+        },
+      },
+      additionalProperties: true,
+    },
+  },
+  additionalProperties: true,
+} as const;
+
+export const dynamic = "force-static";
+
+export function GET() {
+  return Response.json(schema, {
+    headers: {
+      "Cache-Control": "public, max-age=86400",
+      "Access-Control-Allow-Origin": "*",
+      "X-Content-Type-Options": "nosniff",
+    },
+  });
+}

--- a/satgate-landing/app/accept-satgate-capabilities/page.tsx
+++ b/satgate-landing/app/accept-satgate-capabilities/page.tsx
@@ -43,7 +43,7 @@ const badgeCopy = [
   {
     label: "Machine signal",
     value: "roles: [\"acceptor\"]",
-    body: "Future acceptor metadata should advertise accepted capability formats, trust anchors, verification behavior, and returned receipt formats.",
+    body: "Acceptor metadata advertises accepted capability formats, trust anchors, recognized prior receipt decisions, emitted receipt decisions, and the claim boundary.",
   },
 ];
 
@@ -53,7 +53,7 @@ const checklist = [
   "Verify issuer trust anchor before fetching issuer JWKS.",
   "Verify signature, expiry, audience, route/tool scope, caveats, budget, and delegation depth before execution.",
   "Execute only the action authorized by the capability.",
-  "Return a SatGate-compatible receipt for allowed, denied, paid, delegated, or revoked decisions.",
+  "Return a SatGate-compatible receipt for the acceptor v0 decision subset: allowed, denied, or paid.",
   "Expose a test vector or mock endpoint before claiming real production acceptance.",
 ];
 
@@ -211,6 +211,7 @@ export default function AcceptSatGateCapabilitiesPage() {
             </div>
             <div className="mt-6 flex flex-wrap gap-3 md:mt-0">
               <Link href="/examples/mock-acceptor-metadata.v0.json" className="rounded-full border border-gray-700 px-5 py-3 text-sm font-bold text-white transition hover:border-cyan-400">Mock metadata</Link>
+              <Link href="/.well-known/satgate-acceptor.schema.json" className="rounded-full border border-gray-700 px-5 py-3 text-sm font-bold text-white transition hover:border-cyan-400">v0 schema</Link>
               <Link href="/examples/mock-accepted-satgate-receipt.v1.json" className="rounded-full bg-cyan-300 px-5 py-3 text-sm font-bold text-black transition hover:bg-cyan-200">Mock receipt</Link>
             </div>
           </div>

--- a/satgate-landing/public/examples/mock-acceptor-metadata.v0.json
+++ b/satgate-landing/public/examples/mock-acceptor-metadata.v0.json
@@ -14,10 +14,6 @@
     "satgate.capability.v1",
     "macaroon-bearer"
   ],
-  "accepted_receipt_decisions": [
-    "allowed",
-    "paid"
-  ],
   "trust_anchors": [
     {
       "issuer_id": "https://satgate.io",
@@ -47,12 +43,19 @@
       "marketplace listing",
       "reputation score",
       "SatGate endorsement",
-      "network-wide trust"
+      "network-wide trust",
+      "ranking",
+      "certification"
     ]
   },
   "emitted_receipt_decisions": [
     "allowed",
     "denied",
+    "paid"
+  ],
+  "schema_url": "https://satgate.io/.well-known/satgate-acceptor.schema.json",
+  "recognized_receipt_decisions": [
+    "allowed",
     "paid"
   ]
 }

--- a/satgate-landing/scripts/check_acceptance_story.py
+++ b/satgate-landing/scripts/check_acceptance_story.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import re
 import sys
 from pathlib import Path
 
@@ -14,6 +15,7 @@ ACCEPTOR_DOC = REPO / "docs" / "reference" / "acceptor.md"
 DOC_INDEX = REPO / "docs" / "index.md"
 SITEMAP = ROOT / "app" / "sitemap.ts"
 BUILD = ROOT / "app" / "build" / "page.tsx"
+SCHEMA_ROUTE = ROOT / "app" / ".well-known" / "satgate-acceptor.schema.json" / "route.ts"
 MOCK_METADATA = ROOT / "public" / "examples" / "mock-acceptor-metadata.v0.json"
 MOCK_RECEIPT = ROOT / "public" / "examples" / "mock-accepted-satgate-receipt.v1.json"
 
@@ -22,6 +24,8 @@ errors: list[str] = []
 for path, label in [
     (PAGE, "public acceptance page"),
     (DOC, "acceptance docs page"),
+    (ACCEPTOR_DOC, "acceptor metadata draft"),
+    (SCHEMA_ROUTE, "acceptor schema route"),
     (MOCK_METADATA, "mock acceptor metadata"),
     (MOCK_RECEIPT, "mock accepted receipt"),
 ]:
@@ -30,7 +34,9 @@ for path, label in [
 
 page_text = PAGE.read_text() if PAGE.exists() else ""
 doc_text = DOC.read_text() if DOC.exists() else ""
-combined = page_text + "\n" + doc_text
+acceptor_doc_text = ACCEPTOR_DOC.read_text() if ACCEPTOR_DOC.exists() else ""
+schema_text = SCHEMA_ROUTE.read_text() if SCHEMA_ROUTE.exists() else ""
+combined = page_text + "\n" + doc_text + "\n" + acceptor_doc_text + "\n" + schema_text
 
 required_strings = [
     "Accepts SatGate capabilities",
@@ -49,13 +55,26 @@ required_strings = [
     "receipt_id",
     "evidence_pack_id",
     "acceptor_id",
+    "recognized_receipt_decisions",
     "emitted_receipt_decisions",
+    "satgate-acceptor.schema.json",
+    "accepted_for_mock",
+    "provisional",
+    "revoked",
+    "deprecated",
+    "issuer-side authority lifecycle primitives",
+    "issuers can **support** rails",
+    "acceptors **accept** rails",
     "decision_reason",
     "policy_version",
 ]
 for needle in required_strings:
     if needle not in combined:
         errors.append(f"acceptance story missing required string: {needle}")
+
+for stale in ["accepted_receipt_decisions", "allowed, denied, paid, delegated, or revoked"]:
+    if stale in combined:
+        errors.append(f"stale ambiguous acceptor field remains: {stale}")
 
 # These are permitted only inside the explicit forbidden-copy section.
 for overclaim in [
@@ -79,22 +98,50 @@ if ACCEPTOR_DOC.exists() and "accept-satgate-capabilities.md" not in ACCEPTOR_DO
 if BUILD.exists() and "/accept-satgate-capabilities" not in BUILD.read_text():
     errors.append("/build does not link upstream acceptance story")
 
+schema_match = re.search(r"const schema = (\{.*?\}) as const;", schema_text, re.S) if schema_text else None
+if not schema_match:
+    errors.append("acceptor schema route does not define const schema")
+else:
+    # Avoid TypeScript parsing; assert the closed enum strings we care about are present.
+    for enum_value in [
+        "satgate.acceptor_metadata.v0",
+        "internal_mock_only",
+        "active",
+        "accepted",
+        "provisional",
+        "revoked",
+        "deprecated",
+        "accepted_for_mock",
+        "recognized_receipt_decisions",
+        "emitted_receipt_decisions",
+        "capability verification and receipt emission",
+    ]:
+        if enum_value not in schema_text:
+            errors.append(f"acceptor schema missing enum/field: {enum_value}")
+
 if MOCK_METADATA.exists():
     metadata = json.loads(MOCK_METADATA.read_text())
+    if metadata.get("schema_url") != "https://satgate.io/.well-known/satgate-acceptor.schema.json":
+        errors.append("mock acceptor metadata must point schema_url at v0 acceptor schema")
     if metadata.get("status") != "internal_mock_only":
         errors.append("mock acceptor metadata must be labeled internal_mock_only")
     if metadata.get("roles") != ["acceptor"]:
         errors.append("mock acceptor metadata must use roles: ['acceptor']")
     if "trust_anchors" not in metadata:
         errors.append("mock acceptor metadata missing trust_anchors")
+    for anchor in metadata.get("trust_anchors", []):
+        if anchor.get("status") not in {"accepted", "provisional", "revoked", "deprecated", "accepted_for_mock"}:
+            errors.append(f"trust anchor has undefined status enum: {anchor.get('status')}")
     claims = metadata.get("claims", {})
     if claims.get("acceptance_means") != "capability verification and receipt emission":
         errors.append("mock acceptor metadata must define honest acceptance_means")
-    for forbidden in ["marketplace listing", "reputation score", "SatGate endorsement", "network-wide trust"]:
+    for forbidden in ["marketplace listing", "reputation score", "SatGate endorsement", "network-wide trust", "ranking", "certification"]:
         if forbidden not in claims.get("acceptance_does_not_mean", []):
             errors.append(f"mock acceptor metadata missing negative claim: {forbidden}")
-    if "denied" in metadata.get("accepted_receipt_decisions", []):
-        errors.append("mock acceptor metadata must not treat denied as accepted evidence for entry")
+    if "accepted_receipt_decisions" in metadata:
+        errors.append("mock acceptor metadata must not use ambiguous accepted_receipt_decisions")
+    if "denied" in metadata.get("recognized_receipt_decisions", []):
+        errors.append("mock acceptor metadata must not treat denied as recognized evidence for entry")
     if "denied" not in metadata.get("emitted_receipt_decisions", []):
         errors.append("mock acceptor metadata should list denied under emitted_receipt_decisions")
 

--- a/satgate-landing/scripts/check_well_known_satgate.py
+++ b/satgate-landing/scripts/check_well_known_satgate.py
@@ -150,7 +150,7 @@ for needle in REQUIRED_DOC_STRINGS:
         errors.append(f"docs missing trust metadata string: {needle}")
 
 acceptor_text = ACCEPTOR_DOC.read_text() if ACCEPTOR_DOC.exists() else ""
-for needle in ["v0.0 draft", "verification_endpoint", "accepted_capability_formats", "trust_anchors", "rails_adapters", "not yet on the wire"]:
+for needle in ["v0.0 draft", "verification_endpoint", "accepted_capability_formats", "recognized_receipt_decisions", "emitted_receipt_decisions", "trust_anchors", "rails_adapters", "satgate-acceptor.schema.json"]:
     if needle not in acceptor_text:
         errors.append(f"acceptor draft missing required string: {needle}")
 


### PR DESCRIPTION
## Summary
- add `/.well-known/satgate-acceptor.schema.json` as a permissive v0 schema for acceptor metadata
- replace ambiguous `accepted_receipt_decisions` with `recognized_receipt_decisions` + `emitted_receipt_decisions`
- close trust-anchor lifecycle status values: `accepted`, `provisional`, `revoked`, `deprecated`, `accepted_for_mock`
- document acceptor decision-space subset and rails verb distinction: issuer `supported`, acceptor `accepted`
- tighten mock metadata/schema URL, machine-readable negative claims, page copy, and regression guards

## Test Plan
- `npm run test:acceptance-story`
- `npm run test:well-known`
- `npm run test:build-page`
- `npm run build`
- local `next start` smoke test for `/accept-satgate-capabilities`, `/.well-known/satgate-acceptor.schema.json`, and mock acceptor metadata

## Notes
- `denied` is not recognized as evidence for entry; it is only emitted as rejection evidence.
- Acceptor v0 emits a subset of issuer decisions: `allowed`, `denied`, `paid`.
- `accepted_for_mock` remains reserved for mock examples only.
