### PR TITLE
docs: prepare reputation substrate

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -31,6 +31,7 @@ SatGate Gateway is an enterprise API gateway that provides:
 | Export Policy-to-Proof evidence | [Evidence Pack v1](reference/evidence-pack.md) |
 | Discover SatGate trust metadata | [SatGate Trust Metadata](reference/satgate-trust-metadata.md) |
 | Validate SatGate receipts | [SatGate Receipt Schema](reference/receipt-schema.md) |
+| Preserve future verifier-derived reputation optionality | [Reputation Substrate](reference/reputation-substrate.md) |
 | Sketch upstream acceptor metadata | [Acceptor Metadata Draft](reference/acceptor.md) |
 | Accept SatGate capabilities upstream | [Accept SatGate Capabilities](reference/accept-satgate-capabilities.md) |
 | Run in production | [Production Checklist](operations/production-checklist.md) |

--- a/docs/reference/evidence-pack.md
+++ b/docs/reference/evidence-pack.md
@@ -158,3 +158,7 @@ Never leak raw bearer tokens, macaroons, prompts, customer payloads, or full ext
 - chain type: `linear_hash_chain`
 
 The top-level signature signs the Evidence Pack envelope and receipt-chain root. Demo fixtures are explicitly marked as non-verifiable because they use deterministic placeholder hashes and a redacted demo signature.
+
+## Event history and future verifier conclusions
+
+Evidence Pack v1 may include optional `event_history` entries. Event history is the substrate for verifier-observed conclusions such as stayed within budget, completed task, looped/retried, revoked/attenuated, vouched by principal, or accepted by upstream. It is not a public score surface. Reputation, if ever exposed, must fall out of signed receipts and verifier-observed history rather than SatGate assertion.

--- a/docs/reference/receipt-schema.md
+++ b/docs/reference/receipt-schema.md
@@ -93,6 +93,19 @@ Specific profiles can emit a subset. For example, acceptor metadata v0 emits onl
 - `paid` receipts require `amount_usd`, `currency: "USD"`, and `rail` so paid-call evidence does not lose payment context.
 - If `acceptor_id` is present, `capability_hash` is required so acceptor-bound receipts are tied to the capability material without leaking raw credentials.
 
+## Optional verifier-context fields
+
+Receipt v1 is intentionally additive. The following optional fields preserve future verifier/audit optionality without launching public reputation, scores, rankings, or marketplace semantics:
+
+- `task_id`, `task_status` — correlate receipts to a requested task and observed completion state.
+- `attempt`, `max_attempts`, `retry_of_receipt_id`, `parent_receipt_id` — support loop/retry analysis across event history.
+- `budget_id`, `budget_limit_usd` — bind receipts to the budget envelope used for stayed-within-budget conclusions.
+- `principal_id`, `principal_authorization_id`, `vouch_receipt_id` — preserve evidence that a named principal vouched for a subject or capability.
+- `attenuation_depth`, `caveats_hash`, `revoked_receipt_id` — preserve delegation, attenuation, caveat, and revocation lineage without leaking raw credentials.
+- `event_history_ref` — link to Evidence Pack event history when sequence evidence is required.
+
+These fields are evidence handles. They do not create a reputation claim by themselves. Verifier conclusions must be derived from signed receipts, event history, trust anchors, and verifier policy. See [Reputation Substrate](reputation-substrate.md).
+
 ## Related artifacts
 
 - Issuer metadata: `https://satgate.io/.well-known/satgate`

--- a/docs/reference/reputation-substrate.md
+++ b/docs/reference/reputation-substrate.md
@@ -1,0 +1,200 @@
+# Reputation Substrate
+
+Status: **internal substrate only — no public reputation launch**.
+
+This document inventories the receipt fields, event history, and verifier evidence needed to support future trust or reputation analysis without minting a public score, ranking, marketplace claim, certification, or endorsement.
+
+The substrate inventory covers: stayed within budget, completed requested task, looped or retried excessively, was revoked or attenuated, was vouched by a principal, and was accepted by upstream.
+
+Principle: **reputation falls out of signed receipts and verifier-observed history; SatGate should not mint reputation by assertion.**
+
+A future reputation view is only credible if it is derived from real transaction history: signed `satgate.receipt.v1` receipts, issuer/acceptor trust metadata, Evidence Pack event history, and verifier policy. Until that history exists, SatGate should expose proof artifacts and verification criteria — not scores.
+
+## Non-goals
+
+SatGate must not publicly launch any of the following without real transaction history and explicit product approval:
+
+- reputation score
+- trust score
+- ranking
+- marketplace listing
+- certification
+- SatGate endorsement
+- network-wide trust badge
+- public directory ordered by quality or trust
+
+`Accepts SatGate capabilities` remains the correct public phrase. It means scoped capability verification plus SatGate-compatible receipt emission. It does not mean the upstream is trusted, ranked, certified, or vouched for by SatGate.
+
+## Questions the substrate must eventually answer
+
+### Stayed within budget
+
+Verifier question: did the subject remain within the budget envelope that applied at decision time?
+
+Evidence needed:
+
+- `receipt_id`
+- `evidence_pack_id`
+- `subject` or `agent_id`
+- `budget_id`
+- `budget_limit_usd`
+- `amount_usd` or `attempted_amount_usd`
+- `remaining_budget_usd`
+- `decision`
+- `decision_reason`
+- `policy_version`
+- `timestamp`
+- Evidence Pack `budget_snapshot`
+- event history entries: `budget_observed`, `budget_denied`
+
+Interpretation boundary: “stayed within budget” is a verifier conclusion over receipts and budget snapshots, not a global claim about the subject.
+
+### Completed requested task
+
+Verifier question: did the subject complete the requested work, or merely receive authority to attempt it?
+
+Evidence needed:
+
+- `task_id`
+- `task_status`
+- `receipt_id`
+- `decision`
+- `decision_reason`
+- `route_or_tool`
+- `timestamp`
+- optional upstream or principal completion receipt
+- event history entries: `task_requested`, `task_started`, `task_completed`, `task_failed`
+
+Interpretation boundary: an `allowed` receipt proves authority was granted; it does not by itself prove task completion.
+
+### Looped or retried excessively
+
+Verifier question: did the subject retry/loop beyond normal policy or task limits?
+
+Evidence needed:
+
+- `task_id`
+- `attempt`
+- `max_attempts`
+- `retry_of_receipt_id`
+- `parent_receipt_id`
+- `decision_reason`
+- `timestamp`
+- ordered event history with event hashes or receipt chain references
+- event history entries: `attempt`, `retry`
+
+Interpretation boundary: loop detection requires event sequence history. A single receipt can carry attempt context, but cannot prove absence of looping alone.
+
+### Was revoked or attenuated
+
+Verifier question: was the capability revoked, delegated, or attenuated before/at the decision?
+
+Evidence needed:
+
+- `capability_id` or `capability_hash`
+- `parent_receipt_id`
+- `revoked_receipt_id`
+- `attenuation_depth`
+- `caveats_hash`
+- `decision`: `delegated` or `revoked` where applicable
+- `decision_reason`
+- `policy_version`
+- Evidence Pack `authority_chain`
+- event history entries: `delegated`, `attenuated`, `revoked`
+
+Interpretation boundary: revocation/attenuation is authority lifecycle evidence. It is not reputation by itself.
+
+### Was vouched by a principal
+
+Verifier question: did a human, service owner, or principal explicitly vouch for this capability/agent/upstream?
+
+Evidence needed:
+
+- `principal_id`
+- `principal_authorization_id`
+- `vouch_receipt_id`
+- `subject` or `agent_id`
+- `capability_id` or `capability_hash`
+- `timestamp`
+- signature/JWKS verification for the principal or issuer path
+- event history entry: `principal_vouched`
+
+Interpretation boundary: a vouch is scoped evidence from a named principal. It is not a SatGate endorsement unless SatGate is the principal and explicitly says so in a signed receipt.
+
+### Was accepted by upstream
+
+Verifier question: did an upstream actually accept a SatGate capability and emit a compatible receipt?
+
+Evidence needed:
+
+- `acceptor_id`
+- `issuer`
+- `issuer_kid`
+- `capability_hash`
+- `decision`: `allowed`, `denied`, or `paid` in acceptor v0
+- `receipt_hash`
+- `signature`
+- acceptor metadata trust anchors
+- event history entries: `upstream_accepted`, `upstream_denied`
+
+Interpretation boundary: upstream acceptance proves that one integration path verified authority and emitted a receipt. It does not prove global upstream quality, safety, or ranking.
+
+## Additive schema optionality
+
+`/.well-known/satgate-receipt.schema.json` remains backward-compatible. The substrate adds optional field names so future emitters do not invent incompatible names:
+
+- `task_id`
+- `task_status`
+- `attempt`
+- `max_attempts`
+- `retry_of_receipt_id`
+- `parent_receipt_id`
+- `budget_id`
+- `budget_limit_usd`
+- `principal_id`
+- `principal_authorization_id`
+- `vouch_receipt_id`
+- `attenuation_depth`
+- `caveats_hash`
+- `revoked_receipt_id`
+- `event_history_ref`
+
+None of these fields are required in v1. They preserve future optionality without breaking existing receipts.
+
+Evidence Pack v1 likewise keeps an optional `event_history` array for verifier-observed history. Event history can answer sequence questions that a single receipt cannot: looping, retry counts, task lifecycle, post-revocation denials, and upstream acceptance over time.
+
+## Verifier posture
+
+A verifier can compute local conclusions from receipts and events, such as:
+
+- “within budget for policy X during window Y”
+- “completed task Z under principal P”
+- “retried N times and stayed under max_attempts M”
+- “denied after revocation receipt R”
+- “accepted by upstream A under trust-anchor set T”
+
+Those are evidence-derived conclusions. They should stay local or auditor-facing until there is real transaction history, clear scope, and an explicit product decision to expose any aggregate view.
+
+## Guardrail language
+
+Allowed:
+
+- “receipt-derived evidence”
+- “verifier-observed history”
+- “Evidence Pack event history”
+- “acceptance proves verification behavior”
+- “reputation falls out of signed receipts”
+
+Forbidden in public launch copy:
+
+- “SatGate reputation score”
+- “trust score”
+- “ranked upstreams”
+- “certified acceptor”
+- “trusted marketplace”
+- “SatGate endorsed”
+- “network-wide reputation”
+
+## Implementation rule
+
+If a future UI wants to show any reputation-like summary, it must first point to the receipts, event history window, verifier policy, and trust anchors used to compute it. No receipts, no score. No observed history, no ranking. No signed principal vouch, no vouch claim.

--- a/satgate-landing/package.json
+++ b/satgate-landing/package.json
@@ -16,7 +16,8 @@
     "test:proof-spine": "python3 scripts/check_proof_spine.py",
     "test:well-known": "python3 scripts/check_well_known_satgate.py",
     "test:acceptance-story": "python3 scripts/check_acceptance_story.py && python3 scripts/check_receipt_schema.py",
-    "test:receipt-schema": "python3 scripts/check_receipt_schema.py"
+    "test:receipt-schema": "python3 scripts/check_receipt_schema.py",
+    "test:reputation-substrate": "python3 scripts/check_reputation_substrate.py"
   },
   "dependencies": {
     "lucide-react": "^0.555.0",

--- a/satgate-landing/public/evidence-packs/evidence-pack.schema.v1.json
+++ b/satgate-landing/public/evidence-packs/evidence-pack.schema.v1.json
@@ -135,6 +135,13 @@
     "signature": {
       "type": "string",
       "pattern": "^(ed25519:|REDACTED|demo:)"
+    },
+    "event_history": {
+      "type": "array",
+      "description": "Optional verifier-observed events used to answer budget/task/loop/revocation/vouch/acceptance questions. Events are evidence, not reputation scores.",
+      "items": {
+        "$ref": "#/$defs/event"
+      }
     }
   },
   "$defs": {
@@ -479,6 +486,77 @@
           "type": "integer"
         }
       }
+    },
+    "event": {
+      "type": "object",
+      "required": [
+        "event_id",
+        "event_type",
+        "timestamp",
+        "subject",
+        "receipt_id"
+      ],
+      "properties": {
+        "event_id": {
+          "type": "string"
+        },
+        "event_type": {
+          "enum": [
+            "task_requested",
+            "task_started",
+            "task_completed",
+            "task_failed",
+            "attempt",
+            "retry",
+            "budget_observed",
+            "budget_denied",
+            "delegated",
+            "attenuated",
+            "revoked",
+            "principal_vouched",
+            "upstream_accepted",
+            "upstream_denied"
+          ]
+        },
+        "timestamp": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "subject": {
+          "$ref": "#/$defs/identity"
+        },
+        "receipt_id": {
+          "type": "string"
+        },
+        "task_id": {
+          "type": "string"
+        },
+        "attempt": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "budget_id": {
+          "type": "string"
+        },
+        "principal_id": {
+          "type": "string"
+        },
+        "acceptor_id": {
+          "type": "string",
+          "format": "uri"
+        },
+        "prev_event_hash": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "event_hash": {
+          "type": "string",
+          "pattern": "^sha256:"
+        }
+      },
+      "additionalProperties": true
     }
   }
 }

--- a/satgate-landing/schemas/satgate-receipt.schema.json
+++ b/satgate-landing/schemas/satgate-receipt.schema.json
@@ -177,6 +177,86 @@
     "settlement_reference": {
       "type": "string",
       "description": "Optional rail or ledger settlement reference for paid receipts."
+    },
+    "task_id": {
+      "type": "string",
+      "description": "Optional correlation id for the user/principal task this receipt helps prove."
+    },
+    "task_status": {
+      "enum": [
+        "requested",
+        "started",
+        "completed",
+        "failed",
+        "cancelled",
+        "partial"
+      ],
+      "description": "Optional task lifecycle state observed by a verifier or gateway."
+    },
+    "attempt": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "Optional 1-based attempt number for loop/retry analysis."
+    },
+    "max_attempts": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "Optional policy or verifier retry ceiling for the correlated task/action."
+    },
+    "retry_of_receipt_id": {
+      "type": "string",
+      "description": "Optional prior receipt id when this receipt is a retry or loop continuation."
+    },
+    "parent_receipt_id": {
+      "type": "string",
+      "description": "Optional parent receipt id for delegation, attenuation, revocation, or chained execution evidence."
+    },
+    "budget_id": {
+      "type": "string",
+      "description": "Optional budget ledger identifier used to prove stayed-within-budget later."
+    },
+    "budget_limit_usd": {
+      "oneOf": [
+        {
+          "type": "string",
+          "pattern": "^(0|[1-9]\\d*)(\\.\\d{1,6})?$"
+        },
+        {
+          "type": "number",
+          "minimum": 0
+        }
+      ],
+      "description": "Optional USD budget ceiling observed for this decision."
+    },
+    "principal_id": {
+      "type": "string",
+      "description": "Optional human/principal/service identity that authorized, delegated, vouched, or revoked authority."
+    },
+    "principal_authorization_id": {
+      "type": "string",
+      "description": "Optional id for the principal authorization or vouch event behind this decision."
+    },
+    "vouch_receipt_id": {
+      "type": "string",
+      "description": "Optional receipt id that records a principal vouch. This is evidence, not a score."
+    },
+    "attenuation_depth": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Optional observed attenuation/delegation depth at this decision."
+    },
+    "caveats_hash": {
+      "type": "string",
+      "pattern": "^sha256:[A-Za-z0-9+/=_:-]+$",
+      "description": "Optional hash of effective caveats/scopes without leaking raw credential material."
+    },
+    "revoked_receipt_id": {
+      "type": "string",
+      "description": "Optional receipt id for the revocation event this decision enforces or proves."
+    },
+    "event_history_ref": {
+      "type": "string",
+      "description": "Optional Evidence Pack or event stream reference used for verifier-observed history."
     }
   },
   "anyOf": [

--- a/satgate-landing/scripts/check_reputation_substrate.py
+++ b/satgate-landing/scripts/check_reputation_substrate.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+"""Regression guard for reputation substrate without public reputation launch."""
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+REPO = ROOT.parent
+RECEIPT_SCHEMA = ROOT / "schemas" / "satgate-receipt.schema.json"
+EVIDENCE_SCHEMA = ROOT / "public" / "evidence-packs" / "evidence-pack.schema.v1.json"
+SUBSTRATE_DOC = REPO / "docs" / "reference" / "reputation-substrate.md"
+RECEIPT_DOC = REPO / "docs" / "reference" / "receipt-schema.md"
+EVIDENCE_DOC = REPO / "docs" / "reference" / "evidence-pack.md"
+DOC_INDEX = REPO / "docs" / "index.md"
+PUBLIC_ROOTS = [ROOT / "app", ROOT / "public"]
+
+errors: list[str] = []
+
+for path, label in [
+    (RECEIPT_SCHEMA, "receipt schema"),
+    (EVIDENCE_SCHEMA, "evidence pack schema"),
+    (SUBSTRATE_DOC, "reputation substrate doc"),
+    (RECEIPT_DOC, "receipt schema doc"),
+    (DOC_INDEX, "docs index"),
+]:
+    if not path.exists():
+        errors.append(f"missing {label}: {path}")
+
+if errors:
+    print("reputation substrate check failed:")
+    for error in errors:
+        print(f"- {error}")
+    sys.exit(1)
+
+receipt_schema = json.loads(RECEIPT_SCHEMA.read_text())
+evidence_schema = json.loads(EVIDENCE_SCHEMA.read_text())
+substrate_text = SUBSTRATE_DOC.read_text()
+receipt_doc_text = RECEIPT_DOC.read_text()
+evidence_doc_text = EVIDENCE_DOC.read_text() if EVIDENCE_DOC.exists() else ""
+index_text = DOC_INDEX.read_text()
+combined_reference = "\n".join([substrate_text, receipt_doc_text, evidence_doc_text, index_text])
+
+# Required inventory questions and principle.
+for needle in [
+    "stayed within budget",
+    "completed requested task",
+    "looped or retried excessively",
+    "was revoked or attenuated",
+    "was vouched by a principal",
+    "was accepted by upstream",
+    "reputation falls out of signed receipts",
+    "SatGate should not mint reputation by assertion",
+    "No receipts, no score",
+    "No observed history, no ranking",
+]:
+    if needle not in combined_reference:
+        errors.append(f"missing reputation-substrate principle/inventory phrase: {needle}")
+
+# Optional receipt field names must be stable and non-required.
+optional_receipt_fields = [
+    "task_id",
+    "task_status",
+    "attempt",
+    "max_attempts",
+    "retry_of_receipt_id",
+    "parent_receipt_id",
+    "budget_id",
+    "budget_limit_usd",
+    "principal_id",
+    "principal_authorization_id",
+    "vouch_receipt_id",
+    "attenuation_depth",
+    "caveats_hash",
+    "revoked_receipt_id",
+    "event_history_ref",
+]
+receipt_required = set(receipt_schema.get("required", []))
+receipt_properties = receipt_schema.get("properties", {})
+for field in optional_receipt_fields:
+    if field not in receipt_properties:
+        errors.append(f"receipt schema missing optional substrate field: {field}")
+    if field in receipt_required:
+        errors.append(f"substrate field must stay optional in receipt v1: {field}")
+    if field not in receipt_doc_text or field not in substrate_text:
+        errors.append(f"docs missing optional substrate field: {field}")
+
+# Evidence Pack event history must be optional and expressive enough for verifier history.
+evidence_required = set(evidence_schema.get("required", []))
+if "event_history" not in evidence_schema.get("properties", {}):
+    errors.append("evidence pack schema missing optional event_history")
+if "event_history" in evidence_required:
+    errors.append("event_history must remain optional in Evidence Pack v1")
+event_def = evidence_schema.get("$defs", {}).get("event", {})
+event_types = event_def.get("properties", {}).get("event_type", {}).get("enum", [])
+for event_type in [
+    "task_requested",
+    "task_started",
+    "task_completed",
+    "task_failed",
+    "attempt",
+    "retry",
+    "budget_observed",
+    "budget_denied",
+    "delegated",
+    "attenuated",
+    "revoked",
+    "principal_vouched",
+    "upstream_accepted",
+    "upstream_denied",
+]:
+    if event_type not in event_types:
+        errors.append(f"event history enum missing: {event_type}")
+
+def _has_boundary_context(text: str, start: int, end: int) -> bool:
+    window = text[max(0, start - 500): min(len(text), end + 500)]
+    return any(
+        marker in window
+        for marker in [
+            "acceptance_does_not_mean",
+            "Forbidden badge copy",
+            "What the badge does not mean",
+            "does **not** mean",
+            "does not mean",
+            "must not claim",
+            "Forbidden in public launch copy",
+            "Non-goals",
+            "overclaim",
+        ]
+    )
+
+# Keep public launch language out of app/public surfaces except explicit anti-claim examples.
+public_forbidden = [
+    r"SatGate reputation score",
+    r"trust score",
+    r"ranked upstreams",
+    r"certified acceptor",
+    r"trusted marketplace",
+    r"SatGate endorsed",
+    r"network-wide reputation",
+]
+for root in PUBLIC_ROOTS:
+    for path in root.rglob("*"):
+        if not path.is_file() or path.suffix.lower() not in {".ts", ".tsx", ".json", ".md", ".txt"}:
+            continue
+        text = path.read_text(errors="ignore")
+        for pattern in public_forbidden:
+            for match in re.finditer(pattern, text, flags=re.IGNORECASE):
+                if not _has_boundary_context(text, match.start(), match.end()):
+                    errors.append(f"public surface has forbidden reputation launch phrase {pattern}: {path.relative_to(ROOT)}")
+
+for pattern in public_forbidden:
+    # Explicit docs may mention forbidden phrases only as boundaries.
+    if not re.search(pattern, substrate_text, flags=re.IGNORECASE):
+        errors.append(f"substrate doc missing forbidden-boundary phrase: {pattern}")
+
+if "reference/reputation-substrate.md" not in index_text:
+    errors.append("docs index missing reputation substrate reference")
+
+if errors:
+    print("reputation substrate check failed:")
+    for error in errors:
+        print(f"- {error}")
+    sys.exit(1)
+
+print("reputation substrate check passed")


### PR DESCRIPTION
## Summary
- add `docs/reference/reputation-substrate.md` as an internal substrate inventory, explicitly not a public reputation launch
- add optional receipt fields for future verifier evidence: task, retry/loop, budget, principal vouch, attenuation/revocation, and event-history references
- add optional Evidence Pack `event_history` for verifier-observed sequences
- add `test:reputation-substrate` guard for optionality and anti-overclaim boundaries

## Guardrails
- no public score UI
- no marketplace/ranking/certification/endorsement launch
- principle documented: reputation falls out of signed receipts and verifier-observed history; SatGate should not mint reputation by assertion

## Verification
- `npm run test:reputation-substrate`
- `npm run test:receipt-schema`
- `npm run test:proof-spine`
- `npm run test:well-known`
- `npm run build`
