### PR TITLE
feat: add rail partner authority brief

### DIFF
--- a/satgate-landing/app/agent-authority-layer/page.tsx
+++ b/satgate-landing/app/agent-authority-layer/page.tsx
@@ -7,7 +7,7 @@ export const metadata: Metadata = {
   description:
     "SatGate is the rail-neutral authority and accountability layer for AI agents. Signed, verifiable receipts before any rail moves value.",
   keywords: [
-    "agent authority layer",
+    "agent authority and accountability layer",
     "AI agent accountability",
     "AI agent receipts",
     "Evidence Pack verifier",
@@ -63,6 +63,7 @@ const publicSpecs = [
   ["Receipt JSON schema", "https://satgate.io/.well-known/satgate-receipt.schema.json"],
   ["Issuer JWKS", "https://api.satgate.io/.well-known/jwks.json"],
   ["Open verifier", "https://github.com/SatGate-io/evidence-pack-verifier"],
+  ["Rail partner brief", "/partners/rails"],
 ];
 
 const faqs = [

--- a/satgate-landing/app/agent-control-plane/page.tsx
+++ b/satgate-landing/app/agent-control-plane/page.tsx
@@ -30,7 +30,7 @@ export const metadata: Metadata = {
     "agent kill switch",
     "agent Evidence Pack",
     "AI agent spend governance",
-    "economic control plane for AI agents",
+    "economic firewall for AI agents",
   ],
   alternates: {
     canonical: "https://satgate.io/agent-control-plane",

--- a/satgate-landing/app/blog/cursor-mcp-proxy-setup-guide/page.tsx
+++ b/satgate-landing/app/blog/cursor-mcp-proxy-setup-guide/page.tsx
@@ -359,7 +359,7 @@ satgate-gateway --config ./satgate.yaml`}</code>
           <h2 className="text-2xl font-bold mt-8 mb-4 text-white">Final takeaway</h2>
 
           <p className="text-gray-300 leading-relaxed">
-            Cursor MCP is not the problem. Unbounded access is. A proxy layer gives you the missing economic control plane, so the editor can stay fast without turning your tools into an unmetered free-for-all.
+            Cursor MCP is not the problem. Unbounded access is. A proxy layer gives you the missing economic firewall, so the editor can stay fast without turning your tools into an unmetered free-for-all.
           </p>
 
           <p className="text-gray-300 leading-relaxed">

--- a/satgate-landing/app/build/page.tsx
+++ b/satgate-landing/app/build/page.tsx
@@ -337,7 +337,7 @@ export default function BuildPage() {
             <h2 className="text-3xl font-bold text-white sm:text-4xl">Authority and evidence sit above the rail.</h2>
             <div className="mt-5 space-y-5 text-lg leading-8 text-gray-400">
               <p>
-                Payment rails change. The authority and evidence layer is the durable abstraction. SatGate governs MCP tools, REST APIs, API-key billing, x402, L402, and enterprise ledgers today, and is designed to govern planned rails such as AgentCore Payments and Pay.sh without forcing your agent code to care which rail settled underneath.
+                Payment rails change. The Agent Authority & Accountability Layer is the durable abstraction. SatGate governs MCP tools, REST APIs, API-key billing, x402, L402, and enterprise ledgers today, and is designed to govern planned rails such as AgentCore Payments and Pay.sh without forcing your agent code to care which rail settled underneath.
               </p>
               <p>
                 The machine-readable <a href="https://satgate.io/.well-known/satgate" className="text-cyan-300 hover:text-cyan-200">/.well-known/satgate</a> artifact is canonical for rail adapter status; marketing copy should defer to it when a rail is planned rather than already supported.
@@ -445,7 +445,7 @@ export default function BuildPage() {
                 "Scoped authority before every action",
                 "Receipts for allowed, denied, delegated, revoked, and paid decisions",
                 "Evidence Pack IDs your principal can audit",
-                "Rail adapters below the authority layer",
+                "Rail adapters below the Agent Authority & Accountability Layer",
                 "Developer docs instead of payment-company ceremony",
               ].map((item) => (
                 <div key={item} className="flex items-start gap-3 rounded-xl border border-gray-800 bg-black/60 p-4">

--- a/satgate-landing/app/compare/apigee/page.tsx
+++ b/satgate-landing/app/compare/apigee/page.tsx
@@ -30,7 +30,7 @@ export const metadata = {
 };
 
 const rows: Array<[string, string, string]> = [
-  ['Primary job', 'Economic control plane for AI agents', 'Enterprise API management, API products, developer portals, analytics, policy, monetization, and Google Cloud integration'],
+  ['Primary job', 'Economic Firewall for AI agents', 'Enterprise API management, API products, developer portals, analytics, policy, monetization, and Google Cloud integration'],
   ['Best fit', 'Agent/API spend governance, MCP tool budgets, scoped credentials, revocation, audit, and paid-rail context', 'Enterprise API management, API products, developer portals, analytics, policy, monetization, and Google Cloud integration'],
   ['Request-path hard budget enforcement', 'Yes: before upstream API, model, or MCP tool access', 'Partial / depends on gateway policy and traffic type'],
   ['MCP tool budget enforcement', 'Yes: per-tool budgets, cost attribution, and deny decisions', 'Not the primary category focus'],
@@ -86,7 +86,7 @@ export default function ComparePage() {
         <div className="mb-12 max-w-4xl">
           <div className="mb-6 inline-flex rounded-full border border-cyan-500/30 bg-cyan-950/25 px-4 py-2 text-sm text-cyan-200">Comparison</div>
           <h1 className="mb-5 text-5xl font-extrabold tracking-tight md:text-7xl">SatGate vs Google Apigee</h1>
-          <p className="text-xl leading-relaxed text-gray-300 md:text-2xl">Apigee is a full enterprise API management platform. SatGate is different: it is the request-path economic control plane for autonomous agents, API spend, MCP tools, scoped credentials, audit, and L402 paid-agent payments.</p>
+          <p className="text-xl leading-relaxed text-gray-300 md:text-2xl">Apigee is a full enterprise API management platform. SatGate is different: it is the request-path economic firewall for autonomous agents, API spend, MCP tools, scoped credentials, audit, and L402 paid-agent payments.</p>
         </div>
 
         <section className="mb-14 overflow-hidden rounded-2xl border border-gray-800">

--- a/satgate-landing/app/compare/bifrost/page.tsx
+++ b/satgate-landing/app/compare/bifrost/page.tsx
@@ -30,7 +30,7 @@ export default function CompareBifrostPage() {
     isPartOf: { '@type': 'WebSite', name: 'SatGate', url: 'https://satgate.io' },
     about: [
       { '@type': 'Thing', name: 'Bifrost alternative for AI agents' },
-      { '@type': 'Thing', name: 'LLM router vs economic control plane' },
+      { '@type': 'Thing', name: 'LLM router vs economic firewall' },
       { '@type': 'Thing', name: 'AI agent spend governance' },
       { '@type': 'Thing', name: 'MCP per-tool budget enforcement' },
     ],
@@ -197,7 +197,7 @@ export default function CompareBifrostPage() {
                   <p className="text-cyan-400 font-medium text-sm mb-2">SatGate</p>
                   <p className="text-gray-400 text-sm">
                     <strong className="text-white">Hard enforcement.</strong> When budget is exceeded, requests are blocked. 
-                    No "oops" moments. The CFO knows exactly what will be spent.
+                    No &quot;oops&quot; moments. The CFO knows exactly what will be spent.
                   </p>
                 </div>
                 <div className="bg-gray-800/50 rounded-lg p-4">
@@ -280,15 +280,15 @@ export default function CompareBifrostPage() {
                 </li>
                 <li className="flex items-start gap-2">
                   <Check className="text-cyan-400 mt-0.5 flex-shrink-0" size={16} />
-                  <span>You're <strong className="text-white">monetizing API access</strong> (charging per call)</span>
+                  <span>You&apos;re <strong className="text-white">monetizing API access</strong> (charging per call)</span>
                 </li>
                 <li className="flex items-start gap-2">
                   <Check className="text-cyan-400 mt-0.5 flex-shrink-0" size={16} />
-                  <span>You're protecting <strong className="text-white">REST APIs, MCP tools, or any HTTP endpoint</strong></span>
+                  <span>You&apos;re protecting <strong className="text-white">REST APIs, MCP tools, or any HTTP endpoint</strong></span>
                 </li>
                 <li className="flex items-start gap-2">
                   <Check className="text-cyan-400 mt-0.5 flex-shrink-0" size={16} />
-                  <span>The CFO asks <strong className="text-white">"how do we control AI spend?"</strong></span>
+                  <span>The CFO asks <strong className="text-white">&quot;how do we control AI spend?&quot;</strong></span>
                 </li>
               </ul>
             </div>
@@ -306,7 +306,7 @@ export default function CompareBifrostPage() {
                 </li>
                 <li className="flex items-start gap-2">
                   <Check className="text-gray-500 mt-0.5 flex-shrink-0" size={16} />
-                  <span>You're optimizing for <strong className="text-gray-300">minimum latency</strong> on LLM calls</span>
+                  <span>You&apos;re optimizing for <strong className="text-gray-300">minimum latency</strong> on LLM calls</span>
                 </li>
                 <li className="flex items-start gap-2">
                   <Check className="text-gray-500 mt-0.5 flex-shrink-0" size={16} />

--- a/satgate-landing/app/compare/helicone/page.tsx
+++ b/satgate-landing/app/compare/helicone/page.tsx
@@ -26,7 +26,7 @@ export const metadata = {
 };
 
 const rows: Array<[string, string, string]> = [
-  ['Primary job', 'Economic control plane for AI agents', 'LLM observability / AI gateway / debugging and analytics'],
+  ['Primary job', 'Economic Firewall for AI agents', 'LLM observability / AI gateway / debugging and analytics'],
   ['Best fit', 'Agent/API spend governance, MCP tool budgets, scoped access, audit, paid-rail governance', 'Routing, debugging, request analytics, provider integrations, LLM app monitoring'],
   ['Request-path hard budget enforcement', 'Yes', 'Partial or adjacent, depending on gateway limits and usage policy'],
   ['MCP tool budget enforcement', 'Yes', 'Not the primary economic-control focus'],

--- a/satgate-landing/app/compare/kong-ai-gateway/page.tsx
+++ b/satgate-landing/app/compare/kong-ai-gateway/page.tsx
@@ -30,7 +30,7 @@ export const metadata = {
 };
 
 const rows: Array<[string, string, string]> = [
-  ['Primary job', 'Economic control plane for AI agents', 'API gateway, AI gateway, service connectivity, plugins, traffic policy, API platform operations'],
+  ['Primary job', 'Economic Firewall for AI agents', 'API gateway, AI gateway, service connectivity, plugins, traffic policy, API platform operations'],
   ['Best fit', 'Agent/API spend governance, MCP tool budgets, scoped credentials, revocation, audit, and paid-rail context', 'API gateway, AI gateway, service connectivity, plugins, traffic policy, API platform operations'],
   ['Request-path hard budget enforcement', 'Yes: before upstream API, model, or MCP tool access', 'Partial / depends on gateway policy and traffic type'],
   ['MCP tool budget enforcement', 'Yes: per-tool budgets, cost attribution, and deny decisions', 'Not the primary category focus'],
@@ -86,7 +86,7 @@ export default function ComparePage() {
         <div className="mb-12 max-w-4xl">
           <div className="mb-6 inline-flex rounded-full border border-cyan-500/30 bg-cyan-950/25 px-4 py-2 text-sm text-cyan-200">Comparison</div>
           <h1 className="mb-5 text-5xl font-extrabold tracking-tight md:text-7xl">SatGate vs Kong AI Gateway</h1>
-          <p className="text-xl leading-relaxed text-gray-300 md:text-2xl">Kong AI Gateway is the AI-facing extension of a mature API gateway platform. SatGate is different: it is the request-path economic control plane for autonomous agents, API spend, MCP tools, scoped credentials, audit, and L402 paid-agent payments.</p>
+          <p className="text-xl leading-relaxed text-gray-300 md:text-2xl">Kong AI Gateway is the AI-facing extension of a mature API gateway platform. SatGate is different: it is the request-path economic firewall for autonomous agents, API spend, MCP tools, scoped credentials, audit, and L402 paid-agent payments.</p>
         </div>
 
         <section className="mb-14 overflow-hidden rounded-2xl border border-gray-800">

--- a/satgate-landing/app/compare/langfuse/page.tsx
+++ b/satgate-landing/app/compare/langfuse/page.tsx
@@ -30,7 +30,7 @@ export const metadata = {
 };
 
 const rows: Array<[string, string, string]> = [
-  ['Primary job', 'Economic control plane for AI agents', 'LLM observability, traces, prompt management, evaluations, metrics, debugging, and product analytics for AI applications'],
+  ['Primary job', 'Economic Firewall for AI agents', 'LLM observability, traces, prompt management, evaluations, metrics, debugging, and product analytics for AI applications'],
   ['Best fit', 'Agent/API spend governance, MCP tool budgets, scoped credentials, revocation, audit, and paid-rail context', 'LLM observability, traces, prompt management, evaluations, metrics, debugging, and product analytics for AI applications'],
   ['Request-path hard budget enforcement', 'Yes: before upstream API, model, or MCP tool access', 'Partial / depends on gateway policy and traffic type'],
   ['MCP tool budget enforcement', 'Yes: per-tool budgets, cost attribution, and deny decisions', 'Not the primary category focus'],
@@ -86,7 +86,7 @@ export default function ComparePage() {
         <div className="mb-12 max-w-4xl">
           <div className="mb-6 inline-flex rounded-full border border-cyan-500/30 bg-cyan-950/25 px-4 py-2 text-sm text-cyan-200">Comparison</div>
           <h1 className="mb-5 text-5xl font-extrabold tracking-tight md:text-7xl">SatGate vs Langfuse</h1>
-          <p className="text-xl leading-relaxed text-gray-300 md:text-2xl">Langfuse is an LLM observability and evaluation platform. SatGate is different: it is the request-path economic control plane for autonomous agents, API spend, MCP tools, scoped credentials, audit, and L402 paid-agent payments.</p>
+          <p className="text-xl leading-relaxed text-gray-300 md:text-2xl">Langfuse is an LLM observability and evaluation platform. SatGate is different: it is the request-path economic firewall for autonomous agents, API spend, MCP tools, scoped credentials, audit, and L402 paid-agent payments.</p>
         </div>
 
         <section className="mb-14 overflow-hidden rounded-2xl border border-gray-800">

--- a/satgate-landing/app/compare/litellm/page.tsx
+++ b/satgate-landing/app/compare/litellm/page.tsx
@@ -13,7 +13,7 @@ export const metadata = {
     'LiteLLM spend tracking',
     'AI agent cost control',
     'MCP budget enforcement',
-    'economic control plane for AI agents',
+    'economic firewall for AI agents',
   ],
   openGraph: {
     title: 'SatGate vs LiteLLM - AI Gateway vs Economic Firewall',
@@ -29,7 +29,7 @@ export const metadata = {
 };
 
 const rows: Array<[string, string, string]> = [
-  ['Primary job', 'Economic control plane for AI agents', 'LLM gateway / OpenAI-compatible proxy'],
+  ['Primary job', 'Economic Firewall for AI agents', 'LLM gateway / OpenAI-compatible proxy'],
   ['Best fit', 'Agent/API spend governance, MCP tool budgets, scoped access, paid-rail governance', 'Model access, provider abstraction, fallbacks, routing, developer LLM access'],
   ['Request-path hard budget enforcement', 'Yes', 'Partial: budgets and rate limits for LLM gateway usage'],
   ['MCP tool budget enforcement', 'Yes', 'No native MCP economic firewall focus'],

--- a/satgate-landing/app/compare/page.tsx
+++ b/satgate-landing/app/compare/page.tsx
@@ -42,7 +42,7 @@ const comparisons = [
   {
     href: '/compare/portkey',
     title: 'SatGate vs Portkey',
-    description: 'GenAI production stack vs economic control plane. Portkey covers gateway, observability, guardrails, and prompts; SatGate governs agent economics.',
+    description: 'GenAI production stack vs economic firewall. Portkey covers gateway, observability, guardrails, and prompts; SatGate governs agent economics.',
     icon: BarChart3,
     color: 'orange',
   },

--- a/satgate-landing/app/compare/portkey/page.tsx
+++ b/satgate-landing/app/compare/portkey/page.tsx
@@ -26,7 +26,7 @@ export const metadata = {
 };
 
 const rows: Array<[string, string, string]> = [
-  ['Primary job', 'Economic control plane for AI agents', 'Production GenAI stack / AI gateway / observability / guardrails'],
+  ['Primary job', 'Economic Firewall for AI agents', 'Production GenAI stack / AI gateway / observability / guardrails'],
   ['Best fit', 'Agent/API spend governance, MCP tool budgets, scoped access, audit, paid-rail governance', 'AI gateway, observability, guardrails, prompt management, governance, MCP access centralization'],
   ['Request-path hard budget enforcement', 'Yes', 'Partial or adjacent, depending on gateway limits and usage policy'],
   ['MCP tool budget enforcement', 'Yes', 'Not the primary economic-control focus'],

--- a/satgate-landing/app/compare/tyk/page.tsx
+++ b/satgate-landing/app/compare/tyk/page.tsx
@@ -30,7 +30,7 @@ export const metadata = {
 };
 
 const rows: Array<[string, string, string]> = [
-  ['Primary job', 'Economic control plane for AI agents', 'API gateway, API management, policies, developer portal, analytics, self-managed/hybrid/cloud deployment, AI-native APIM'],
+  ['Primary job', 'Economic Firewall for AI agents', 'API gateway, API management, policies, developer portal, analytics, self-managed/hybrid/cloud deployment, AI-native APIM'],
   ['Best fit', 'Agent/API spend governance, MCP tool budgets, scoped credentials, revocation, audit, and paid-rail context', 'API gateway, API management, policies, developer portal, analytics, self-managed/hybrid/cloud deployment, AI-native APIM'],
   ['Request-path hard budget enforcement', 'Yes: before upstream API, model, or MCP tool access', 'Partial / depends on gateway policy and traffic type'],
   ['MCP tool budget enforcement', 'Yes: per-tool budgets, cost attribution, and deny decisions', 'Not the primary category focus'],
@@ -86,7 +86,7 @@ export default function ComparePage() {
         <div className="mb-12 max-w-4xl">
           <div className="mb-6 inline-flex rounded-full border border-cyan-500/30 bg-cyan-950/25 px-4 py-2 text-sm text-cyan-200">Comparison</div>
           <h1 className="mb-5 text-5xl font-extrabold tracking-tight md:text-7xl">SatGate vs Tyk</h1>
-          <p className="text-xl leading-relaxed text-gray-300 md:text-2xl">Tyk is an API management platform with gateway, governance, analytics, and portal capabilities. SatGate is different: it is the request-path economic control plane for autonomous agents, API spend, MCP tools, scoped credentials, audit, and L402 paid-agent payments.</p>
+          <p className="text-xl leading-relaxed text-gray-300 md:text-2xl">Tyk is an API management platform with gateway, governance, analytics, and portal capabilities. SatGate is different: it is the request-path economic firewall for autonomous agents, API spend, MCP tools, scoped credentials, audit, and L402 paid-agent payments.</p>
         </div>
 
         <section className="mb-14 overflow-hidden rounded-2xl border border-gray-800">

--- a/satgate-landing/app/components/GovernClient.tsx
+++ b/satgate-landing/app/components/GovernClient.tsx
@@ -75,7 +75,7 @@ export default function GovernPage() {
             </span>
           </h1>
           <p className="text-xl text-gray-400 mb-10 max-w-2xl mx-auto leading-relaxed">
-            SatGate is the economic control plane for enterprise agents: scope authority before work starts, enforce policy at runtime, and preserve evidence after every allowed, denied, delegated, or revoked action.
+            SatGate is the Economic Firewall for enterprise agents: scope authority before work starts, enforce policy at runtime, and preserve evidence after every allowed, denied, delegated, or revoked action.
           </p>
           <div className="flex flex-col sm:flex-row gap-4 justify-center">
             <Link href="/policy-to-proof" className="bg-white text-black px-8 py-3 rounded-lg font-bold hover:bg-gray-200 transition flex items-center justify-center gap-2">

--- a/satgate-landing/app/components/HomeClient.tsx
+++ b/satgate-landing/app/components/HomeClient.tsx
@@ -30,7 +30,7 @@ const LandingPage = () => {
           <div className="hidden xl:flex items-center gap-5 text-sm font-medium text-gray-400">
             <Link href="/govern" className="hover:text-white transition">Enterprise</Link>
             <Link href="/mcp-gateway" className="hover:text-white transition">MCP Gateway</Link>
-            <Link href="/agent-authority-layer" className="hover:text-white transition">Authority Layer</Link>
+            <Link href="/agent-authority-layer" className="hover:text-white transition">Authority & Accountability</Link>
             <Link href="/build" className="hover:text-white transition">Build</Link>
             <Link href="/sandbox" className="hover:text-white transition">Demo</Link>
             <Link href="/pricing" className="hover:text-white transition">Pricing</Link>
@@ -75,7 +75,7 @@ const LandingPage = () => {
               onClick={() => setMobileMenuOpen(false)}
               className="block text-gray-400 hover:text-white hover:bg-gray-800/50 transition py-3 px-4 rounded-lg"
             >
-              Authority Layer
+              Authority & Accountability
             </Link>
             <Link
               href="/build"
@@ -730,7 +730,8 @@ const LandingPage = () => {
                 <li><Link href="/economic-firewall" className="hover:text-white transition">Economic Firewall</Link></li>
                 <li><Link href="/govern" className="hover:text-white transition">Enterprise</Link></li>
                 <li><Link href="/policy-to-proof" className="hover:text-white transition">Policy-to-Proof</Link></li>
-                <li><Link href="/agent-authority-layer" className="hover:text-white transition">Authority Layer</Link></li>
+                <li><Link href="/agent-authority-layer" className="hover:text-white transition">Authority & Accountability</Link></li>
+                <li><Link href="/partners/rails" className="hover:text-white transition">Rail Partners</Link></li>
                 <li><Link href="/pricing" className="hover:text-white transition">Pricing</Link></li>
                 <li><a href="https://cloud.satgate.io/cloud/login" target="_blank" rel="noopener noreferrer" className="hover:text-white transition">Cloud Dashboard</a></li>
               </ul>

--- a/satgate-landing/app/economic-firewall/page.tsx
+++ b/satgate-landing/app/economic-firewall/page.tsx
@@ -10,7 +10,7 @@ export const metadata = {
     'economic firewall for AI agents',
     'AI agent spend control',
     'AI agent budget enforcement',
-    'economic control plane for AI agents',
+    'economic firewall for AI agents',
     'request-layer cost control',
     'API budget enforcement',
     'agent API governance',

--- a/satgate-landing/app/govern/page.tsx
+++ b/satgate-landing/app/govern/page.tsx
@@ -11,7 +11,7 @@ export const metadata: Metadata = {
   keywords: [
     "enterprise AI agent governance",
     "AI agent authority governance",
-    "economic control plane for AI agents",
+    "economic firewall for AI agents",
     "MCP governance for enterprises",
     "AI agent budget enforcement",
     "agent delegation controls",
@@ -43,7 +43,7 @@ const webPageSchema = {
   isPartOf: { "@type": "WebSite", name: "SatGate", url: "https://satgate.io" },
   about: [
     { "@type": "Thing", name: "AI agent governance" },
-    { "@type": "Thing", name: "economic control plane for AI agents" },
+    { "@type": "Thing", name: "economic firewall for AI agents" },
     { "@type": "Thing", name: "MCP governance for enterprises" },
     { "@type": "Thing", name: "agent delegation controls" },
     { "@type": "Thing", name: "Policy-to-Proof for AI agents" },
@@ -64,7 +64,7 @@ const faqSchema = {
     },
     {
       "@type": "Question",
-      name: "What is an economic control plane for AI agents?",
+      name: "What is an economic firewall for AI agents?",
       acceptedAnswer: {
         "@type": "Answer",
         text: "An economic firewall for AI agents sits in the request path and applies scopes, budgets, delegation rules, revocation, and audit before an agent reaches an upstream API, model, or MCP tool. Humans and platforms set authority; agents consume bounded primitives; upstreams receive evidence.",

--- a/satgate-landing/app/mcp-budget-enforcement/page.tsx
+++ b/satgate-landing/app/mcp-budget-enforcement/page.tsx
@@ -194,7 +194,7 @@ export default function McpBudgetEnforcementPage() {
             Rate limits are too crude. Dashboards are too late. Approval queues do not scale when agents make hundreds of small decisions. MCP budget enforcement belongs in the request path, where each tool call can be priced, evaluated, allowed, denied, routed, approved, or bound to paid-rail context before execution.
           </p>
           <p>
-            SatGate is the authority layer for that path: observe MCP activity, control risky spend before execution, and prove each budget or paid-rail decision with an Evidence Pack receipt.
+            SatGate is the economic firewall for that path: observe MCP activity, control risky spend before execution, and prove each budget or paid-rail decision with an Evidence Pack receipt.
           </p>
         </div>
         <div className="rounded-2xl border border-cyan-900/50 bg-cyan-950/10 p-6">

--- a/satgate-landing/app/partners/rails/page.tsx
+++ b/satgate-landing/app/partners/rails/page.tsx
@@ -1,0 +1,220 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { ArrowRight, BadgeCheck, FileText, GitBranch, Handshake, Layers3, ReceiptText, ShieldCheck } from "lucide-react";
+
+export const metadata: Metadata = {
+  title: "SatGate for Payment Rails | Agent Authority & Accountability",
+  description:
+    "SatGate gives payment rails, API platforms, and agent ecosystems a rail-neutral authority and accountability layer: policy before action, receipts after action, and Evidence Packs for dispute-ready proof.",
+  keywords: [
+    "agent payment rail governance",
+    "AI agent authority and accountability layer",
+    "x402 governance",
+    "L402 governance",
+    "agent payment receipts",
+    "Evidence Pack verifier",
+    "agent accountability layer",
+  ],
+  alternates: { canonical: "https://satgate.io/partners/rails" },
+  openGraph: {
+    title: "SatGate for Payment Rails | Agent Authority & Accountability",
+    description:
+      "A rail-neutral Economic Firewall for partners that need authorization, scope, budget, and Evidence Pack proof around agent-initiated transactions.",
+    url: "https://satgate.io/partners/rails",
+    type: "website",
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "SatGate for Payment Rails",
+    description:
+      "Policy before agent action. Receipts after action. Evidence Packs for partner review.",
+  },
+};
+
+const partnerFit = [
+  ["Payment rails", "x402, L402, Stripe, AgentCore Payments, Pay.sh, card, wallet, and ledger teams that need proof around autonomous-agent payment attempts."],
+  ["API platforms", "Marketplaces and API providers that want scoped agent acceptance without inheriting every identity, delegation, or dispute question."],
+  ["Agent platforms", "Runtimes, MCP gateways, and orchestration layers that need one authority contract across many paid and unpaid rails."],
+];
+
+const flow = [
+  ["1", "Authority", "The principal or platform delegates bounded capability: agent, tenant, route/tool, budget, expiry, policy version, and delegation depth."],
+  ["2", "Decision", "SatGate enforces policy in the request path before the upstream API, MCP tool, or payment rail executes."],
+  ["3", "Receipt", "Every allowed, denied, delegated, revoked, or paid decision emits a signed receipt with policy basis and rail context."],
+  ["4", "Evidence Pack", "Receipts roll into a verifiable Evidence Pack anchored by issuer JWKS and independently checked by the open verifier."],
+];
+
+const railQuestions = [
+  "Was this agent delegated authority before the transaction?",
+  "Which policy, tenant, budget, route, tool, and delegation chain applied?",
+  "Did the decision happen before value moved or an upstream action executed?",
+  "Can a partner, customer, auditor, or fraud team verify the artifact without trusting a dashboard screenshot?",
+];
+
+const publicArtifacts = [
+  ["Public verifier", "https://github.com/SatGate-io/evidence-pack-verifier"],
+  ["Live Evidence Pack", "https://api.satgate.io/v1/evidence/evid_LrlgUSR1R3SEYtxy0npX7mgneWZFa5ek"],
+  ["Receipt schema", "https://satgate.io/.well-known/satgate-receipt.schema.json"],
+  ["Partner brief PDF", "/briefs/satgate-agent-authority-rails-brief.pdf"],
+];
+
+const jsonLd = {
+  "@context": "https://schema.org",
+  "@graph": [
+    {
+      "@type": "WebPage",
+      name: "SatGate for Payment Rails",
+      url: "https://satgate.io/partners/rails",
+      description: metadata.description,
+      isPartOf: { "@type": "WebSite", name: "SatGate", url: "https://satgate.io" },
+      about: [
+        { "@type": "Thing", name: "agent payment rail governance" },
+        { "@type": "Thing", name: "Agent Authority & Accountability Layer" },
+        { "@type": "Thing", name: "Evidence Pack verification" },
+        { "@type": "Thing", name: "rail-neutral Economic Firewall" },
+      ],
+    },
+    {
+      "@type": "BreadcrumbList",
+      itemListElement: [
+        { "@type": "ListItem", position: 1, name: "Home", item: "https://satgate.io" },
+        { "@type": "ListItem", position: 2, name: "Partners", item: "https://satgate.io/partners/rails" },
+        { "@type": "ListItem", position: 3, name: "Rails", item: "https://satgate.io/partners/rails" },
+      ],
+    },
+  ],
+};
+
+export default function RailPartnersPage() {
+  return (
+    <main className="min-h-screen bg-black text-white">
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }} />
+
+      <section className="relative overflow-hidden border-b border-white/10 px-6 py-24 sm:py-32">
+        <div className="absolute inset-0 bg-[radial-gradient(circle_at_top_left,rgba(34,211,238,0.2),transparent_35%),radial-gradient(circle_at_bottom_right,rgba(168,85,247,0.18),transparent_38%)]" />
+        <div className="relative mx-auto grid max-w-6xl gap-12 lg:grid-cols-[1.05fr_0.95fr] lg:items-center">
+          <div>
+            <Link href="/" className="mb-8 inline-flex text-sm font-semibold text-gray-400 transition hover:text-white">← Back to Home</Link>
+            <div className="mb-6 inline-flex items-center gap-2 rounded-full border border-cyan-400/30 bg-cyan-400/10 px-3 py-1 text-xs font-semibold uppercase tracking-[0.24em] text-cyan-200">
+              <Handshake size={14} /> Partner brief
+            </div>
+            <h1 className="max-w-4xl text-5xl font-black tracking-tight sm:text-6xl lg:text-7xl">
+              Agent authority for every payment rail.
+            </h1>
+            <p className="mt-6 max-w-3xl text-xl leading-8 text-gray-300">
+              Rails can authorize value movement. SatGate proves the agent was allowed to attempt it: who delegated authority, which policy applied, what budget was left, and what evidence exists after the decision.
+            </p>
+            <p className="mt-5 max-w-3xl text-lg leading-8 text-gray-400">
+              The Economic Firewall category stays durable while rails change. SatGate’s Agent Authority & Accountability Layer sits above x402, L402, Stripe, AgentCore Payments, Pay.sh, API-key billing, and enterprise ledgers.
+            </p>
+            <div className="mt-8 flex flex-col gap-3 sm:flex-row sm:flex-wrap">
+              <a href="/briefs/satgate-agent-authority-rails-brief.pdf" className="inline-flex items-center justify-center gap-2 rounded-lg bg-white px-6 py-3 font-bold text-black transition hover:bg-gray-200">
+                Download partner brief <FileText size={18} />
+              </a>
+              <Link href="/agent-authority-layer" className="inline-flex items-center justify-center gap-2 rounded-lg border border-gray-700 px-6 py-3 font-bold text-white transition hover:border-cyan-500">
+                See the authority and accountability layer <ArrowRight size={18} />
+              </Link>
+            </div>
+          </div>
+
+          <div className="rounded-3xl border border-cyan-300/20 bg-white/[0.03] p-6 shadow-2xl shadow-cyan-950/30">
+            <div className="mb-5 flex items-center gap-2 text-emerald-200">
+              <BadgeCheck /> Partner questions SatGate answers
+            </div>
+            <div className="space-y-4">
+              {railQuestions.map((item) => (
+                <div key={item} className="rounded-2xl border border-white/10 bg-black/50 p-4 text-gray-300">
+                  {item}
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="mx-auto max-w-6xl px-6 py-20">
+        <div className="mb-10 max-w-3xl">
+          <p className="mb-3 text-sm font-mono uppercase tracking-[0.22em] text-purple-300">Partner fit</p>
+          <h2 className="text-3xl font-bold text-white sm:text-4xl">SatGate is useful when a rail does not want to become the whole governance stack.</h2>
+          <p className="mt-5 text-lg leading-8 text-gray-400">
+            A single rail sees the transaction. Enterprises need proof across tools, APIs, delegations, budgets, denials, and retries. SatGate preserves that authority chain and gives partners a verifiable artifact to evaluate.
+          </p>
+        </div>
+        <div className="grid gap-6 md:grid-cols-3">
+          {partnerFit.map(([title, body]) => (
+            <div key={title} className="rounded-2xl border border-gray-800 bg-gray-950 p-6">
+              <Layers3 className="mb-4 text-cyan-300" />
+              <h3 className="text-xl font-bold text-white">{title}</h3>
+              <p className="mt-3 leading-7 text-gray-400">{body}</p>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section className="border-y border-gray-900 bg-gray-950/60">
+        <div className="mx-auto max-w-6xl px-6 py-20">
+          <div className="mb-10 max-w-3xl">
+            <p className="mb-3 text-sm font-mono uppercase tracking-[0.22em] text-emerald-300">Policy-to-Proof</p>
+            <h2 className="text-3xl font-bold text-white sm:text-4xl">The handoff is simple: policy in, receipt out.</h2>
+          </div>
+          <div className="grid gap-4 md:grid-cols-4">
+            {flow.map(([step, title, body]) => (
+              <div key={title} className="rounded-2xl border border-gray-800 bg-black p-5">
+                <div className="mb-4 flex h-10 w-10 items-center justify-center rounded-full bg-cyan-400/10 font-black text-cyan-200">{step}</div>
+                <h3 className="font-bold text-white">{title}</h3>
+                <p className="mt-2 text-sm leading-6 text-gray-400">{body}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section className="mx-auto grid max-w-6xl gap-10 px-6 py-20 lg:grid-cols-[0.95fr_1.05fr] lg:items-start">
+        <div>
+          <p className="mb-3 text-sm font-mono uppercase tracking-[0.22em] text-cyan-300">Public proof</p>
+          <h2 className="text-3xl font-bold text-white sm:text-4xl">Partners should not have to trust a screenshot.</h2>
+          <p className="mt-5 text-lg leading-8 text-gray-400">
+            Evidence Packs are signed and externally verifiable. A partner, customer, or reviewer can fetch the pack, discover issuer keys, recompute receipt hashes, and verify the signature with the open-source verifier.
+          </p>
+          <div className="mt-8 flex flex-col gap-3 sm:flex-row sm:flex-wrap">
+            <a href="https://github.com/SatGate-io/evidence-pack-verifier" className="inline-flex items-center justify-center gap-2 rounded-lg bg-white px-6 py-3 font-bold text-black transition hover:bg-gray-200">
+              Open verifier <ArrowRight size={18} />
+            </a>
+            <Link href="/policy-to-proof" className="inline-flex items-center justify-center gap-2 rounded-lg border border-gray-700 px-6 py-3 font-bold text-white transition hover:border-purple-500">
+              See Policy-to-Proof
+            </Link>
+          </div>
+        </div>
+        <div className="rounded-2xl border border-gray-800 bg-black p-6">
+          <div className="mb-4 flex items-center gap-2 text-cyan-200">
+            <ReceiptText size={20} /> Partner artifacts
+          </div>
+          <div className="space-y-3">
+            {publicArtifacts.map(([label, href]) => (
+              <a key={label} href={href} className="block rounded-xl border border-gray-800 bg-gray-950 p-4 text-sm text-gray-300 transition hover:border-cyan-500 hover:text-white">
+                <span className="font-semibold text-white">{label}</span>
+                <span className="mt-1 block break-all text-gray-500">{href}</span>
+              </a>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section className="border-t border-gray-900 px-6 py-20 text-center">
+        <ShieldCheck className="mx-auto mb-6 text-cyan-300" size={36} />
+        <h2 className="mx-auto max-w-3xl text-3xl font-bold text-white sm:text-4xl">Build the rail. Let SatGate carry agent authority and evidence across it.</h2>
+        <p className="mx-auto mt-5 max-w-2xl text-lg leading-8 text-gray-400">
+          The partner conversation starts with receipts: what the rail sees, what SatGate proves, and what the ecosystem can verify later.
+        </p>
+        <div className="mt-8 flex flex-col items-center justify-center gap-3 sm:flex-row">
+          <a href="mailto:contact@satgate.io?subject=SatGate%20rail%20partner%20brief" className="inline-flex items-center justify-center gap-2 rounded-lg bg-white px-6 py-3 font-bold text-black transition hover:bg-gray-200">
+            Talk to SatGate <ArrowRight size={18} />
+          </a>
+          <Link href="/build" className="inline-flex items-center justify-center gap-2 rounded-lg border border-gray-700 px-6 py-3 font-bold text-white transition hover:border-cyan-400">
+            Developer primitives <GitBranch size={18} />
+          </Link>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/satgate-landing/app/pricing/page.tsx
+++ b/satgate-landing/app/pricing/page.tsx
@@ -50,7 +50,7 @@ const PricingPage = () => {
     dateModified: '2026-05-03',
     isPartOf: { '@type': 'WebSite', name: 'SatGate', url: 'https://satgate.io' },
     about: [
-      { '@type': 'Thing', name: 'economic control plane for AI agents' },
+      { '@type': 'Thing', name: 'economic firewall for AI agents' },
       { '@type': 'Thing', name: 'AI agent budget enforcement' },
       { '@type': 'Thing', name: 'SatGate Economic Firewall' },
       { '@type': 'Thing', name: 'request-path spend governance' },

--- a/satgate-landing/app/privacy/page.tsx
+++ b/satgate-landing/app/privacy/page.tsx
@@ -29,7 +29,7 @@ export default function PrivacyPage() {
     isPartOf: { '@type': 'WebSite', name: 'SatGate', url: 'https://satgate.io' },
     about: [
       { '@type': 'Thing', name: 'SatGate Cloud privacy' },
-      { '@type': 'Thing', name: 'self-hosted economic control plane privacy' },
+      { '@type': 'Thing', name: 'self-hosted Economic Firewall privacy' },
       { '@type': 'Thing', name: 'API request metadata privacy' },
       { '@type': 'Thing', name: 'hybrid gateway telemetry' },
     ],

--- a/satgate-landing/app/satgate-for-claude-code/page.tsx
+++ b/satgate-landing/app/satgate-for-claude-code/page.tsx
@@ -146,7 +146,7 @@ export default function SatGateIntegrationPage() {
       <section className="border-y border-gray-900 bg-gray-950/60">
         <div className="mx-auto max-w-6xl px-6 py-20">
           <h2 className="mb-4 text-3xl font-bold text-white">SatGate controls for Claude Code</h2>
-          <p className="mb-10 max-w-3xl text-lg text-gray-400">Use SatGate as the economic control plane around agentic tool use: Observe first, Control when limits are known, Charge when external agents should pay for access.</p>
+          <p className="mb-10 max-w-3xl text-lg text-gray-400">Use SatGate as the economic firewall around agentic tool use: Observe first, Control when limits are known, Charge when external agents should pay for access.</p>
           <div className="grid gap-5 md:grid-cols-2 lg:grid-cols-4">
             {controls.map(({ icon: Icon, title, body }) => (
               <div key={title} className="rounded-xl border border-gray-800 bg-black p-6 transition hover:border-cyan-900/70">

--- a/satgate-landing/app/satgate-for-claude-desktop/page.tsx
+++ b/satgate-landing/app/satgate-for-claude-desktop/page.tsx
@@ -148,7 +148,7 @@ export default function SatGateIntegrationPage() {
       <section className="border-y border-gray-900 bg-gray-950/60">
         <div className="mx-auto max-w-6xl px-6 py-20">
           <h2 className="mb-4 text-3xl font-bold text-white">SatGate controls for Claude Desktop</h2>
-          <p className="mb-10 max-w-3xl text-lg text-gray-400">Use SatGate as the economic control plane around agentic tool use: Observe first, Control when limits are known, Charge when external agents should pay for access.</p>
+          <p className="mb-10 max-w-3xl text-lg text-gray-400">Use SatGate as the economic firewall around agentic tool use: Observe first, Control when limits are known, Charge when external agents should pay for access.</p>
           <div className="grid gap-5 md:grid-cols-2 lg:grid-cols-4">
             {controls.map(({ icon: Icon, title, body }) => (
               <div key={title} className="rounded-xl border border-gray-800 bg-black p-6 transition hover:border-cyan-900/70">

--- a/satgate-landing/app/satgate-for-cursor/page.tsx
+++ b/satgate-landing/app/satgate-for-cursor/page.tsx
@@ -146,7 +146,7 @@ export default function SatGateIntegrationPage() {
       <section className="border-y border-gray-900 bg-gray-950/60">
         <div className="mx-auto max-w-6xl px-6 py-20">
           <h2 className="mb-4 text-3xl font-bold text-white">SatGate controls for Cursor</h2>
-          <p className="mb-10 max-w-3xl text-lg text-gray-400">Use SatGate as the economic control plane around agentic tool use: Observe first, Control when limits are known, Charge when external agents should pay for access.</p>
+          <p className="mb-10 max-w-3xl text-lg text-gray-400">Use SatGate as the economic firewall around agentic tool use: Observe first, Control when limits are known, Charge when external agents should pay for access.</p>
           <div className="grid gap-5 md:grid-cols-2 lg:grid-cols-4">
             {controls.map(({ icon: Icon, title, body }) => (
               <div key={title} className="rounded-xl border border-gray-800 bg-black p-6 transition hover:border-cyan-900/70">

--- a/satgate-landing/app/satgate-for-hermes-agent/page.tsx
+++ b/satgate-landing/app/satgate-for-hermes-agent/page.tsx
@@ -83,7 +83,7 @@ export default function SatGateForHermesAgentPage() {
       {
         '@type': 'Question',
         name: 'Does SatGate replace Hermes Agent?',
-        acceptedAnswer: { '@type': 'Answer', text: 'No. Hermes Agent remains the agent workflow. SatGate adds the economic control plane around MCP tools, APIs, model routes, paid data sources, and credentials.' },
+        acceptedAnswer: { '@type': 'Answer', text: 'No. Hermes Agent remains the agent workflow. SatGate adds the economic firewall around MCP tools, APIs, model routes, paid data sources, and credentials.' },
       },
     ],
   };
@@ -112,7 +112,7 @@ export default function SatGateForHermesAgentPage() {
             <BrainCircuit size={16} /> Hermes Agent MCP spend control
           </div>
 
-          <h1 className="mb-8 max-w-5xl text-5xl font-extrabold tracking-tight md:text-7xl">Give Hermes Agent workflows an economic control plane</h1>
+          <h1 className="mb-8 max-w-5xl text-5xl font-extrabold tracking-tight md:text-7xl">Give Hermes Agent workflows an economic firewall</h1>
           <p className="mb-10 max-w-4xl text-xl leading-relaxed text-gray-300 md:text-2xl">
             Hermes Agent is built for persistent, skillful agent workflows. SatGate adds the missing economic firewall: per-agent budgets, MCP tool cost policy, scoped credentials, revocation, and audit before upstream APIs or tools execute.
           </p>
@@ -170,7 +170,7 @@ export default function SatGateForHermesAgentPage() {
             {[
               ['Can SatGate govern Hermes Agent MCP tools?', 'Yes. SatGate can sit between Hermes Agent workflows and MCP servers or upstream APIs to enforce budgets, allowed tools, scoped credentials, revocation, and Evidence Packs before tool calls execute.'],
               ['Why does a self-improving agent need economic governance?', 'Persistent or learning agents can reuse skills, retry workflows, call tools, and delegate work over time. SatGate adds request-path economic policy so those actions have budgets, scopes, expiry, and kill switches.'],
-              ['Does SatGate replace Hermes Agent?', 'No. Hermes Agent remains the agent workflow. SatGate adds the economic control plane around MCP tools, APIs, model routes, paid data sources, and credentials.'],
+              ['Does SatGate replace Hermes Agent?', 'No. Hermes Agent remains the agent workflow. SatGate adds the economic firewall around MCP tools, APIs, model routes, paid data sources, and credentials.'],
             ].map(([question, answer]) => (
               <div key={question}>
                 <h3 className="mb-2 text-lg font-bold text-white">{question}</h3>

--- a/satgate-landing/app/satgate-for-openclaw/page.tsx
+++ b/satgate-landing/app/satgate-for-openclaw/page.tsx
@@ -3,7 +3,7 @@ import { ArrowRight, Bot, DollarSign, Gauge, KeyRound, ShieldCheck, Terminal, Wo
 
 export const metadata = {
   title: 'SatGate for OpenClaw Agents',
-  description: 'Use SatGate as the economic control plane for OpenClaw agents, sub-agents, tools, MCP calls, model routes, and API spend.',
+  description: 'Use SatGate as the economic firewall for OpenClaw agents, sub-agents, tools, MCP calls, model routes, and API spend.',
   alternates: { canonical: 'https://satgate.io/satgate-for-openclaw' },
   keywords: [
     'SatGate for OpenClaw',
@@ -15,14 +15,14 @@ export const metadata = {
   ],
   openGraph: {
     title: 'SatGate for OpenClaw Agents',
-    description: 'Use SatGate as the economic control plane for OpenClaw agents, sub-agents, tools, MCP calls, model routes, and API spend.',
+    description: 'Use SatGate as the economic firewall for OpenClaw agents, sub-agents, tools, MCP calls, model routes, and API spend.',
     url: 'https://satgate.io/satgate-for-openclaw',
     type: 'website',
   },
   twitter: {
     card: 'summary_large_image',
     title: 'SatGate for OpenClaw Agents',
-    description: 'Use SatGate as the economic control plane for OpenClaw agents, sub-agents, tools, MCP calls, model routes, and API spend.',
+    description: 'Use SatGate as the economic firewall for OpenClaw agents, sub-agents, tools, MCP calls, model routes, and API spend.',
   },
 };
 
@@ -45,7 +45,7 @@ export default function SatGateIntegrationPage() {
     about: [
       { '@type': 'Thing', name: 'OpenClaw agent spend control' },
       { '@type': 'Thing', name: 'OpenClaw MCP budget enforcement' },
-      { '@type': 'Thing', name: 'economic control plane for OpenClaw agents' },
+      { '@type': 'Thing', name: 'economic firewall for OpenClaw agents' },
       { '@type': 'Thing', name: 'sub-agent budget attribution' },
       { '@type': 'Thing', name: 'L402 paid agent payments' },
     ],
@@ -110,7 +110,7 @@ export default function SatGateIntegrationPage() {
             <Terminal size={16} /> OpenClaw agent spend control
           </div>
 
-          <h1 className="mb-8 max-w-5xl text-5xl font-extrabold tracking-tight md:text-7xl">Give OpenClaw agents an economic control plane</h1>
+          <h1 className="mb-8 max-w-5xl text-5xl font-extrabold tracking-tight md:text-7xl">Give OpenClaw agents an economic firewall</h1>
           <p className="mb-10 max-w-4xl text-xl leading-relaxed text-gray-300 md:text-2xl">OpenClaw agents can run tools, spawn sub-agents, call MCP servers, route through models, and act across workflows. SatGate adds the economic firewall underneath: observe, control, and prove agent/API activity before upstream access.</p>
 
           <div className="flex flex-col gap-4 sm:flex-row">
@@ -146,7 +146,7 @@ export default function SatGateIntegrationPage() {
       <section className="border-y border-gray-900 bg-gray-950/60">
         <div className="mx-auto max-w-6xl px-6 py-20">
           <h2 className="mb-4 text-3xl font-bold text-white">SatGate controls for OpenClaw</h2>
-          <p className="mb-10 max-w-3xl text-lg text-gray-400">Use SatGate as the economic control plane around agentic tool use: Observe first, Control when limits are known, Charge when external agents should pay for access.</p>
+          <p className="mb-10 max-w-3xl text-lg text-gray-400">Use SatGate as the economic firewall around agentic tool use: Observe first, Control when limits are known, Charge when external agents should pay for access.</p>
           <div className="grid gap-5 md:grid-cols-2 lg:grid-cols-4">
             {controls.map(({ icon: Icon, title, body }) => (
               <div key={title} className="rounded-xl border border-gray-800 bg-black p-6 transition hover:border-cyan-900/70">

--- a/satgate-landing/app/seo-distribution-kit/page.tsx
+++ b/satgate-landing/app/seo-distribution-kit/page.tsx
@@ -104,7 +104,7 @@ export default function SeoDistributionKitPage() {
         name: 'Who should use the distribution kit?',
         acceptedAnswer: {
           '@type': 'Answer',
-          text: 'The kit is for founders, developer advocates, content teams, sales engineers, and partners who need consistent language for SatGate as the economic control plane for AI agents.',
+          text: 'The kit is for founders, developer advocates, content teams, sales engineers, and partners who need consistent language for SatGate as the economic firewall for AI agents.',
         },
       },
     ],
@@ -167,7 +167,7 @@ export default function SeoDistributionKitPage() {
           {[
             ['What is the SatGate SEO Distribution Kit?', 'The SatGate SEO Distribution Kit packages launch copy, backlink angles, promotion targets, and reusable positioning for AI agent cost control, economic firewall, MCP governance, and L402 payment assets.'],
             ['Which SatGate pages should be promoted first?', 'Promote the tools hub, AI agent cost control, economic firewall, runaway spend index, ROI calculator, MCP policy generators, revocable capability-token template, L402 pricing calculator, governance dashboard, Protect demo, and monetization demo first.'],
-            ['Who should use the distribution kit?', 'The kit is for founders, developer advocates, content teams, sales engineers, and partners who need consistent language for SatGate as the economic control plane for AI agents.'],
+            ['Who should use the distribution kit?', 'The kit is for founders, developer advocates, content teams, sales engineers, and partners who need consistent language for SatGate as the economic firewall for AI agents.'],
           ].map(([question, answer]) => (
             <div key={question} className="rounded-2xl border border-gray-800 bg-gray-950 p-6">
               <h3 className="mb-3 text-xl font-bold text-white">{question}</h3>

--- a/satgate-landing/app/sitemap.ts
+++ b/satgate-landing/app/sitemap.ts
@@ -14,6 +14,7 @@ const staticRoutes: SitemapEntry[] = [
   { path: '/govern', lastModified: '2026-05-05', changeFrequency: 'weekly', priority: 0.9 },
   { path: '/economic-firewall', lastModified: '2026-05-05', changeFrequency: 'weekly', priority: 0.9 },
   { path: '/agent-authority-layer', lastModified: '2026-05-14', changeFrequency: 'weekly', priority: 0.95 },
+  { path: '/partners/rails', lastModified: '2026-05-14', changeFrequency: 'weekly', priority: 0.85 },
   { path: '/policy-to-proof', lastModified: '2026-05-10', changeFrequency: 'weekly', priority: 0.95 },
   { path: '/stripe-link-agents-vs-satgate', lastModified: '2026-05-02', changeFrequency: 'weekly', priority: 0.9 },
   { path: '/agent-payment-controls', lastModified: '2026-05-02', changeFrequency: 'weekly', priority: 0.9 },

--- a/satgate-landing/app/stripe-link-agents-vs-satgate/page.tsx
+++ b/satgate-landing/app/stripe-link-agents-vs-satgate/page.tsx
@@ -10,7 +10,7 @@ export const metadata = {
     'Link for Agents',
     'agent payment controls',
     'AI agent wallet governance',
-    'economic control plane for AI agents',
+    'economic firewall for AI agents',
     'economic firewall for AI agents',
     'HTTP 402 agents',
     'L402 agent payments',
@@ -136,7 +136,7 @@ export default function StripeLinkAgentsVsSatGatePage() {
           <ShieldCheck className="text-cyan-300 mb-5" size={34} />
           <h2 className="text-2xl font-bold text-white mb-4">What SatGate is built for</h2>
           <p className="text-gray-300 leading-relaxed mb-5">
-            SatGate is the economic control plane in front of APIs, models, MCP tools, and delegated agent workflows. It observes traffic, enforces policy, meters usage, revokes access, and charges for API access when needed.
+            SatGate is the economic firewall in front of APIs, models, MCP tools, and delegated agent workflows. It observes traffic, enforces policy, meters usage, revokes access, and charges for API access when needed.
           </p>
           <ul className="space-y-3 text-gray-300">
             {['Request-path budget enforcement', 'Per-agent and per-tool metering', 'Revocable capability and API access', 'paid-rail context-native API monetization'].map((item) => (

--- a/satgate-landing/app/terms/page.tsx
+++ b/satgate-landing/app/terms/page.tsx
@@ -31,7 +31,7 @@ export default function TermsPage() {
       { '@type': 'Thing', name: 'SatGate terms of service' },
       { '@type': 'Thing', name: 'economic access control' },
       { '@type': 'Thing', name: 'paid-rail context' },
-      { '@type': 'Thing', name: 'self-hosted economic control plane' },
+      { '@type': 'Thing', name: 'self-hosted Economic Firewall' },
       { '@type': 'Thing', name: 'Apache 2.0 open source license' },
     ],
   };

--- a/satgate-landing/package.json
+++ b/satgate-landing/package.json
@@ -19,7 +19,8 @@
     "test:receipt-schema": "python3 scripts/check_receipt_schema.py",
     "test:reputation-substrate": "python3 scripts/check_reputation_substrate.py",
     "test:cache-protocol": "python3 scripts/check_cache_protocol.py",
-    "test:buyer-narrative": "python3 scripts/check_buyer_narrative.py"
+    "test:buyer-narrative": "python3 scripts/check_buyer_narrative.py",
+    "test:authority-followups": "python3 scripts/check_authority_followups.py"
   },
   "dependencies": {
     "lucide-react": "^0.555.0",

--- a/satgate-landing/public/briefs/satgate-agent-authority-rails-brief.pdf
+++ b/satgate-landing/public/briefs/satgate-agent-authority-rails-brief.pdf
@@ -1,0 +1,104 @@
+%PDF-1.4
+%‚„œ”
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [5 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+4 0 obj
+<< /Length 1954 >>
+stream
+BT
+/F1 11 Tf
+50 770 Td
+14 TL
+(SatGate Agent Authority & Accountability Layer) Tj
+T*
+(Partner brief for payment rails, API platforms, and agent ecosystems) Tj
+T*
+() Tj
+T*
+(Positioning) Tj
+T*
+(SatGate is the Economic Firewall for agentic API access. The Agent Authority &) Tj
+T*
+(Accountability Layer sits above payment rails, APIs, MCP tools, and enterprise ledgers) Tj
+T*
+(so partners can prove which agent was authorized, under which policy, before value) Tj
+T*
+(moved or an upstream action executed.) Tj
+T*
+() Tj
+T*
+(Why rails need this) Tj
+T*
+(Payment rails answer whether value can move. Enterprises and partners still need to) Tj
+T*
+(know who delegated authority, what scope and budget applied, whether the decision) Tj
+T*
+(happened before execution, and what evidence exists after the fact.) Tj
+T*
+() Tj
+T*
+(Policy-to-Proof flow) Tj
+T*
+(1. Authority: delegate a bounded capability with tenant, route, tool, budget, expiry,) Tj
+T*
+(policy version, and delegation depth.) Tj
+T*
+(2. Decision: enforce policy in the request path before API, MCP, or payment execution.) Tj
+T*
+(3. Receipt: emit a signed decision receipt for allowed, denied, delegated, revoked,) Tj
+T*
+(and paid events.) Tj
+T*
+(4. Evidence Pack: roll receipts into verifiable artifacts anchored by issuer JWKS and) Tj
+T*
+(checked by the open verifier.) Tj
+T*
+() Tj
+T*
+(Partner artifact links) Tj
+T*
+(Overview: https://satgate.io/partners/rails) Tj
+T*
+(Authority layer: https://satgate.io/agent-authority-layer) Tj
+T*
+(Open verifier: https://github.com/SatGate-io/evidence-pack-verifier) Tj
+T*
+(Live Evidence Pack:) Tj
+T*
+(https://api.satgate.io/v1/evidence/evid_LrlgUSR1R3SEYtxy0npX7mgneWZFa5ek) Tj
+T*
+(Receipt schema: https://satgate.io/.well-known/satgate-receipt.schema.json) Tj
+T*
+() Tj
+T*
+(Partner conversation) Tj
+T*
+(Start with receipts: what your rail sees, what SatGate proves, and what a customer,) Tj
+T*
+(reviewer, fraud team, or auditor can independently verify later.) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 3 0 R >> >> /Contents 4 0 R >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000015 00000 n 
+0000000064 00000 n 
+0000000121 00000 n 
+0000000191 00000 n 
+0000002197 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+2323
+%%EOF

--- a/satgate-landing/scripts/check_authority_followups.py
+++ b/satgate-landing/scripts/check_authority_followups.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+from pathlib import Path
+import re
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+APP = ROOT / "app"
+HOME = APP / "components" / "HomeClient.tsx"
+SITEMAP = APP / "sitemap.ts"
+RAILS = APP / "partners" / "rails" / "page.tsx"
+AUTHORITY = APP / "agent-authority-layer" / "page.tsx"
+PDF = ROOT / "public" / "briefs" / "satgate-agent-authority-rails-brief.pdf"
+
+errors: list[str] = []
+
+required_files = [RAILS, PDF]
+for path in required_files:
+    if not path.exists():
+        errors.append(f"missing required artifact: {path.relative_to(ROOT)}")
+
+if RAILS.exists():
+    rails = RAILS.read_text()
+    for needle in [
+        "Agent authority for every payment rail.",
+        "Economic Firewall category stays durable while rails change",
+        "Agent Authority & Accountability Layer",
+        "Policy-to-Proof",
+        "Evidence Pack",
+        "https://github.com/SatGate-io/evidence-pack-verifier",
+        "/briefs/satgate-agent-authority-rails-brief.pdf",
+    ]:
+        if needle not in rails:
+            errors.append(f"/partners/rails missing anchor: {needle}")
+
+sitemap = SITEMAP.read_text() if SITEMAP.exists() else ""
+if "path: '/partners/rails'" not in sitemap:
+    errors.append("/partners/rails missing from sitemap")
+
+home = HOME.read_text() if HOME.exists() else ""
+if 'href="/partners/rails"' not in home:
+    errors.append("homepage footer does not link to /partners/rails")
+if "Authority Layer" in home:
+    errors.append("homepage still uses short stale label: Authority Layer")
+
+if AUTHORITY.exists():
+    authority = AUTHORITY.read_text()
+    if "/partners/rails" not in authority:
+        errors.append("/agent-authority-layer does not link to /partners/rails")
+
+public_tsx = "\n".join(path.read_text(errors="ignore") for path in APP.rglob("*.tsx"))
+for pattern in [
+    r"economic control plane",
+    r"Authority Layer",
+    r"\bAgent Authority Layer\b",
+    r"robot[- ]customer",
+    r"SatGate Charge",
+    r"L402 Charge",
+    r"production-ready",
+    r"Gemma4",
+    r"buyers need to see",
+    r"credible demo",
+]:
+    if re.search(pattern, public_tsx, flags=re.IGNORECASE):
+        errors.append(f"forbidden public framing matched: {pattern}")
+
+if PDF.exists():
+    head = PDF.read_bytes()[:5]
+    if head != b"%PDF-":
+        errors.append("partner brief is not a PDF")
+
+if errors:
+    print("authority follow-up check failed:")
+    for error in errors:
+        print(f"- {error}")
+    sys.exit(1)
+
+print("authority follow-up check passed")

--- a/satgate-landing/scripts/check_build_page.py
+++ b/satgate-landing/scripts/check_build_page.py
@@ -20,7 +20,7 @@ required_page_strings = [
     "import os",
     "os.getenv(\"SATGATE_API_KEY\")",
     "Economic Firewall for AI agents",
-    "authority and evidence layer",
+    "Agent Authority & Accountability Layer",
     "https://github.com/SatGate-io/satgate/blob/main/docs/index.md",
     "govern / enforce / prove",
     "issue / pay / verify",


### PR DESCRIPTION
## Summary
- Adds `/partners/rails` as the payment-rail partner page for SatGate’s Agent Authority & Accountability Layer.
- Publishes a downloadable partner PDF at `/briefs/satgate-agent-authority-rails-brief.pdf`.
- Stages P5 terminology reconciliation: Economic Firewall stays the category, Agent Authority & Accountability Layer is the named rail-neutral layer, and stale “economic control plane” / short “Authority Layer” labels are removed from public TSX surfaces.
- Adds `test:authority-followups` guard for the new route, PDF, sitemap, homepage link, authority-page crosslink, and stale public framing.

## Verification
- `npm ci` → 0 vulnerabilities
- `npm audit --audit-level=moderate` → 0 vulnerabilities
- `npx eslint <changed public TSX files>` → 0 errors, existing warnings only
- `npm run test:authority-followups`
- `npm run test:build-page`
- `npm run build`
- Local HTTP smoke on `next start`:
  - `/partners/rails` HTTP 200 and contains PDF/verifier links
  - `/briefs/satgate-agent-authority-rails-brief.pdf` HTTP 200 `application/pdf` and `%PDF-` header
  - `/sitemap.xml` includes `/partners/rails`
  - `/agent-authority-layer` links to `/partners/rails`

## Notes
- Full repo `npm run lint` still fails on pre-existing unrelated pages (`blog/*`, `crawl`, `protect`, `pay`, etc.). The changed-file lint path has 0 errors.
- P3/P4 outreach/MCP drafts were staged in Obsidian, not sent.
