### PR TITLE
fix: link rail partner page to economic firewall

### DIFF
--- a/satgate-landing/app/partners/rails/page.tsx
+++ b/satgate-landing/app/partners/rails/page.tsx
@@ -114,6 +114,9 @@ export default function RailPartnersPage() {
               <Link href="/agent-authority-layer" className="inline-flex items-center justify-center gap-2 rounded-lg border border-gray-700 px-6 py-3 font-bold text-white transition hover:border-cyan-500">
                 See the authority and accountability layer <ArrowRight size={18} />
               </Link>
+              <Link href="/economic-firewall" className="inline-flex items-center justify-center gap-2 rounded-lg border border-gray-700 px-6 py-3 font-bold text-white transition hover:border-purple-500">
+                See the Economic Firewall category <ArrowRight size={18} />
+              </Link>
             </div>
           </div>
 


### PR DESCRIPTION
## Summary
- Adds the missing `/economic-firewall` backlink from `/partners/rails` required by the post-merge Q3 live checklist.

## Verification
- `npm run test:authority-followups`
- `npx eslint app/partners/rails/page.tsx`
- `npm run build`

## Context
PR #127 shipped correctly except the live checklist caught that `/partners/rails` linked to `/agent-authority-layer` but not back to `/economic-firewall`. This is the surgical fix before declaring P0-P5 sprint-complete.
