### PR TITLE
feat: add public L402 paid retry demo

### DIFF
--- a/docs/getting-started/issue-pay-verify.md
+++ b/docs/getting-started/issue-pay-verify.md
@@ -1,0 +1,117 @@
+# Issue → Pay → Verify Quick Start
+
+Run a public L402 paid-retry path locally: first request gets `402 Payment Required`, the mock Lightning provider settles the invoice, and the retry reaches the upstream with an `Authorization: L402 ...` proof.
+
+> This uses SatGate's `mock` Lightning provider for local demos and CI. Real Lightning backends still require an external wallet/payment flow; `/api/l402/mock-pay` is not available there.
+
+## 1. Configure a paid route
+
+Create `gateway.yaml`:
+
+```yaml
+version: 1
+
+server:
+  listen: ":8080"
+
+admin:
+  token: "my-admin-token"
+
+lightning:
+  provider: mock
+
+upstreams:
+  httpbin:
+    url: "https://httpbin.org"
+
+routes:
+  - name: paid-demo
+    match:
+      pathPrefix: /premium
+    upstream: httpbin
+    stripPrefix: true
+    policy:
+      kind: l402
+      priceSats: 10
+```
+
+Start SatGate:
+
+```bash
+export ADMIN_TOKEN=my-admin-token
+satgate --config gateway.yaml
+```
+
+If you built from source, use `./satgate --config gateway.yaml`.
+
+## 2. Issue: request the paid route
+
+```bash
+curl -i http://localhost:8080/premium/anything
+```
+
+Expected result:
+
+- HTTP status: `402 Payment Required`
+- Header: `WWW-Authenticate: L402 macaroon="...", invoice="..."`
+- Body fields: `payment_hash`, `invoice`, `amount_sats`
+
+Capture the challenge:
+
+```bash
+CHALLENGE=$(curl -s -D /tmp/satgate-l402.headers \
+  http://localhost:8080/premium/anything \
+  -o /tmp/satgate-l402.json \
+  -w '%{http_code}')
+
+test "$CHALLENGE" = "402"
+MACAROON=$(python3 - <<'PY'
+import re
+headers=open('/tmp/satgate-l402.headers').read()
+print(re.search(r'macaroon="([^"]+)"', headers).group(1))
+PY
+)
+PAYMENT_HASH=$(python3 - <<'PY'
+import json
+print(json.load(open('/tmp/satgate-l402.json'))['payment_hash'])
+PY
+)
+```
+
+## 3. Pay: settle the mock invoice
+
+```bash
+AUTHORIZATION=$(curl -s -X POST http://localhost:8080/api/l402/mock-pay \
+  -H 'Content-Type: application/json' \
+  -H 'X-Admin-Token: my-admin-token' \
+  -d "{\"payment_hash\":\"$PAYMENT_HASH\",\"macaroon\":\"$MACAROON\"}" \
+  | python3 -c 'import json,sys; print(json.load(sys.stdin)["authorization"])')
+```
+
+Expected result: `AUTHORIZATION` starts with `L402 ` and contains the paid macaroon plus payment preimage.
+
+## 4. Verify: retry with the L402 proof
+
+```bash
+curl -i http://localhost:8080/premium/anything \
+  -H "Authorization: $AUTHORIZATION"
+```
+
+Expected result:
+
+- HTTP status: `200 OK`
+- The upstream response is returned.
+- Reusing the same `AUTHORIZATION` fails because SatGate's L402 replay guard permits each payment proof once.
+
+## What this proves
+
+- The route issues a real HTTP `402` L402 challenge.
+- The mock Lightning provider can complete a local payment without a wallet.
+- The retry is authorized by the L402 macaroon plus preimage.
+- SatGate proxies only after payment proof verification.
+
+## What this does not prove
+
+- Real Lightning settlement on Phoenixd, LND, NWC, or Alby.
+- SatGate Cloud billing or buyer checkout.
+- Native Evidence Pack export from the gateway response.

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -100,12 +100,14 @@ TOKEN=$(curl -s -X POST http://localhost:8080/api/capability/mint \
 curl http://localhost:8080/api/anything \
   -H "Authorization: Bearer $TOKEN"
 
-# Optional paid route — returns 402 Payment Required with a mock settlement challenge; paid retry returns a paid-call receipt for the Evidence Pack
+# Optional paid route — returns 402 Payment Required with a mock settlement challenge.
+# For the full paid retry, use the issue → pay → verify quickstart.
 curl -i http://localhost:8080/premium/anything
 ```
 
 ## Next Steps
 
+- [Issue → Pay → Verify L402 Quickstart](issue-pay-verify.md)
 - [Route Configuration](../configuration/routes.md)
 - [Policy & Scope](../configuration/policy-scope.md)
 - [MCP Gateway Guide](../guides/mcp-gateway.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -28,6 +28,7 @@ For app teams and agent builders. The developer primitive is three calls:
 Build paths:
 
 - [Quickstart](getting-started/quickstart.md)
+- [Issue → pay → verify L402 quickstart](getting-started/issue-pay-verify.md)
 - [Raw HTTP issue/pay/verify](guides/raw-http.md)
 - [MCP integration](guides/mcp-gateway.md)
 - [OpenAI tools example](guides/openai-tools.md)

--- a/pkg/lightning/mock.go
+++ b/pkg/lightning/mock.go
@@ -93,6 +93,18 @@ func (m *MockProvider) SimulatePayment(paymentHash string) {
 	}
 }
 
+// GetPreimage returns the mock preimage for a payment hash.
+func (m *MockProvider) GetPreimage(paymentHash string) (string, bool) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	inv, ok := m.invoices[paymentHash]
+	if !ok {
+		return "", false
+	}
+	return inv.Preimage, true
+}
+
 // GetBalance returns mock balance
 func (m *MockProvider) GetBalance() (int64, error) {
 	m.mu.RLock()

--- a/pkg/macaroon/macaroon.go
+++ b/pkg/macaroon/macaroon.go
@@ -80,13 +80,15 @@ func (s *Service) Mint(scope string, expiresAt time.Time) (*Macaroon, error) {
 // from the root key and comparing the final signature.
 // Accepts both binary (libmacaroon V2) and JSON (custom) formats.
 func (s *Service) Verify(token string) (*Macaroon, error) {
-	// Try binary format first (lnget/Aperture clients), then JSON format (our SDKs)
-	mac, err := s.DecodeBinary(token)
+	// Binary L402 macaroons use libmacaroon's canonical signature algorithm;
+	// verify them with the library before converting into SatGate's struct shape.
+	if mac, err := s.verifyBinary(token); err == nil {
+		return mac, nil
+	}
+
+	mac, err := s.Decode(token)
 	if err != nil {
-		mac, err = s.Decode(token)
-		if err != nil {
-			return nil, fmt.Errorf("failed to decode token: %w", err)
-		}
+		return nil, fmt.Errorf("failed to decode token: %w", err)
 	}
 
 	// Reconstruct the chained signature from root key
@@ -103,6 +105,26 @@ func (s *Service) Verify(token string) (*Macaroon, error) {
 	}
 
 	return mac, nil
+}
+
+func (s *Service) verifyBinary(token string) (*Macaroon, error) {
+	data, err := base64.StdEncoding.DecodeString(token)
+	if err != nil {
+		data, err = base64.RawStdEncoding.DecodeString(token)
+		if err != nil {
+			return nil, fmt.Errorf("invalid base64: %w", err)
+		}
+	}
+
+	var v2mac macaroonv2.Macaroon
+	if err := v2mac.UnmarshalBinary(data); err != nil {
+		return nil, fmt.Errorf("invalid binary macaroon: %w", err)
+	}
+	if err := v2mac.Verify(s.rootKey, s.verifyCaveat, nil); err != nil {
+		return nil, err
+	}
+
+	return s.decodeVerifiedBinaryMacaroon(&v2mac), nil
 }
 
 // Delegate creates a child macaroon with additional caveats using proper
@@ -225,6 +247,10 @@ func (s *Service) DecodeBinary(token string) (*Macaroon, error) {
 		return nil, fmt.Errorf("invalid binary macaroon: %w", err)
 	}
 
+	return s.decodeVerifiedBinaryMacaroon(&v2mac), nil
+}
+
+func (s *Service) decodeVerifiedBinaryMacaroon(v2mac *macaroonv2.Macaroon) *Macaroon {
 	mac := &Macaroon{
 		Version:    2,
 		Location:   v2mac.Location(),
@@ -237,7 +263,7 @@ func (s *Service) DecodeBinary(token string) (*Macaroon, error) {
 		mac.Caveats = append(mac.Caveats, string(cav.Id))
 	}
 
-	return mac, nil
+	return mac
 }
 
 // Encode serializes a macaroon to a string

--- a/pkg/proxy/proxy_oss.go
+++ b/pkg/proxy/proxy_oss.go
@@ -215,6 +215,14 @@ func (g *Gateway) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	// Admin endpoint: complete a mock L402 payment for local demos and tests.
+	// This is intentionally available only for Lightning providers that expose
+	// mock preimages; real Lightning backends must settle externally.
+	if r.URL.Path == "/api/l402/mock-pay" && r.Method == "POST" {
+		g.handleL402MockPay(w, r)
+		return
+	}
+
 	// Admin endpoint: Capability token minting
 	if r.URL.Path == "/api/capability/mint" && r.Method == "POST" {
 		g.handleCapabilityMint(w, r)
@@ -535,6 +543,84 @@ func (g *Gateway) handleCheckPayment(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
 	fmt.Fprintf(w, `{"paid":%t}`, paid)
+}
+
+type mockL402Payer interface {
+	SimulatePayment(paymentHash string)
+	GetPreimage(paymentHash string) (string, bool)
+}
+
+func (g *Gateway) handleL402MockPay(w http.ResponseWriter, r *http.Request) {
+	if !g.validAdminToken(r.Header.Get("X-Admin-Token")) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusUnauthorized)
+		json.NewEncoder(w).Encode(map[string]string{"error": "Invalid or missing X-Admin-Token"})
+		return
+	}
+
+	mock, ok := g.lightning.(mockL402Payer)
+	if !ok {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotImplemented)
+		json.NewEncoder(w).Encode(map[string]string{"error": "mock L402 payment is only available with the mock Lightning provider"})
+		return
+	}
+
+	r.Body = io.NopCloser(io.LimitReader(r.Body, 1048576))
+	var req struct {
+		PaymentHash string `json:"payment_hash"`
+		Macaroon    string `json:"macaroon"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		json.NewEncoder(w).Encode(map[string]string{"error": "Invalid request body"})
+		return
+	}
+	if len(req.PaymentHash) != 64 || req.Macaroon == "" {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		json.NewEncoder(w).Encode(map[string]string{"error": "payment_hash and macaroon are required"})
+		return
+	}
+
+	preimage, ok := mock.GetPreimage(req.PaymentHash)
+	if !ok {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		json.NewEncoder(w).Encode(map[string]string{"error": "payment hash not found"})
+		return
+	}
+	mock.SimulatePayment(req.PaymentHash)
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(map[string]string{
+		"paid":          "true",
+		"payment_hash":  req.PaymentHash,
+		"authorization": "L402 " + req.Macaroon + ":" + preimage,
+	})
+}
+
+func (g *Gateway) validAdminToken(adminToken string) bool {
+	if adminToken == "" {
+		return false
+	}
+
+	validTokens := []string{}
+	if g.config.Admin.Token != "" {
+		validTokens = append(validTokens, g.config.Admin.Token)
+	}
+	if envToken := strings.TrimSpace(getEnv("ADMIN_TOKEN", "")); envToken != "" {
+		validTokens = append(validTokens, envToken)
+	}
+
+	for _, vt := range validTokens {
+		if subtle.ConstantTimeCompare([]byte(adminToken), []byte(vt)) == 1 {
+			return true
+		}
+	}
+	return false
 }
 
 // matchRoute finds the route matching the request.

--- a/pkg/proxy/proxy_oss.go
+++ b/pkg/proxy/proxy_oss.go
@@ -203,8 +203,9 @@ func (g *Gateway) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Rate limit admin API endpoints
-	if strings.HasPrefix(r.URL.Path, "/api/") {
+	// Rate limit built-in admin/API endpoints without throttling customer
+	// upstream routes that happen to live under /api/.
+	if isBuiltInAPIEndpoint(r.URL.Path) {
 		clientIP := extractIP(r)
 		if !g.adminLimiter.allow(clientIP) {
 			w.Header().Set("Content-Type", "application/json")
@@ -512,6 +513,12 @@ func (g *Gateway) issueL402Challenge(w http.ResponseWriter, r *http.Request, rou
 	fmt.Fprintf(w, `{"error":"payment_required","invoice":"%s","amount_sats":%d,"payment_hash":"%s"}`, invoice, priceSats, paymentHash)
 }
 
+func isBuiltInAPIEndpoint(path string) bool {
+	return path == "/api/l402/mock-pay" ||
+		strings.HasPrefix(path, "/api/capability/") ||
+		strings.HasPrefix(path, "/api/governance/")
+}
+
 // handleCheckPayment allows frontend to poll for payment status
 func (g *Gateway) handleCheckPayment(w http.ResponseWriter, r *http.Request) {
 	// Extract payment hash from URL: /check-payment/{payment_hash}
@@ -545,11 +552,6 @@ func (g *Gateway) handleCheckPayment(w http.ResponseWriter, r *http.Request) {
 	fmt.Fprintf(w, `{"paid":%t}`, paid)
 }
 
-type mockL402Payer interface {
-	SimulatePayment(paymentHash string)
-	GetPreimage(paymentHash string) (string, bool)
-}
-
 func (g *Gateway) handleL402MockPay(w http.ResponseWriter, r *http.Request) {
 	if !g.validAdminToken(r.Header.Get("X-Admin-Token")) {
 		w.Header().Set("Content-Type", "application/json")
@@ -558,7 +560,7 @@ func (g *Gateway) handleL402MockPay(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	mock, ok := g.lightning.(mockL402Payer)
+	mock, ok := g.lightning.(*lightning.MockProvider)
 	if !ok {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusNotImplemented)
@@ -581,6 +583,14 @@ func (g *Gateway) handleL402MockPay(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusBadRequest)
 		json.NewEncoder(w).Encode(map[string]string{"error": "payment_hash and macaroon are required"})
+		return
+	}
+
+	mac, err := g.macaroonSvc.Verify(req.Macaroon)
+	if err != nil || mac.GetCaveat("payment_hash") != req.PaymentHash {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		json.NewEncoder(w).Encode(map[string]string{"error": "macaroon does not match payment_hash"})
 		return
 	}
 

--- a/pkg/proxy/proxy_oss_test.go
+++ b/pkg/proxy/proxy_oss_test.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"regexp"
 	"strings"
 	"testing"
 	"time"
@@ -366,24 +367,7 @@ func TestL402Policy_NoToken_Returns402(t *testing.T) {
 	}))
 	defer upstream.Close()
 
-	cfg := &config.Config{
-		Server: config.ServerConfig{Listen: ":8080"},
-		Admin:  config.AdminConfig{Token: "admin-secret", CORSAllowedOrigins: []string{"https://example.com"}},
-		Upstreams: map[string]config.Upstream{
-			"backend": {URL: upstream.URL},
-		},
-		Routes: []config.Route{
-			{
-				Name:     "paid",
-				Match:    config.RouteMatch{PathPrefix: "/api/"},
-				Upstream: "backend",
-				Policy: config.RoutePolicy{
-					Kind:      "l402",
-					PriceSats: 100,
-				},
-			},
-		},
-	}
+	cfg := newL402TestConfig(upstream.URL)
 	gw := newTestGateway(t, cfg)
 
 	req := httptest.NewRequest("GET", "/api/test", nil)
@@ -403,6 +387,90 @@ func TestL402Policy_NoToken_Returns402(t *testing.T) {
 	if !strings.Contains(authHeader, "invoice=") {
 		t.Error("expected invoice in L402 challenge")
 	}
+}
+
+func TestL402Policy_MockPayEndpointReturnsAuthorizationForPaidRetry(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(map[string]string{"paid": "true", "path": r.URL.Path})
+	}))
+	defer upstream.Close()
+
+	gw := newTestGateway(t, newL402TestConfig(upstream.URL))
+
+	challengeReq := httptest.NewRequest("GET", "/api/test", nil)
+	challengeW := httptest.NewRecorder()
+	gw.ServeHTTP(challengeW, challengeReq)
+	if challengeW.Code != http.StatusPaymentRequired {
+		t.Fatalf("expected initial 402, got %d", challengeW.Code)
+	}
+
+	macaroon := extractL402MacaroonFromChallenge(t, challengeW.Header().Get("WWW-Authenticate"))
+	var challengeBody map[string]interface{}
+	if err := json.NewDecoder(challengeW.Body).Decode(&challengeBody); err != nil {
+		t.Fatalf("decode challenge body: %v", err)
+	}
+	paymentHash, ok := challengeBody["payment_hash"].(string)
+	if !ok || paymentHash == "" {
+		t.Fatalf("expected payment_hash in challenge body, got %#v", challengeBody)
+	}
+
+	payReq := httptest.NewRequest("POST", "/api/l402/mock-pay", strings.NewReader(`{"payment_hash":"`+paymentHash+`","macaroon":"`+macaroon+`"}`))
+	payReq.Header.Set("Content-Type", "application/json")
+	payReq.Header.Set("X-Admin-Token", "admin-secret")
+	payW := httptest.NewRecorder()
+	gw.ServeHTTP(payW, payReq)
+	if payW.Code != http.StatusOK {
+		t.Fatalf("expected mock pay endpoint to return 200, got %d body=%s", payW.Code, payW.Body.String())
+	}
+
+	var payBody map[string]string
+	if err := json.NewDecoder(payW.Body).Decode(&payBody); err != nil {
+		t.Fatalf("decode pay body: %v", err)
+	}
+	authorization := payBody["authorization"]
+	if !strings.HasPrefix(authorization, "L402 "+macaroon+":") {
+		t.Fatalf("expected L402 authorization header, got %q", authorization)
+	}
+
+	paidReq := httptest.NewRequest("GET", "/api/test", nil)
+	paidReq.Header.Set("Authorization", authorization)
+	paidW := httptest.NewRecorder()
+	gw.ServeHTTP(paidW, paidReq)
+	if paidW.Code != http.StatusOK {
+		t.Fatalf("expected paid retry to proxy upstream, got %d body=%s", paidW.Code, paidW.Body.String())
+	}
+}
+
+func newL402TestConfig(upstreamURL string) *config.Config {
+	return &config.Config{
+		Server: config.ServerConfig{Listen: ":8080"},
+		Admin:  config.AdminConfig{Token: "admin-secret", CORSAllowedOrigins: []string{"https://example.com"}},
+		Upstreams: map[string]config.Upstream{
+			"backend": {URL: upstreamURL},
+		},
+		Routes: []config.Route{
+			{
+				Name:     "paid",
+				Match:    config.RouteMatch{PathPrefix: "/api/"},
+				Upstream: "backend",
+				Policy: config.RoutePolicy{
+					Kind:      "l402",
+					PriceSats: 100,
+				},
+			},
+		},
+	}
+}
+
+func extractL402MacaroonFromChallenge(t *testing.T, challenge string) string {
+	t.Helper()
+	match := regexp.MustCompile(`macaroon="([^"]+)"`).FindStringSubmatch(challenge)
+	if len(match) != 2 {
+		t.Fatalf("expected macaroon in challenge %q", challenge)
+	}
+	return match[1]
 }
 
 // --- StripPrefix tests ---

--- a/pkg/proxy/proxy_oss_test.go
+++ b/pkg/proxy/proxy_oss_test.go
@@ -75,6 +75,21 @@ func newTestGatewayWithUpstream(t *testing.T, upstream *httptest.Server, policyK
 	return gw, cfg
 }
 
+type structuralNonMockProvider struct{}
+
+func (structuralNonMockProvider) CreateInvoice(amountSats int64, memo string) (*lightning.Invoice, error) {
+	return lightning.NewMockProvider().CreateInvoice(amountSats, memo)
+}
+func (structuralNonMockProvider) CheckPayment(paymentHash string) (bool, error) { return false, nil }
+func (structuralNonMockProvider) GetBalance() (int64, error)                    { return 0, nil }
+func (structuralNonMockProvider) GetInfo() (*lightning.NodeInfo, error) {
+	return &lightning.NodeInfo{}, nil
+}
+func (structuralNonMockProvider) SimulatePayment(paymentHash string) {}
+func (structuralNonMockProvider) GetPreimage(paymentHash string) (string, bool) {
+	return strings.Repeat("a", 64), true
+}
+
 // --- New() constructor tests ---
 
 func TestNew_RequiresConfig(t *testing.T) {
@@ -399,22 +414,7 @@ func TestL402Policy_MockPayEndpointReturnsAuthorizationForPaidRetry(t *testing.T
 
 	gw := newTestGateway(t, newL402TestConfig(upstream.URL))
 
-	challengeReq := httptest.NewRequest("GET", "/api/test", nil)
-	challengeW := httptest.NewRecorder()
-	gw.ServeHTTP(challengeW, challengeReq)
-	if challengeW.Code != http.StatusPaymentRequired {
-		t.Fatalf("expected initial 402, got %d", challengeW.Code)
-	}
-
-	macaroon := extractL402MacaroonFromChallenge(t, challengeW.Header().Get("WWW-Authenticate"))
-	var challengeBody map[string]interface{}
-	if err := json.NewDecoder(challengeW.Body).Decode(&challengeBody); err != nil {
-		t.Fatalf("decode challenge body: %v", err)
-	}
-	paymentHash, ok := challengeBody["payment_hash"].(string)
-	if !ok || paymentHash == "" {
-		t.Fatalf("expected payment_hash in challenge body, got %#v", challengeBody)
-	}
+	macaroon, paymentHash := issueL402TestChallenge(t, gw)
 
 	payReq := httptest.NewRequest("POST", "/api/l402/mock-pay", strings.NewReader(`{"payment_hash":"`+paymentHash+`","macaroon":"`+macaroon+`"}`))
 	payReq.Header.Set("Content-Type", "application/json")
@@ -443,6 +443,66 @@ func TestL402Policy_MockPayEndpointReturnsAuthorizationForPaidRetry(t *testing.T
 	}
 }
 
+func TestL402Policy_MockPayEndpointRejectsMismatchedMacaroonHash(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	gw := newTestGateway(t, newL402TestConfig(upstream.URL))
+	macaroon, _ := issueL402TestChallenge(t, gw)
+	_, differentPaymentHash := issueL402TestChallenge(t, gw)
+
+	payReq := httptest.NewRequest("POST", "/api/l402/mock-pay", strings.NewReader(`{"payment_hash":"`+differentPaymentHash+`","macaroon":"`+macaroon+`"}`))
+	payReq.Header.Set("Content-Type", "application/json")
+	payReq.Header.Set("X-Admin-Token", "admin-secret")
+	payW := httptest.NewRecorder()
+	gw.ServeHTTP(payW, payReq)
+
+	if payW.Code != http.StatusBadRequest {
+		t.Fatalf("expected mismatched macaroon/payment_hash to return 400, got %d body=%s", payW.Code, payW.Body.String())
+	}
+	if !strings.Contains(payW.Body.String(), "macaroon does not match payment_hash") {
+		t.Fatalf("expected mismatch error body, got %s", payW.Body.String())
+	}
+}
+
+func TestL402Policy_MockPayEndpointRequiresConcreteMockProvider(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	gw := newTestGateway(t, newL402TestConfig(upstream.URL))
+	gw.lightning = structuralNonMockProvider{}
+
+	payReq := httptest.NewRequest("POST", "/api/l402/mock-pay", strings.NewReader(`{"payment_hash":"hash","macaroon":"mac"}`))
+	payReq.Header.Set("Content-Type", "application/json")
+	payReq.Header.Set("X-Admin-Token", "admin-secret")
+	payW := httptest.NewRecorder()
+	gw.ServeHTTP(payW, payReq)
+
+	if payW.Code != http.StatusNotImplemented {
+		t.Fatalf("expected non-concrete mock provider to return 501, got %d body=%s", payW.Code, payW.Body.String())
+	}
+}
+
+func TestIsBuiltInAPIEndpoint(t *testing.T) {
+	tests := map[string]bool{
+		"/api/l402/mock-pay":    true,
+		"/api/capability/mint":  true,
+		"/api/governance/rules": true,
+		"/api/test":             false,
+		"/api/customer/v1":      false,
+		"/check-payment/hash":   false,
+	}
+	for path, want := range tests {
+		if got := isBuiltInAPIEndpoint(path); got != want {
+			t.Fatalf("isBuiltInAPIEndpoint(%q)=%t, want %t", path, got, want)
+		}
+	}
+}
+
 func newL402TestConfig(upstreamURL string) *config.Config {
 	return &config.Config{
 		Server: config.ServerConfig{Listen: ":8080"},
@@ -462,6 +522,28 @@ func newL402TestConfig(upstreamURL string) *config.Config {
 			},
 		},
 	}
+}
+
+func issueL402TestChallenge(t *testing.T, gw *Gateway) (string, string) {
+	t.Helper()
+
+	challengeReq := httptest.NewRequest("GET", "/api/test", nil)
+	challengeW := httptest.NewRecorder()
+	gw.ServeHTTP(challengeW, challengeReq)
+	if challengeW.Code != http.StatusPaymentRequired {
+		t.Fatalf("expected initial 402, got %d body=%s", challengeW.Code, challengeW.Body.String())
+	}
+
+	macaroon := extractL402MacaroonFromChallenge(t, challengeW.Header().Get("WWW-Authenticate"))
+	var challengeBody map[string]interface{}
+	if err := json.NewDecoder(challengeW.Body).Decode(&challengeBody); err != nil {
+		t.Fatalf("decode challenge body: %v", err)
+	}
+	paymentHash, ok := challengeBody["payment_hash"].(string)
+	if !ok || paymentHash == "" {
+		t.Fatalf("expected payment_hash in challenge body, got %#v", challengeBody)
+	}
+	return macaroon, paymentHash
 }
 
 func extractL402MacaroonFromChallenge(t *testing.T, challenge string) string {


### PR DESCRIPTION
## Summary
- add a mock Lightning `/api/l402/mock-pay` endpoint for local/demo paid retries
- fix binary L402 macaroon verification by using libmacaroon verification for binary tokens
- add an Issue → Pay → Verify quickstart showing 402 challenge, mock settlement, and authorized retry

## Verification
- `go test ./...`
- built `./cmd/satgate`
- live local HTTP proof: `/premium/anything` returned 402, `/api/l402/mock-pay` returned `L402 ...`, paid retry returned 200 via httpbin

## Notes
- `/api/l402/mock-pay` requires `X-Admin-Token` and only works with the mock Lightning provider; real Lightning providers still settle externally.
