### PR TITLE
Align SEO pages with Policy-to-Proof CTR path

### DIFF
--- a/satgate-landing/app/blog/api-gateway-for-ai-agents/page.tsx
+++ b/satgate-landing/app/blog/api-gateway-for-ai-agents/page.tsx
@@ -197,7 +197,7 @@ Monetization          Subscription tiers      Per-call micropayments (L402)`}</c
             The gap isn't in routing, load balancing, or TLS termination. Every gateway handles that. The gap is in <strong className="text-white">economic awareness</strong> — understanding that API calls have variable costs, that agents need budgets (not rate limits), and that delegation requires cryptographic trust chains.
           </p>
 
-          <h2 className="text-2xl font-bold text-white mt-12 mb-4">The Missing Layer: Economic Governance</h2>
+          <h2 className="text-2xl font-bold text-white mt-12 mb-4">The Missing Layer: Request-Path Governance</h2>
           
           <p className="text-gray-300 leading-relaxed">
             An API gateway for AI agents needs three capabilities that traditional gateways lack entirely:
@@ -279,7 +279,7 @@ satgate mint \\
           <h2 className="text-2xl font-bold text-white mt-12 mb-4">How SatGate Approaches It</h2>
           
           <p className="text-gray-300 leading-relaxed">
-            SatGate isn't competing with Kong or Gravitee on routing and load balancing. Those are solved problems. Instead, SatGate sits as an <strong className="text-white">economic governance layer</strong> — either as a standalone proxy or alongside your existing gateway.
+            SatGate isn't competing with Kong or Gravitee on routing and load balancing. Those are solved problems. Instead, SatGate sits as a <strong className="text-white">request-path governance layer</strong> — either as a standalone proxy or alongside your existing gateway.
           </p>
 
           <p className="text-gray-300 leading-relaxed">
@@ -292,12 +292,12 @@ satgate mint \\
 └──────────────┬───────────────────────────┘
                │
 ┌──────────────▼───────────────────────────┐
-│  SatGate Economic Layer                  │
-│  ├─ Verify macaroon + caveats            │
-│  ├─ Check budget (atomic Redis op)       │
+│  SatGate Policy-to-Proof Layer           │
+│  ├─ Verify capability + caveats          │
+│  ├─ Check policy and budget atomically   │
 │  ├─ Resolve tool cost                    │
-│  ├─ Decrement budget                     │
-│  └─ Log economic event                   │
+│  ├─ Allow, deny, or require approval     │
+│  └─ Emit Evidence Pack                   │
 └──────────────┬───────────────────────────┘
                │
 ┌──────────────▼───────────────────────────┐
@@ -307,23 +307,23 @@ satgate mint \\
           </pre>
 
           <p className="text-gray-300 leading-relaxed">
-            This means you don't rip and replace your existing infrastructure. SatGate adds the economic layer that agents need while your current gateway continues handling TLS, routing, and load balancing.
+            This means you don't rip and replace your existing infrastructure. SatGate adds the Policy-to-Proof layer that agents need while your current gateway continues handling TLS, routing, and load balancing.
           </p>
 
-          <h2 className="text-2xl font-bold text-white mt-12 mb-4">The Enterprise Path: Observe → Control → Charge</h2>
+          <h2 className="text-2xl font-bold text-white mt-12 mb-4">The Enterprise Path: Observe → Control → Prove</h2>
           
           <p className="text-gray-300 leading-relaxed">
             Most enterprises aren't ready to enforce budgets on day one. That's fine. SatGate supports a progressive adoption model:
           </p>
 
           <ul className="text-gray-300 space-y-3">
-            <li><strong className="text-white">Observe:</strong> Deploy in audit mode. See what your agents are spending. No enforcement, just visibility. "We had no idea GPT-4 calls were 80% of our agent costs."</li>
-            <li><strong className="text-white">Control:</strong> Enable request-path budget enforcement. Set dollar-denominated limits per agent, per team, per route, and per MCP tool. "Engineering gets $5,000/month for agent API spend."</li>
-            <li><strong className="text-white">Charge (L402):</strong> Enable Lightning-based micropayments. SatGate governs paid-rail context for paid agents that pay per API request before access. Fiat402 is separate and should not be conflated with Charge.</li>
+            <li><strong className="text-white">Observe:</strong> Deploy in audit mode. See what agents are calling, spending, and delegating. No enforcement yet, just structured visibility.</li>
+            <li><strong className="text-white">Control:</strong> Enable request-path policy. Set budget, scope, route, tenant, and MCP-tool limits that block bad calls before they execute.</li>
+            <li><strong className="text-white">Prove:</strong> Preserve Evidence Packs for allow, deny, spend, delegation, and revocation decisions so security, finance, and auditors can verify what happened later.</li>
           </ul>
 
           <p className="text-gray-300 leading-relaxed">
-            Each stage builds on the last. By the time you're at L402, you have a fully autonomous economic system — agents that can discover, negotiate, and pay for API services without human intervention.
+            Each stage builds on the last. By the time paid rails enter the flow, they are governed context, not the control plane. Humans set policy and budgets; agents execute within those boundaries; SatGate preserves the proof.
           </p>
 
           <h2 className="text-2xl font-bold text-white mt-12 mb-4">What to Look For in an Agent-Aware Gateway</h2>
@@ -338,9 +338,9 @@ satgate mint \\
             <li>✅ <strong className="text-white">Atomic budget enforcement</strong> (no race conditions at scale)</li>
             <li>✅ <strong className="text-white">Capability-based tokens</strong> (attenuated delegation, not all-or-nothing keys)</li>
             <li>✅ <strong className="text-white">Delegation chain tracking</strong> (who delegated to whom, and whose budget pays)</li>
-            <li>✅ <strong className="text-white">Economic Evidence Pack</strong> (spend attribution by agent, tool, team)</li>
+            <li>✅ <strong className="text-white">Evidence Packs</strong> (signed proof of allow, deny, spend, and delegation decisions)</li>
             <li>✅ <strong className="text-white">Structured budget exhaustion errors</strong> (agents need to reason about limits)</li>
-            <li>✅ <strong className="text-white">Progressive adoption</strong> (observe → control → charge)</li>
+            <li>✅ <strong className="text-white">Progressive adoption</strong> (observe → control → prove)</li>
           </ul>
 
           <h2 className="text-2xl font-bold text-white mt-12 mb-4">The Bottom Line</h2>
@@ -350,7 +350,7 @@ satgate mint \\
           </p>
 
           <p className="text-gray-300 leading-relaxed">
-            You don't need to replace your gateway. You need to add an economic governance layer that understands budgets, delegation, and variable costs. That's the difference between an API gateway that routes traffic and one that governs autonomous economic activity.
+            You don't need to replace your gateway. You need to add request-path governance that understands authority, budgets, delegation, and variable costs, then proves each decision. That's the difference between an API gateway that routes traffic and one that governs autonomous agent activity.
           </p>
 
           <div className="my-8 rounded-2xl border border-cyan-900/60 bg-cyan-950/20 p-6">
@@ -404,24 +404,24 @@ satgate mint \\
           </div>
 
           <div className="my-10 rounded-2xl border border-cyan-900/60 bg-cyan-950/20 p-6">
-            <h3 className="mb-3 text-xl font-bold text-white">Compare routing gateways against economic control</h3>
-            <p className="mb-4 text-gray-300">Use the comparison hub and MCP proxy generator to map where existing gateways stop and SatGate&apos;s request-path controls begin.</p>
+            <h3 className="mb-3 text-xl font-bold text-white">Compare routing gateways against Policy-to-Proof</h3>
+            <p className="mb-4 text-gray-300">Use the comparison hub and MCP governance pages to map where existing gateways stop and SatGate&apos;s authority, budget, and Evidence Pack controls begin.</p>
             <div className="flex flex-wrap gap-3 text-sm font-semibold">
               <Link href="/compare" className="text-cyan-300 hover:text-cyan-200">Comparison hub →</Link>
-              <Link href="/mcp-proxy-config-generator" className="text-cyan-300 hover:text-cyan-200">MCP proxy config generator →</Link>
-              <Link href="/economic-firewall" className="text-cyan-300 hover:text-cyan-200">Economic firewall →</Link>
+              <Link href="/mcp-governance" className="text-cyan-300 hover:text-cyan-200">MCP governance →</Link>
+              <Link href="/policy-to-proof" className="text-cyan-300 hover:text-cyan-200">Policy-to-Proof →</Link>
             </div>
           </div>
 
 
           <div className="my-10 rounded-2xl border border-cyan-900/50 bg-cyan-950/10 p-6">
-            <h3 className="mb-3 text-xl font-bold text-white">SatGate growth path: Observe → Control → Charge</h3>
+            <h3 className="mb-3 text-xl font-bold text-white">SatGate path: Observe → Control → Prove</h3>
             <p className="mb-4 text-gray-300">
-              Start by using SatGate to Observe agent, API, and MCP usage. Move to Control when budgets, scopes, and revocation need to stop bad calls before they run. Add Charge when usage should become billable access, chargeback, or paid-agent revenue.
+              Start by observing agent, API, and MCP usage. Move to request-path control when budgets, scopes, and revocation need to stop bad calls before they run. Preserve Evidence Packs so every allow, deny, and budget decision can be verified later.
             </p>
             <div className="flex flex-wrap gap-3 text-sm font-semibold">
-              <Link href="/mcp-gateway" className="text-cyan-300 hover:text-cyan-200">MCP gateway →</Link>
-              <Link href="/capability-auth" className="text-cyan-300 hover:text-cyan-200">Capability auth →</Link>
+              <Link href="/policy-to-proof" className="text-cyan-300 hover:text-cyan-200">Policy-to-Proof →</Link>
+              <Link href="/mcp-governance" className="text-cyan-300 hover:text-cyan-200">MCP governance →</Link>
               <Link href="/govern" className="text-cyan-300 hover:text-cyan-200">See SatGate governance →</Link>
             </div>
           </div>

--- a/satgate-landing/app/blog/how-to-add-budget-limits-to-openai-api-calls/page.tsx
+++ b/satgate-landing/app/blog/how-to-add-budget-limits-to-openai-api-calls/page.tsx
@@ -579,7 +579,7 @@ satgate token update incident-token --daily-limit 1000 --expires 1h`}</code>
               <Link href="/ai-agent-cost-control" className="text-cyan-300 hover:text-cyan-200">AI agent cost control →</Link>
               <Link href="/tools" className="text-cyan-300 hover:text-cyan-200">Cost-control tools →</Link>
               <Link href="/agent-spend-policy-template" className="text-cyan-300 hover:text-cyan-200">Agent spend policy template →</Link>
-              <Link href="/economic-firewall-readiness-grader" className="text-cyan-300 hover:text-cyan-200">Readiness grader →</Link>
+              <Link href="/policy-to-proof" className="text-cyan-300 hover:text-cyan-200">Policy-to-Proof →</Link>
               <Link href="/agent-api-key-risk-assessment" className="text-cyan-300 hover:text-cyan-200">API key risk assessment →</Link>
               <Link href="/ai-agent-runaway-spend-index" className="text-cyan-300 hover:text-cyan-200">Runaway spend index →</Link>
               <Link href="/blog/llm-cost-management" className="text-cyan-300 hover:text-cyan-200">LLM cost management →</Link>
@@ -589,13 +589,13 @@ satgate token update incident-token --daily-limit 1000 --expires 1h`}</code>
 
 
           <div className="my-10 rounded-2xl border border-cyan-900/50 bg-cyan-950/10 p-6">
-            <h3 className="mb-3 text-xl font-bold text-white">SatGate growth path: Observe → Control → Charge</h3>
+            <h3 className="mb-3 text-xl font-bold text-white">SatGate path: Observe → Control → Prove</h3>
             <p className="mb-4 text-gray-300">
-              Start by using SatGate to Observe agent, API, and MCP usage. Move to Control when budgets, scopes, and revocation need to stop bad calls before they run. Add Charge when usage should become billable access, chargeback, or paid-agent revenue.
+              Start by observing agent, API, and MCP usage. Move to request-path control when budgets, scopes, and revocation need to stop bad calls before they run. Preserve Evidence Packs so every allow, deny, and budget decision can be verified later.
             </p>
             <div className="flex flex-wrap gap-3 text-sm font-semibold">
-              <Link href="/mcp-gateway" className="text-cyan-300 hover:text-cyan-200">MCP gateway →</Link>
-              <Link href="/capability-auth" className="text-cyan-300 hover:text-cyan-200">Capability auth →</Link>
+              <Link href="/policy-to-proof" className="text-cyan-300 hover:text-cyan-200">Policy-to-Proof →</Link>
+              <Link href="/mcp-governance" className="text-cyan-300 hover:text-cyan-200">MCP governance →</Link>
               <Link href="/govern" className="text-cyan-300 hover:text-cyan-200">See SatGate governance →</Link>
             </div>
           </div>

--- a/satgate-landing/app/blog/http-402-payment-required-use-cases/page.tsx
+++ b/satgate-landing/app/blog/http-402-payment-required-use-cases/page.tsx
@@ -458,18 +458,18 @@ Parent Agent ($50 macaroon)
             The pattern is consistent: wherever monthly subscriptions create friction for machine consumers, 402 with L402 provides a smoother alternative. Agents don&apos;t want to manage subscriptions. They want to pay for what they use, when they use it.
           </p>
 
-          <h2 className="text-2xl font-bold text-white mt-12 mb-4">The Future: 402 as Default Commerce Layer</h2>
+          <h2 className="text-2xl font-bold text-white mt-12 mb-4">The Future: 402 as a Paid Rail Under Authority</h2>
 
           <p className="text-gray-300 leading-relaxed">
             HTTP 402 is evolving from a curiosity into a fundamental building block of the agent economy. As more APIs expose 402 endpoints, agents will develop increasingly sophisticated payment strategies: comparing prices across providers, pre-funding budgets for anticipated workflows, and negotiating bulk rates through macaroon caveats.
           </p>
 
           <p className="text-gray-300 leading-relaxed">
-            The end state is an internet where machines can discover, evaluate, purchase, and consume digital services without any human in the loop. Not because humans aren&apos;t important &mdash; but because humans set the budgets, constraints, and policies, and the machines execute within those boundaries at speeds no human could match.
+            The enterprise end state is not agents spending freely. Humans and platforms set budgets, constraints, and policies; agents execute inside those boundaries; the payment rail carries value only after authority has been checked.
           </p>
 
           <p className="text-gray-300 leading-relaxed">
-            HTTP 402 was reserved for future use in 1997. The future is here, and it looks like delegated agents consuming paid API calls with paid-rail context, governed by macaroon tokens, settled in milliseconds. The dormant status code just woke up.
+HTTP 402 was reserved for future use in 1997. For agent systems, the useful version is narrower: 402 is paid-rail context around an authority decision, with policy checked before value moves and Evidence Packs available after the call.
           </p>
 
           <div className="my-10 rounded-2xl border border-yellow-900/60 bg-yellow-950/20 p-6">
@@ -482,35 +482,35 @@ Parent Agent ($50 macaroon)
               <Link href="/l402-agent-payments" className="text-cyan-300 hover:text-cyan-200">L402 agent payments →</Link>
               <Link href="/http-402-for-ai-agents" className="text-cyan-300 hover:text-cyan-200">HTTP 402 for AI agents →</Link>
               <Link href="/agent-payment-controls" className="text-cyan-300 hover:text-cyan-200">Agent payment controls →</Link>
-              <Link href="/economic-firewall" className="text-cyan-300 hover:text-cyan-200">Economic firewall →</Link>
+              <Link href="/partners/rails" className="text-cyan-300 hover:text-cyan-200">Paid-rail governance →</Link>
             </div>
           </div>
 
 
           <div className="my-10 rounded-2xl border border-cyan-900/50 bg-cyan-950/10 p-6">
-            <h3 className="mb-3 text-xl font-bold text-white">SatGate growth path: Observe → Control → Charge</h3>
+            <h3 className="mb-3 text-xl font-bold text-white">SatGate path: Observe → Control → Prove</h3>
             <p className="mb-4 text-gray-300">
-              Start by using SatGate to Observe agent, API, and MCP usage. Move to Control when budgets, scopes, and revocation need to stop bad calls before they run. Add Charge when usage should become billable access, chargeback, or paid-agent revenue.
+              Start by observing paid-agent and API usage. Move to Control when budgets, scopes, and payment authority need to stop bad calls before value moves. Preserve Evidence Packs so each paid-rail decision can be verified later.
             </p>
             <div className="flex flex-wrap gap-3 text-sm font-semibold">
-              <Link href="/mcp-gateway" className="text-cyan-300 hover:text-cyan-200">MCP gateway →</Link>
-              <Link href="/capability-auth" className="text-cyan-300 hover:text-cyan-200">Capability auth →</Link>
+              <Link href="/partners/rails" className="text-cyan-300 hover:text-cyan-200">Paid-rail partner brief →</Link>
+              <Link href="/policy-to-proof" className="text-cyan-300 hover:text-cyan-200">Policy-to-Proof →</Link>
               <Link href="/govern" className="text-cyan-300 hover:text-cyan-200">See SatGate governance →</Link>
             </div>
           </div>
 
           {/* CTA Section */}
           <div className="mt-16 bg-gradient-to-r from-blue-900/20 to-cyan-900/20 border border-blue-800/30 rounded-xl p-8">
-            <h3 className="text-xl font-bold text-white mb-3">Add 402 Payment Required to Your API</h3>
+            <h3 className="text-xl font-bold text-white mb-3">Govern 402 payments before value moves</h3>
             <p className="text-gray-300 mb-4">
-              SatGate is an economic gateway that adds L402 payment support, budget enforcement, and macaroon authentication to any API. Deploy in front of your existing infrastructure and start monetizing agent traffic today.
+              SatGate treats HTTP 402 and L402 as paid rails around authority decisions. Deploy it in front of APIs to enforce scope, budget, and payment policy before execution, then preserve Evidence Packs for later verification.
             </p>
             <div className="flex flex-wrap gap-3">
               <a href="https://github.com/SatGate-io/satgate" className="inline-flex items-center gap-2 bg-white text-black px-6 py-3 rounded-lg font-bold hover:bg-gray-200 transition text-sm">
                 View on GitHub
               </a>
-              <Link href="/blog/l402-protocol-explained" className="inline-flex items-center gap-2 border border-blue-500 text-blue-300 px-6 py-3 rounded-lg font-bold hover:bg-blue-900/30 transition text-sm">
-                Read: L402 Protocol Explained →
+              <Link href="/partners/rails" className="inline-flex items-center gap-2 border border-blue-500 text-blue-300 px-6 py-3 rounded-lg font-bold hover:bg-blue-900/30 transition text-sm">
+                Read: Paid-Rail Partner Brief →
               </Link>
             </div>
           </div>

--- a/satgate-landing/app/blog/llm-cost-management/page.tsx
+++ b/satgate-landing/app/blog/llm-cost-management/page.tsx
@@ -335,10 +335,10 @@ Authorization: Bearer macaroon_v1_agent42_budget500
             With capability-based budgets, the orchestrator <em>delegates a portion</em> of its budget to each sub-agent. The research agent gets 2,000 credits. Each scraper gets 200. Summarizers get 50. The total can never exceed the parent's allocation. It's hierarchical, cryptographically enforced, and impossible to game.
           </p>
 
-          <h2 className="text-2xl font-bold text-white mt-12 mb-4">The Economic Firewall Approach</h2>
+          <h2 className="text-2xl font-bold text-white mt-12 mb-4">The Policy-to-Proof Approach</h2>
 
           <p className="text-gray-300 leading-relaxed">
-            SatGate implements these four capabilities as an <strong className="text-white">economic firewall</strong> — a gateway-layer enforcement mechanism that sits between your agents and the LLM providers they call.
+            SatGate implements these four capabilities as request-path governance: a policy enforcement point between your agents and the LLM providers they call, plus Evidence Packs that prove what was allowed or denied later.
           </p>
 
           <p className="text-gray-300 leading-relaxed">
@@ -441,8 +441,8 @@ satgate mint \\
             <h3 className="mb-3 text-xl font-bold text-white">From dashboard to control plane</h3>
             <p className="mb-4 text-gray-300">If a page is already earning LLM cost management impressions, route that intent into the pages that convert: tools, policy templates, and comparison pages.</p>
             <div className="flex flex-wrap gap-3 text-sm font-semibold">
-              <Link href="/tools" className="text-cyan-300 hover:text-cyan-200">AI agent cost tools →</Link>
-              <Link href="/economic-firewall" className="text-cyan-300 hover:text-cyan-200">Economic firewall →</Link>
+              <Link href="/govern" className="text-cyan-300 hover:text-cyan-200">AI agent governance →</Link>
+              <Link href="/policy-to-proof" className="text-cyan-300 hover:text-cyan-200">Policy-to-Proof →</Link>
               <Link href="/agent-spend-policy-template" className="text-cyan-300 hover:text-cyan-200">Spend policy template →</Link>
               <Link href="/mcp-cost-control" className="text-cyan-300 hover:text-cyan-200">MCP cost control →</Link>
               <Link href="/mcp-proxy-config-generator" className="text-cyan-300 hover:text-cyan-200">MCP proxy config generator →</Link>
@@ -463,13 +463,13 @@ satgate mint \\
 
 
           <div className="my-10 rounded-2xl border border-cyan-900/50 bg-cyan-950/10 p-6">
-            <h3 className="mb-3 text-xl font-bold text-white">SatGate growth path: Observe → Control → Charge</h3>
+            <h3 className="mb-3 text-xl font-bold text-white">SatGate path: Observe → Control → Prove</h3>
             <p className="mb-4 text-gray-300">
-              Start by using SatGate to Observe agent, API, and MCP usage. Move to Control when budgets, scopes, and revocation need to stop bad calls before they run. Add Charge when usage should become billable access, chargeback, or paid-agent revenue.
+              Start by observing agent, API, and MCP usage. Move to request-path control when budgets, scopes, and revocation need to stop bad calls before they run. Preserve Evidence Packs so every allow, deny, and budget decision can be verified later.
             </p>
             <div className="flex flex-wrap gap-3 text-sm font-semibold">
-              <Link href="/mcp-gateway" className="text-cyan-300 hover:text-cyan-200">MCP gateway →</Link>
-              <Link href="/capability-auth" className="text-cyan-300 hover:text-cyan-200">Capability auth →</Link>
+              <Link href="/policy-to-proof" className="text-cyan-300 hover:text-cyan-200">Policy-to-Proof →</Link>
+              <Link href="/mcp-governance" className="text-cyan-300 hover:text-cyan-200">MCP governance →</Link>
               <Link href="/govern" className="text-cyan-300 hover:text-cyan-200">See SatGate governance →</Link>
             </div>
           </div>

--- a/satgate-landing/app/blog/macaroon-tokens-vs-api-keys/page.tsx
+++ b/satgate-landing/app/blog/macaroon-tokens-vs-api-keys/page.tsx
@@ -613,13 +613,13 @@ attenuated_token = agent_a_token.add_caveats([
 
 
           <div className="my-10 rounded-2xl border border-cyan-900/50 bg-cyan-950/10 p-6">
-            <h3 className="mb-3 text-xl font-bold text-white">SatGate growth path: Observe → Control → Charge</h3>
+            <h3 className="mb-3 text-xl font-bold text-white">SatGate path: Observe → Control → Prove</h3>
             <p className="mb-4 text-gray-300">
-              Start by using SatGate to Observe agent, API, and MCP usage. Move to Control when budgets, scopes, and revocation need to stop bad calls before they run. Add Charge when usage should become billable access, chargeback, or paid-agent revenue.
+              Start by observing agent, API, and MCP usage. Move to request-path control when budgets, scopes, and revocation need to stop bad calls before they run. Preserve Evidence Packs so every allow, deny, and budget decision can be verified later.
             </p>
             <div className="flex flex-wrap gap-3 text-sm font-semibold">
-              <Link href="/mcp-gateway" className="text-cyan-300 hover:text-cyan-200">MCP gateway →</Link>
-              <Link href="/capability-auth" className="text-cyan-300 hover:text-cyan-200">Capability auth →</Link>
+              <Link href="/policy-to-proof" className="text-cyan-300 hover:text-cyan-200">Policy-to-Proof →</Link>
+              <Link href="/mcp-governance" className="text-cyan-300 hover:text-cyan-200">MCP governance →</Link>
               <Link href="/govern" className="text-cyan-300 hover:text-cyan-200">See SatGate governance →</Link>
             </div>
           </div>

--- a/satgate-landing/app/components/GovernClient.tsx
+++ b/satgate-landing/app/components/GovernClient.tsx
@@ -75,7 +75,7 @@ export default function GovernPage() {
             </span>
           </h1>
           <p className="text-xl text-gray-400 mb-10 max-w-2xl mx-auto leading-relaxed">
-            SatGate is the Economic Firewall for enterprise agents: scope authority before work starts, enforce policy at runtime, and preserve evidence after every allowed, denied, delegated, or revoked action.
+            SatGate is the Economic Firewall for enterprise agents, implemented through Policy-to-Proof: scope authority before work starts, enforce request-path policy, and preserve Evidence Packs after every allowed, denied, delegated, or revoked action.
           </p>
           <div className="flex flex-col sm:flex-row gap-4 justify-center">
             <Link href="/policy-to-proof" className="bg-white text-black px-8 py-3 rounded-lg font-bold hover:bg-gray-200 transition flex items-center justify-center gap-2">
@@ -823,7 +823,7 @@ export SATGATE_TOKEN=$TOKEN
           <div className="space-y-6">
             {[
               ['What is AI agent governance?', 'AI agent governance is the set of controls that determines which agents can call which APIs, tools, and models; how much they can spend; what authority they can delegate; and when access must be revoked. For autonomous agents, governance needs request-path enforcement, not just logs and dashboards.'],
-              ['What is an economic firewall for AI agents?', 'An economic firewall for AI agents sits in the request path and applies scopes, budgets, delegation rules, revocation, and audit before an agent reaches an upstream API, model, or MCP tool. Humans and platforms set authority; agents consume bounded primitives; upstreams receive evidence.'],
+              ['What is Policy-to-Proof governance for AI agents?', 'Policy-to-Proof governance sits in the request path, applies scopes, budgets, delegation rules, and revocation before an agent reaches an upstream API, model, or MCP tool, then preserves Evidence Packs so the decision can be verified later.'],
               ['How should enterprises govern MCP tool usage?', 'Enterprises should govern MCP tools with per-tool budgets, scoped capability tokens, task and tenant attribution, Evidence Packs, revocation, and hard request-path policy decisions. Rate limits and dashboards are useful, but they do not replace enforcement before tool calls execute.'],
               ['What is the difference between AI governance and AI agent governance?', 'AI governance usually covers model risk, data policy, compliance, and human review. AI agent governance adds request-path controls for autonomous actions: scopes, budgets, delegated authority, revocation, denial reasons, spend attribution, and proof before APIs or MCP tools execute.'],
               ['Is SatGate tied to x402, L402, AgentCore Payments, or Pay.sh?', 'No. x402, L402, AgentCore Payments, Pay.sh, and related rails make it easier for agents to call paid services. SatGate is protocol-independent: it records the requesting agent, allowed action, policy basis, spend context, and evidence needed for audit, review, and control — payment or not.'],

--- a/satgate-landing/app/govern/page.tsx
+++ b/satgate-landing/app/govern/page.tsx
@@ -2,24 +2,25 @@ import type { Metadata } from "next";
 import GovernClient from "../components/GovernClient";
 
 export const metadata: Metadata = {
-  title: "AI Agent Governance: Govern, Enforce, Prove",
+  title: "AI Agent Governance: Policy-to-Proof",
   description:
-    "Give agents bounded economic authority with scoped policy, request-path enforcement, and proof humans and upstream APIs can trust.",
+    "AI agent governance for the Economic Firewall category: scope authority, enforce request-path policy, and export Evidence Packs for every agent decision.",
   alternates: {
     canonical: "https://satgate.io/govern",
   },
   keywords: [
     "enterprise AI agent governance",
     "AI agent authority governance",
-    "economic firewall for AI agents",
+    "Economic Firewall for AI agents",
+    "Policy-to-Proof governance for AI agents",
     "MCP governance for enterprises",
     "AI agent budget enforcement",
     "agent delegation controls",
     "Policy-to-Proof for AI agents",
-    "Govern Enforce Prove",
+    "Evidence Packs for AI agents",
   ],
   openGraph: {
-    title: "AI Agent Governance: Govern, Enforce, Prove",
+    title: "AI Agent Governance: Policy-to-Proof",
     description:
       "Give enterprise agents bounded economic authority with request-path enforcement and Evidence Pack proof.",
     url: "https://satgate.io/govern",
@@ -27,7 +28,7 @@ export const metadata: Metadata = {
   },
   twitter: {
     card: "summary_large_image",
-    title: "AI Agent Governance: Govern, Enforce, Prove",
+    title: "AI Agent Governance: Policy-to-Proof",
     description:
       "Delegate bounded authority, enforce policy, and export Policy-to-Proof evidence for enterprise AI agents with SatGate.",
   },
@@ -39,11 +40,12 @@ const webPageSchema = {
   name: "AI Agent Governance Platform",
   description: metadata.description,
   url: "https://satgate.io/govern",
-  dateModified: "2026-05-05",
+  dateModified: "2026-05-18",
   isPartOf: { "@type": "WebSite", name: "SatGate", url: "https://satgate.io" },
   about: [
     { "@type": "Thing", name: "AI agent governance" },
-    { "@type": "Thing", name: "economic firewall for AI agents" },
+    { "@type": "Thing", name: "Economic Firewall for AI agents" },
+    { "@type": "Thing", name: "Policy-to-Proof governance for AI agents" },
     { "@type": "Thing", name: "MCP governance for enterprises" },
     { "@type": "Thing", name: "agent delegation controls" },
     { "@type": "Thing", name: "Policy-to-Proof for AI agents" },
@@ -64,10 +66,10 @@ const faqSchema = {
     },
     {
       "@type": "Question",
-      name: "What is an economic firewall for AI agents?",
+      name: "What is Policy-to-Proof governance for AI agents?",
       acceptedAnswer: {
         "@type": "Answer",
-        text: "An economic firewall for AI agents sits in the request path and applies scopes, budgets, delegation rules, revocation, and audit before an agent reaches an upstream API, model, or MCP tool. Humans and platforms set authority; agents consume bounded primitives; upstreams receive evidence.",
+        text: "Policy-to-Proof governance for AI agents sits in the request path, applies scopes, budgets, delegation rules, and revocation before an agent reaches an upstream API, model, or MCP tool, then preserves an Evidence Pack so the decision can be verified later.",
       },
     },
     {

--- a/satgate-landing/seo/reports/opportunities.json
+++ b/satgate-landing/seo/reports/opportunities.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-05-10T22:40:19.919292Z",
+  "generatedAt": "2026-05-19T00:37:01.226986Z",
   "items": [
     {
       "path": "/blog/how-to-add-budget-limits-to-openai-api-calls",
@@ -133,7 +133,7 @@
       ],
       "intent": "commercial-investigation",
       "funnelStage": "solution-aware",
-      "productAngle": "SatGate acts as an economic firewall and gateway for agent API and MCP access.",
+      "productAngle": "SatGate adds request-path governance for agent API and MCP access: authority before execution, budget enforcement, and Evidence Pack proof.",
       "cta": "Route agents through SatGate",
       "status": "existing",
       "clicks": 0,

--- a/satgate-landing/seo/reports/opportunities.md
+++ b/satgate-landing/seo/reports/opportunities.md
@@ -1,6 +1,6 @@
 # SatGate SEO Machine Report
 
-Generated: 2026-05-10T22:40:19.920227Z
+Generated: 2026-05-19T00:37:01.228056Z
 
 ## Ranked opportunities
 

--- a/satgate-landing/seo/reports/page-audit.json
+++ b/satgate-landing/seo/reports/page-audit.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-05-10T22:40:19.919763Z",
+  "generatedAt": "2026-05-19T00:37:01.227531Z",
   "items": [
     {
       "path": "/blog/how-to-add-budget-limits-to-openai-api-calls",
@@ -34,11 +34,10 @@
         "/ai-agent-runaway-spend-index",
         "/blog",
         "/blog/llm-cost-management",
-        "/capability-auth",
-        "/economic-firewall-readiness-grader",
         "/govern",
-        "/mcp-gateway",
+        "/mcp-governance",
         "/openai-budget-policy-generator",
+        "/policy-to-proof",
         "/tools"
       ],
       "schemaTypes": [
@@ -49,7 +48,7 @@
         "TechArticle",
         "Thing"
       ],
-      "wordCount": 1318,
+      "wordCount": 1315,
       "hasObserveControlProve": true,
       "hasEvidencePack": true,
       "hasFAQ": true,
@@ -75,7 +74,7 @@
         "The LLM Cost Management Landscape Today",
         "Why Monitoring Fails When Agents Hold the Wallet",
         "What Real LLM Cost Management Looks Like",
-        "The Economic Firewall Approach",
+        "The Policy-to-Proof Approach",
         "Monitoring + Enforcement: Not Either/Or",
         "LLM Cost Dashboard FAQ",
         "Getting Started"
@@ -83,17 +82,15 @@
       "internalLinks": [
         "/agent-spend-policy-template",
         "/blog",
-        "/capability-auth",
         "/compare",
-        "/economic-firewall",
         "/economic-firewall-readiness-grader",
         "/govern",
         "/llm-cost-dashboard",
         "/llm-cost-monitoring",
         "/mcp-cost-control",
-        "/mcp-gateway",
+        "/mcp-governance",
         "/mcp-proxy-config-generator",
-        "/tools"
+        "/policy-to-proof"
       ],
       "schemaTypes": [
         "Answer",
@@ -103,7 +100,7 @@
         "TechArticle",
         "Thing"
       ],
-      "wordCount": 2177,
+      "wordCount": 2179,
       "hasObserveControlProve": true,
       "hasEvidencePack": true,
       "hasFAQ": true,
@@ -132,20 +129,18 @@
         "The L402 Protocol: Making 402 Practical",
         "Implementation Considerations",
         "402 in the Wild: Early Adopters",
-        "The Future: 402 as Default Commerce Layer"
+        "The Future: 402 as a Paid Rail Under Authority"
       ],
       "internalLinks": [
         "/agent-payment-controls",
         "/blog",
-        "/blog/l402-protocol-explained",
-        "/capability-auth",
-        "/economic-firewall",
         "/govern",
         "/http-402-for-ai-agents",
         "/l402-agent-payments",
         "/l402-api-pricing-calculator",
-        "/mcp-gateway",
         "/paid-agent-payments",
+        "/partners/rails",
+        "/policy-to-proof",
         "/tools"
       ],
       "schemaTypes": [
@@ -156,7 +151,7 @@
         "TechArticle",
         "Thing"
       ],
-      "wordCount": 2611,
+      "wordCount": 2596,
       "hasObserveControlProve": true,
       "hasEvidencePack": true,
       "hasFAQ": true,
@@ -194,11 +189,11 @@
         "/agent-capability-tokens",
         "/agent-control-plane",
         "/blog",
-        "/capability-auth",
         "/design-partners",
         "/economic-firewall-readiness-grader",
         "/govern",
-        "/mcp-gateway",
+        "/mcp-governance",
+        "/policy-to-proof",
         "/revocable-agent-credentials",
         "/revocable-capability-token-policy-template"
       ],
@@ -210,7 +205,7 @@
         "TechArticle",
         "Thing"
       ],
-      "wordCount": 2673,
+      "wordCount": 2671,
       "hasObserveControlProve": true,
       "hasEvidencePack": true,
       "hasFAQ": true,
@@ -221,10 +216,10 @@
     {
       "path": "/govern",
       "exists": true,
-      "title": "AI Agent Governance: Govern, Enforce, Prove",
-      "titleLength": 43,
-      "metaDescription": "Govern enterprise AI agents with SatGate: scope authority, enforce request-path policy, and prove every mint, delegation, spend, denial, and revocation.",
-      "metaDescriptionLength": 152,
+      "title": "AI Agent Governance: Policy-to-Proof",
+      "titleLength": 36,
+      "metaDescription": "AI agent governance for the Economic Firewall category: scope authority, enforce request-path policy, and export Evidence Packs for every agent decision.",
+      "metaDescriptionLength": 153,
       "canonical": "/govern",
       "h1": [
         "Govern what agents can do. Prove every decision."
@@ -235,7 +230,7 @@
         "Built for enterprise control owners",
         "Govern, enforce, prove.",
         "The runaway agent story",
-        "Dashboards that end in evidence.",
+        "Receipts that roll up into Evidence Packs.",
         "Delegation that leaves a trail",
         "Single Go Binary. Zero Dependencies.",
         "The authority commons \u2014 inside your company",
@@ -269,7 +264,7 @@
         "WebPage",
         "WebSite"
       ],
-      "wordCount": 1683,
+      "wordCount": 1696,
       "hasObserveControlProve": true,
       "hasEvidencePack": true,
       "hasFAQ": true,
@@ -293,22 +288,20 @@
         "The Old Model: Human-Driven API Traffic",
         "The New Model: Autonomous Agent Traffic",
         "What Traditional Gateways Actually Do",
-        "The Missing Layer: Economic Governance",
+        "The Missing Layer: Request-Path Governance",
         "Why Not Just Add Plugins?",
         "How SatGate Approaches It",
-        "The Enterprise Path: Observe \u2192 Control \u2192 Charge",
+        "The Enterprise Path: Observe \u2192 Control \u2192 Prove",
         "What to Look For in an Agent-Aware Gateway",
         "The Bottom Line",
         "API Gateway for AI Agents FAQ"
       ],
       "internalLinks": [
         "/blog",
-        "/capability-auth",
         "/compare",
-        "/economic-firewall",
         "/govern",
-        "/mcp-gateway",
-        "/mcp-proxy-config-generator"
+        "/mcp-governance",
+        "/policy-to-proof"
       ],
       "schemaTypes": [
         "Answer",
@@ -318,7 +311,7 @@
         "TechArticle",
         "Thing"
       ],
-      "wordCount": 1391,
+      "wordCount": 1376,
       "hasObserveControlProve": true,
       "hasEvidencePack": true,
       "hasFAQ": true,
@@ -340,7 +333,7 @@
       "h1Count": 1,
       "h2s": [
         "MCP connection is not MCP governance",
-        "Observe, Control, Charge MCP tool use",
+        "Observe, Control, Prove MCP tool use",
         "MCP policy templates teams can start from",
         "Claude, Hermes, and Ollama get scoped MCP authority \u2014 not standing authority",
         "SaaS MCP is Fly-hosted",
@@ -366,7 +359,7 @@
         "Question",
         "SoftwareApplication"
       ],
-      "wordCount": 903,
+      "wordCount": 910,
       "hasObserveControlProve": true,
       "hasEvidencePack": true,
       "hasFAQ": true,
@@ -408,7 +401,7 @@
         "Question",
         "SoftwareApplication"
       ],
-      "wordCount": 518,
+      "wordCount": 521,
       "hasObserveControlProve": true,
       "hasEvidencePack": true,
       "hasFAQ": true,

--- a/satgate-landing/seo/reports/recommendations.json
+++ b/satgate-landing/seo/reports/recommendations.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-05-10T22:40:19.920072Z",
+  "generatedAt": "2026-05-19T00:37:01.227868Z",
   "items": [
     {
       "path": "/blog/how-to-add-budget-limits-to-openai-api-calls",

--- a/satgate-landing/seo/reports/recommendations.md
+++ b/satgate-landing/seo/reports/recommendations.md
@@ -1,6 +1,6 @@
 # SatGate SEO Machine Report
 
-Generated: 2026-05-10T22:40:19.920227Z
+Generated: 2026-05-19T00:37:01.228056Z
 
 ## Ranked opportunities
 

--- a/satgate-landing/seo/targets.json
+++ b/satgate-landing/seo/targets.json
@@ -91,7 +91,7 @@
     ],
     "intent": "commercial-investigation",
     "funnelStage": "solution-aware",
-    "productAngle": "SatGate acts as an economic firewall and gateway for agent API and MCP access.",
+    "productAngle": "SatGate adds request-path governance for agent API and MCP access: authority before execution, budget enforcement, and Evidence Pack proof.",
     "cta": "Route agents through SatGate",
     "status": "existing"
   },


### PR DESCRIPTION
## Summary
- Retitled `/govern` metadata toward AI agent governance + Policy-to-Proof while preserving Economic Firewall as the category.
- Reworked high-intent blog CTAs from `Observe → Control → Charge` to `Observe → Control → Prove`.
- Reframed HTTP 402/L402 content as paid-rail context under authority, not the product center.
- Updated SEO target/report artifacts from the SEO machine.

## Verification
- `npm run seo:check` → 14 opportunities, 0 audit issue groups
- `npm run build` → passed, 120 static pages generated
- Local rendered probe on `/govern` plus 5 touched blog pages confirmed `Policy-to-Proof` + `Evidence Pack` present and targeted stale phrases absent
- Specialist review via SatGate SEO/copy pass; fixed the one inconsistency it flagged (`economic layer` → `Policy-to-Proof layer`) and balanced `/govern` with Economic Firewall as category

## Notes
- `baseline-browser-mapping` warning is pre-existing package freshness noise from Next/build output.
