### PR TITLE
Add AI spend governance SEO blog

### DIFF
--- a/satgate-landing/app/blog/ai-spend-governance/page.tsx
+++ b/satgate-landing/app/blog/ai-spend-governance/page.tsx
@@ -1,0 +1,320 @@
+import Link from 'next/link';
+import { ArrowLeft, Calendar, Clock } from 'lucide-react';
+
+export const metadata = {
+  title: 'AI Spend Governance: Control Usage-Based AI Costs Before They Scale',
+  description:
+    'Why usage-based AI pricing, agentic workflows, and tool-calling systems require request-path spend governance, not just dashboards after the bill arrives.',
+  alternates: { canonical: 'https://satgate.io/blog/ai-spend-governance' },
+  keywords: [
+    'AI spend governance',
+    'enterprise AI cost control',
+    'usage-based AI pricing',
+    'AI agent cost management',
+    'LLM cost governance',
+    'AI budget controls',
+    'AI model spend management',
+    'AI cost observability',
+    'AI FinOps',
+    'request-path budget enforcement',
+  ],
+  openGraph: {
+    title: 'AI Spend Governance: Control Usage-Based AI Costs Before They Scale',
+    description:
+      'Flat-rate AI hid the economics. Agentic AI exposes them. Enterprises need Observe, Control, Prove for spend before execution.',
+    url: 'https://satgate.io/blog/ai-spend-governance',
+    type: 'article',
+    publishedTime: '2026-05-22T00:00:00Z',
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'AI Spend Governance: Control Usage-Based AI Costs Before They Scale',
+    description:
+      'Usage-based AI pricing makes cost an operating risk. The answer is request-path governance: Observe, Control, Prove.',
+  },
+};
+
+export default function AiSpendGovernanceBlogPage() {
+  const articleJsonLd = {
+    '@context': 'https://schema.org',
+    '@type': 'TechArticle',
+    headline: 'AI Spend Governance: Control Usage-Based AI Costs Before They Scale',
+    description: metadata.description,
+    author: { '@type': 'Organization', name: 'SatGate' },
+    publisher: { '@type': 'Organization', name: 'SatGate', url: 'https://satgate.io' },
+    datePublished: '2026-05-22',
+    dateModified: '2026-05-22',
+    mainEntityOfPage: 'https://satgate.io/blog/ai-spend-governance',
+    about: [
+      { '@type': 'Thing', name: 'AI spend governance' },
+      { '@type': 'Thing', name: 'usage-based AI pricing' },
+      { '@type': 'Thing', name: 'enterprise AI cost control' },
+      { '@type': 'Thing', name: 'AI agent cost management' },
+      { '@type': 'Thing', name: 'request-path budget enforcement' },
+      { '@type': 'Thing', name: 'AI FinOps' },
+      { '@type': 'Thing', name: 'Policy-to-Proof' },
+    ],
+  };
+
+  const faqSchema = {
+    '@context': 'https://schema.org',
+    '@type': 'FAQPage',
+    mainEntity: [
+      {
+        '@type': 'Question',
+        name: 'What is AI spend governance?',
+        acceptedAnswer: {
+          '@type': 'Answer',
+          text: 'AI spend governance is the practice of observing AI usage, enforcing budgets and policy before execution, and preserving evidence of what happened afterward. It connects finance, security, compliance, and engineering around usage-based AI costs.',
+        },
+      },
+      {
+        '@type': 'Question',
+        name: 'Why is usage-based AI pricing harder to manage than SaaS seats?',
+        acceptedAnswer: {
+          '@type': 'Answer',
+          text: 'SaaS seat management controls who can log in. Usage-based AI pricing depends on model choice, token volume, context length, tool calls, retries, workflow design, and autonomous agent behavior. Two users with the same seat can create very different costs.',
+        },
+      },
+      {
+        '@type': 'Question',
+        name: 'Are dashboards enough for AI cost control?',
+        acceptedAnswer: {
+          '@type': 'Answer',
+          text: 'Dashboards are necessary but not enough. They explain spend after it happens. Agentic AI also needs request-path controls that can allow, block, downgrade, route, or escalate expensive actions before the bill is created.',
+        },
+      },
+      {
+        '@type': 'Question',
+        name: 'What should enterprises require from an AI spend governance layer?',
+        acceptedAnswer: {
+          '@type': 'Answer',
+          text: 'Enterprises should require usage attribution by user, agent, workflow, model, API, and tool; request-path policy enforcement; budget controls; routing decisions; approval flows; and Evidence Pack receipts that prove which policy allowed or denied each important action.',
+        },
+      },
+    ],
+  };
+
+  return (
+    <div className="min-h-screen bg-black text-gray-100 font-sans">
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(articleJsonLd) }} />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(faqSchema) }} />
+
+      <div className="max-w-3xl mx-auto px-6 py-16">
+        <Link href="/blog" className="text-gray-500 hover:text-white flex items-center gap-2 transition mb-8">
+          <ArrowLeft size={18} /> Back to Blog
+        </Link>
+
+        <header className="mb-12">
+          <div className="flex flex-wrap gap-2 mb-4">
+            <span className="px-2 py-1 rounded-full bg-purple-900/30 border border-purple-500/30 text-purple-300 text-xs font-mono">AI Spend Governance</span>
+            <span className="px-2 py-1 rounded-full bg-cyan-900/30 border border-cyan-500/30 text-cyan-300 text-xs font-mono">Cost Control</span>
+            <span className="px-2 py-1 rounded-full bg-yellow-900/30 border border-yellow-500/30 text-yellow-300 text-xs font-mono">Economic Firewall</span>
+          </div>
+
+          <h1 className="text-4xl font-bold mb-4">AI Spend Governance: Control Usage-Based AI Costs Before They Scale</h1>
+
+          <div className="mb-6 rounded-2xl border border-yellow-900/60 bg-yellow-950/20 p-5">
+            <p className="mb-2 text-sm font-semibold uppercase tracking-[0.2em] text-yellow-300">Short answer</p>
+            <p className="text-gray-300">
+              Flat-rate AI made adoption feel simple. Usage-based AI makes every model call, tool call, retry, and agent loop part of the operating model. Enterprises need to Observe, Control, and Prove AI usage before costs turn into surprises.
+            </p>
+          </div>
+
+          <p className="text-xl text-gray-400 mb-6 italic">
+            The next AI budget problem will not be solved by another dashboard. It needs governance in the request path.
+          </p>
+
+          <div className="flex items-center gap-4 text-sm text-gray-500">
+            <span className="flex items-center gap-1"><Calendar size={14} /> May 22, 2026</span>
+            <span className="flex items-center gap-1"><Clock size={14} /> 9 min read</span>
+          </div>
+        </header>
+
+        <article className="prose prose-invert prose-lg max-w-none">
+          <p className="text-gray-300 text-lg leading-relaxed">
+            The AI subsidy era is ending. Early enterprise AI adoption was built on a comforting assumption: model costs would keep falling, flat-rate seats would hide the mess, and usage could scale without anyone thinking too hard about the bill.
+          </p>
+
+          <p className="text-gray-300 leading-relaxed">
+            That assumption breaks once AI moves from chat to work. A human typing into a chatbot is one cost profile. An agent that reads context, calls tools, retries failures, routes across models, and runs in the background is another thing entirely.
+          </p>
+
+          <p className="text-gray-300 leading-relaxed">
+            Token-based pricing exposes what flat-rate AI plans masked: AI cost is not just a procurement issue. Once agents, copilots, workflows, APIs, and paid tools start making calls all day, spend becomes an operating risk.
+          </p>
+
+          <h2 className="text-2xl font-bold text-white mt-12 mb-4">Why agentic AI costs stratify</h2>
+
+          <p className="text-gray-300 leading-relaxed">
+            Enterprises will not get one cheap blended AI price. Costs will stratify by task, model, context window, tool use, autonomy, and risk. A short summary, a legal review, a coding agent, a retrieval workflow, and an MCP tool chain should not be priced, routed, or governed the same way.
+          </p>
+
+          <div className="overflow-x-auto rounded-2xl border border-gray-800 bg-gray-950/70 my-6">
+            <table className="w-full text-left text-sm text-gray-300">
+              <thead className="border-b border-gray-800 text-xs uppercase tracking-[0.18em] text-gray-500">
+                <tr>
+                  <th className="px-4 py-3">Cost driver</th>
+                  <th className="px-4 py-3">Why it changes governance</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-800">
+                <tr><td className="px-4 py-3 font-semibold text-white">Model choice</td><td className="px-4 py-3">A high-end model may be justified for regulated analysis, but wasteful for routine classification.</td></tr>
+                <tr><td className="px-4 py-3 font-semibold text-white">Context window</td><td className="px-4 py-3">Long context raises cost quickly, especially when agents carry history across steps.</td></tr>
+                <tr><td className="px-4 py-3 font-semibold text-white">Tool calls</td><td className="px-4 py-3">The model call is only part of the bill. APIs, MCP tools, search, code execution, and data access can add their own costs.</td></tr>
+                <tr><td className="px-4 py-3 font-semibold text-white">Retries and loops</td><td className="px-4 py-3">A bad plan, prompt injection, or flaky integration can multiply spend before anyone notices.</td></tr>
+                <tr><td className="px-4 py-3 font-semibold text-white">Risk level</td><td className="px-4 py-3">A low-risk request can be auto-approved. A high-risk action may need routing, approval, or denial with evidence.</td></tr>
+              </tbody>
+            </table>
+          </div>
+
+          <p className="text-gray-300 leading-relaxed">
+            That is why AI spend governance is broader than LLM cost monitoring. The enterprise needs to know not only what a request costs, but whether the request was allowed, which policy applied, which budget constrained it, and what proof exists afterward.
+          </p>
+
+          <h2 className="text-2xl font-bold text-white mt-12 mb-4">Seat management is not AI spend governance</h2>
+
+          <p className="text-gray-300 leading-relaxed">
+            Traditional SaaS governance asks who has access, which plan they are on, and whether the vendor is approved. That works when cost is tied mostly to seats.
+          </p>
+
+          <p className="text-gray-300 leading-relaxed">
+            AI usage-based pricing changes the question. Two employees with the same AI seat can create wildly different costs. One asks for a meeting summary. Another launches a coding agent that runs for an hour, calls a dozen tools, and uses a frontier model for every step.
+          </p>
+
+          <div className="my-8 rounded-2xl border border-purple-900/60 bg-purple-950/20 p-6">
+            <h2 className="text-2xl font-bold text-white mb-4">AI governance has to answer harder questions</h2>
+            <ul className="text-gray-300 space-y-2">
+              <li>Which user, team, agent, workflow, model, API, and tool drove the spend?</li>
+              <li>Was the action inside the delegated authority for that user or agent?</li>
+              <li>Was the model choice appropriate for the task and risk?</li>
+              <li>Was there budget left before the request executed?</li>
+              <li>Should the request have been allowed, downgraded, routed, escalated, or denied?</li>
+              <li>Can finance, security, compliance, and leadership audit the decision later?</li>
+            </ul>
+          </div>
+
+          <p className="text-gray-300 leading-relaxed">
+            If the answer lives only in a monthly invoice, it is too late. If the answer lives only in an observability dashboard, it may still be too late. Agentic systems need decisions at the moment of action.
+          </p>
+
+          <h2 className="text-2xl font-bold text-white mt-12 mb-4">Dashboards are necessary. They are not sufficient.</h2>
+
+          <p className="text-gray-300 leading-relaxed">
+            Dashboards are useful. Finance needs attribution. Engineering needs traces. Security needs logs. Product teams need to understand which workflows create value and which ones burn money.
+          </p>
+
+          <p className="text-gray-300 leading-relaxed">
+            But dashboards explain spend after it happens. They do not stop an agent from making the next expensive call.
+          </p>
+
+          <p className="text-gray-300 leading-relaxed">
+            The missing layer sits in the request path. Before the model, tool, API, or paid rail executes, the system should check authority, policy, budget, route, risk, and evidence requirements. Then it should make a decision.
+          </p>
+
+          <div className="bg-gray-900/70 border border-gray-800 rounded-lg p-6 my-6">
+            <p className="text-gray-300 leading-relaxed mb-0">
+              <strong className="text-white">A dashboard says:</strong> This agent spent $2,300 last week.
+            </p>
+            <p className="text-gray-300 leading-relaxed mt-4 mb-0">
+              <strong className="text-white">A governance layer says:</strong> This agent has $40 left, this task is low risk, this cheaper model is approved, and the next request will leave a receipt.
+            </p>
+          </div>
+
+          <p className="text-gray-300 leading-relaxed">
+            That difference matters. Reporting helps explain the bill. Request-path governance changes the bill before it exists. For enterprise AI cost control and AI agent cost management, that is the line between accounting and enforcement.
+          </p>
+
+          <div className="my-8 rounded-2xl border border-gray-800 bg-gray-950/70 p-6">
+            <p className="mb-3 text-sm font-semibold uppercase tracking-[0.2em] text-gray-500">Next step</p>
+            <h2 className="text-2xl font-bold text-white mb-3">Estimate the cost of runaway agent loops</h2>
+            <p className="text-gray-300 leading-relaxed mb-5">
+              If your team is moving from pilots to agentic workflows, model the downside case before the invoice arrives.
+            </p>
+            <Link href="/runaway-agent-cost-calculator" className="inline-flex items-center justify-center rounded-lg border border-gray-700 px-5 py-3 font-bold text-white transition hover:border-cyan-500">
+              Use the runaway agent cost calculator
+            </Link>
+          </div>
+
+          <h2 className="text-2xl font-bold text-white mt-12 mb-4">The Observe, Control, Prove model</h2>
+
+          <p className="text-gray-300 leading-relaxed">
+            AI spend governance needs three motions working together.
+          </p>
+
+          <h3 className="text-xl font-bold text-white mt-8 mb-3">Observe every call</h3>
+          <p className="text-gray-300 leading-relaxed">
+            Track usage by user, agent, team, workflow, tenant, model, API, paid service, MCP tool, and policy version. Cost attribution has to reach the unit of work, not stop at the vendor invoice.
+          </p>
+
+          <h3 className="text-xl font-bold text-white mt-8 mb-3">Control before execution</h3>
+          <p className="text-gray-300 leading-relaxed">
+            Enforce budgets, approvals, routing, rate limits, model selection, delegation depth, and tool permissions before the request runs. A control that fires after the request is just an alert with better branding.
+          </p>
+
+          <h3 className="text-xl font-bold text-white mt-8 mb-3">Prove what happened</h3>
+          <p className="text-gray-300 leading-relaxed">
+            Preserve Evidence Pack receipts that show who delegated authority, which policy applied, what budget constrained the action, what decision was made, and why it was allowed or denied. Finance needs the cost trail. Security and compliance need the authority trail.
+          </p>
+
+          <h2 className="text-2xl font-bold text-white mt-12 mb-4">What enterprises should require</h2>
+
+          <p className="text-gray-300 leading-relaxed">
+            A serious AI spend governance layer should do more than report token totals. It should connect cost, authority, policy, and evidence at request time.
+          </p>
+
+          <ul className="text-gray-300 space-y-2">
+            <li>Attribute spend by user, team, tenant, agent, workflow, model, API, and tool.</li>
+            <li>Set budgets by task, team, agent, capability, tenant, or workflow.</li>
+            <li>Route work to the right model or tool based on cost, risk, and policy.</li>
+            <li>Block, downgrade, approve, or escalate requests before execution.</li>
+            <li>Enforce delegated authority instead of relying on broad API keys.</li>
+            <li>Create receipts for allowed and denied actions.</li>
+            <li>Export evidence for finance, security, compliance, and leadership review.</li>
+          </ul>
+
+          <p className="text-gray-300 leading-relaxed">
+            This is where AI FinOps and AI governance meet. FinOps cares about unit economics. Governance cares about authority and risk. Agentic AI forces both into the same request.
+          </p>
+
+          <h2 className="text-2xl font-bold text-white mt-12 mb-4">The operating model for enterprise AI</h2>
+
+          <p className="text-gray-300 leading-relaxed">
+            The next phase of enterprise AI will not be defined only by better models. It will be defined by whether companies can govern usage before it turns into spend.
+          </p>
+
+          <p className="text-gray-300 leading-relaxed">
+            Companies still need experimentation. They still need teams to test new models, agents, tools, and workflows. But unfettered access does not scale when every action can create variable cost and risk.
+          </p>
+
+          <p className="text-gray-300 leading-relaxed">
+            The winning enterprises will not be the ones that give every agent unlimited access. They will be the ones that make AI usage observable, controllable, and provable by default.
+          </p>
+
+          <div className="my-10 rounded-2xl border border-cyan-900/60 bg-cyan-950/20 p-6">
+            <h2 className="text-2xl font-bold text-white mb-4">SatGate&apos;s view</h2>
+            <p className="text-gray-300 leading-relaxed">
+              SatGate is Economic Firewall infrastructure for enterprise agents. It gives teams a Policy-to-Proof control layer for AI, API, MCP, and paid-tool usage: observe the call, control the policy before execution, and prove what happened afterward with Evidence Pack receipts.
+            </p>
+            <div className="mt-6 flex flex-col sm:flex-row gap-3">
+              <Link href="/economic-firewall" className="inline-flex items-center justify-center rounded-lg bg-cyan-400 px-5 py-3 font-bold text-black transition hover:bg-cyan-300">
+                Learn about Economic Firewalls
+              </Link>
+              <Link href="/policy-to-proof" className="inline-flex items-center justify-center rounded-lg border border-gray-700 px-5 py-3 font-bold text-white transition hover:border-cyan-500">
+                See Policy-to-Proof
+              </Link>
+            </div>
+          </div>
+
+          <h2 className="text-2xl font-bold text-white mt-12 mb-4">Related reading</h2>
+          <ul className="text-gray-300 space-y-2">
+            <li><Link href="/blog/llm-cost-management" className="text-cyan-400 hover:text-cyan-300 underline">LLM cost management: dashboards vs real-time budget enforcement</Link></li>
+            <li><Link href="/blog/ai-agent-spending-limits" className="text-cyan-400 hover:text-cyan-300 underline">AI agent spending limits: hard budgets by agent, tool, and workflow</Link></li>
+            <li><Link href="/blog/the-enterprise-adoption-playbook-observe-control-charge" className="text-cyan-400 hover:text-cyan-300 underline">The enterprise adoption playbook: Observe, Control, Prove</Link></li>
+            <li><Link href="/compare/langsmith-helicone-datadog" className="text-cyan-400 hover:text-cyan-300 underline">LLM observability vs agent control</Link></li>
+          </ul>
+        </article>
+      </div>
+    </div>
+  );
+}

--- a/satgate-landing/app/blog/page.tsx
+++ b/satgate-landing/app/blog/page.tsx
@@ -1,5 +1,5 @@
 import Link from 'next/link';
-import { ArrowLeft, ArrowRight, Calendar, Clock, User } from 'lucide-react';
+import { ArrowLeft, ArrowRight, Calendar, Clock } from 'lucide-react';
 
 export const metadata = {
   title: 'AI Agent Governance Blog: Cost Control, MCP, L402, Economic Firewalls',
@@ -30,6 +30,15 @@ export const metadata = {
 
 // Blog post data - in a real setup this would come from a CMS or markdown files
 const posts = [
+  {
+    slug: 'ai-spend-governance',
+    title: 'AI Spend Governance: Control Usage-Based AI Costs Before They Scale',
+    description: 'Usage-based AI pricing makes cost an operating risk. Learn why enterprises need request-path controls to observe, control, and prove AI agent spend.',
+    date: '2026-05-22',
+    readTime: '9 min read',
+    author: 'SatGate Team',
+    tags: ['AI Spend Governance', 'Cost Control', 'AI Agents', 'Enterprise'],
+  },
   {
     slug: 'cursor-mcp-proxy-setup-guide',
     title: 'Cursor MCP Proxy Setup Guide: Add Budget Controls and Evidence Packs to Your Tools',
@@ -372,7 +381,7 @@ export default function BlogPage() {
               ['/runaway-agent-cost-calculator', 'Runaway Agent Cost Calculator', 'Model loop, retry, fanout, and paid tool-call exposure.'],
               ['/openai-budget-policy-generator', 'OpenAI Budget Policy Generator', 'Generate OpenAI spend caps, routing, revocation, and audit policy.'],
               ['/mcp-tool-cost-policy-generator', 'MCP Tool Cost Policy Generator', 'Create per-tool MCP budgets, risk actions, and audit rules.'],
-              ['/economic-firewall-readiness-grader', 'Economic Firewall Readiness Grader', 'Score identity, budgets, MCP tools, revocation, audit, routing, and Charge.'],
+              ['/economic-firewall-readiness-grader', 'Economic Firewall Readiness Grader', 'Score identity, budgets, MCP tools, revocation, audit, routing, and proof.'],
               ['/economic-firewall', 'Economic Firewall Definition', 'Learn the request-path category for AI agent economic governance.'],
             ].map(([href, title, body]) => (
               <Link key={href} href={href} className="rounded-xl border border-gray-800 bg-black/60 p-4 transition hover:border-cyan-500/50 hover:bg-cyan-950/20">

--- a/satgate-landing/app/sitemap.ts
+++ b/satgate-landing/app/sitemap.ts
@@ -51,7 +51,7 @@ const staticRoutes: SitemapEntry[] = [
   { path: '/integrations', lastModified: '2026-05-03', changeFrequency: 'weekly', priority: 0.8 },
   { path: '/pricing', lastModified: '2026-05-03', changeFrequency: 'monthly', priority: 0.9 },
   { path: '/security', lastModified: '2026-05-03', changeFrequency: 'monthly', priority: 0.8 },
-  { path: '/blog', lastModified: '2026-05-04', changeFrequency: 'weekly', priority: 0.8 },
+  { path: '/blog', lastModified: '2026-05-22', changeFrequency: 'weekly', priority: 0.8 },
   { path: '/compare', lastModified: '2026-05-10', changeFrequency: 'monthly', priority: 0.8 },
   { path: '/compare/aws-agentcore-payments', lastModified: '2026-05-10', changeFrequency: 'monthly', priority: 0.8 },
   { path: '/compare/cloudflare-ai-gateway', lastModified: '2026-05-10', changeFrequency: 'monthly', priority: 0.8 },
@@ -94,6 +94,7 @@ const staticRoutes: SitemapEntry[] = [
 ];
 
 const blogRoutes: SitemapEntry[] = [
+  { path: '/blog/ai-spend-governance', lastModified: '2026-05-22', changeFrequency: 'monthly', priority: 0.8 },
   { path: '/blog/why-routing-isnt-governance', lastModified: '2026-05-04', changeFrequency: 'monthly', priority: 0.6 },
   { path: '/blog/beyond-connection-economic-governance-mcp', lastModified: '2026-05-04', changeFrequency: 'monthly', priority: 0.6 },
   { path: '/blog/how-we-built-budget-enforcement-mcp', lastModified: '2026-05-04', changeFrequency: 'monthly', priority: 0.6 },

--- a/satgate-landing/package-lock.json
+++ b/satgate-landing/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "lucide-react": "^0.555.0",
-        "next": "^16.2.6",
+        "next": "16.2.5",
         "react": "19.2.1",
         "react-dom": "19.2.1",
         "resend": "^6.9.3"
@@ -1037,9 +1037,9 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "16.2.6",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.6.tgz",
-      "integrity": "sha512-gd8HoHN4ufj73WmR3JmVolrpJR47ILK6LouP5xElPglaVxir6e1a7VzvTvDWkOoPXT9rkkTzyCxBu4yeZfZwcw==",
+      "version": "16.2.5",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.5.tgz",
+      "integrity": "sha512-Lb9ElHD2klcyeVD25vW+siPFqz9QMzDUSgvFZNO+dZEKoMHex4viJhVuzBhrXKqb+UKnih7mVYbt50/7KLsSCA==",
       "license": "MIT"
     },
     "node_modules/@next/eslint-plugin-next": {
@@ -1053,9 +1053,9 @@
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "16.2.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.6.tgz",
-      "integrity": "sha512-ZJGkkcNfYgrrMkqOdZ7zoLa1TOy0qpcMfk/z4Mh/FKUz40gVO+HNQWqmLxf67Z5WB64DRp0dhEbyHfel+6sJUg==",
+      "version": "16.2.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.5.tgz",
+      "integrity": "sha512-BW+8PGVmsruomXHsitD8JG6gny9lEdobctjBwvtPF8AKtxGDR7nR35FOl/oK9UAPXBOBm+vx0k8qtpeHOXQMGQ==",
       "cpu": [
         "arm64"
       ],
@@ -1069,9 +1069,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "16.2.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.6.tgz",
-      "integrity": "sha512-v/YLBHIY132Ced3puBJ7YJKw1lqsCrgcNo2aRJlCEyQrrCeRJlvGlnmxhPxNQI3KE3N1DN5r9TPNPvka3nq5RQ==",
+      "version": "16.2.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.5.tgz",
+      "integrity": "sha512-ZoCGnCl9LlQJWmqXrZAUlNxvuNmclvE+7zUif+nDydkkehl9FKxHJ+wxSQMj+C37BYFerKiEdX9s9o02ir975Q==",
       "cpu": [
         "x64"
       ],
@@ -1085,9 +1085,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "16.2.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.6.tgz",
-      "integrity": "sha512-RPOvqlYBbcQjkz9VQQDZ2T2bARIjXZV1KFlt+V2Mr6SW/e4I9fcKsaA0hdyf2FHoTlsV2xnBd5Y912rP/1Ce6w==",
+      "version": "16.2.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.5.tgz",
+      "integrity": "sha512-AwcZzMChaWkOTZt3vu+2ZMIj8g4dYQY+B8VUVhlFSQ2JtvyZpefyYHTe00D6b6L7BysYw7vl3zsvs9jix8tl5Q==",
       "cpu": [
         "arm64"
       ],
@@ -1104,9 +1104,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "16.2.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.6.tgz",
-      "integrity": "sha512-URUTu1+dMkxJsPFgm+OeEvq9wf5sujw0EvgYy80TDGHTSLTnIHeqb0Eu8A3sC95IRgjejQL+kC4mw+4yPxiAXA==",
+      "version": "16.2.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.5.tgz",
+      "integrity": "sha512-QqMgqWbCBFsfiQ7BF3dUlW8HJy1LWhpcqbTpoHMWA9IV+TnWwDKozQJA5NdIAHjQ00yX2Q7AUkLr/XK4n77q8A==",
       "cpu": [
         "arm64"
       ],
@@ -1123,9 +1123,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "16.2.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.6.tgz",
-      "integrity": "sha512-DOj182mPV8G3UkrayLoREM5YEYI+Dk5wv7Ox9xl1fFibAELEsFD0lDPfHIeILlutMMfdyhlzYPELG3peuKaurw==",
+      "version": "16.2.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.5.tgz",
+      "integrity": "sha512-3hzeiFGZtyATVx9pCeuzTshXmh50vHZitqaeZiyJZaUmjQyrfjsVUgS8apOj1vEJCIpKJM/55F45yPAV2kpjsA==",
       "cpu": [
         "x64"
       ],
@@ -1142,9 +1142,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "16.2.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.6.tgz",
-      "integrity": "sha512-HKQ5SP/V/ub73UvF7n/zeJlxk2kLmtL7Wzrg4WfmkjmNos5onJ2tKu7yZOPdL18A6Svfn3max29ym+ry7NkK4g==",
+      "version": "16.2.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.5.tgz",
+      "integrity": "sha512-0mzZV/mAt7Qj2tYNdTB6AqrS8dwng/AQLSYC5Z1YLpZdi2wxqKDPK7RY2RvjB1fXyJfOfdA3l/yTF5yLi+WfuQ==",
       "cpu": [
         "x64"
       ],
@@ -1161,9 +1161,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "16.2.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.6.tgz",
-      "integrity": "sha512-LZXpTlPyS5v7HhSmnvsLGP3iIYgYOBnc8r8ArlT55sGHV89bR2HlDdBjWQ+PY6SJMmk8TuVGFuxalnP3k/0Dwg==",
+      "version": "16.2.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.5.tgz",
+      "integrity": "sha512-f/H4nZ2zJBvA8/+HpsB9mNonF9zfQoAU6D0WxJrfzhJDvJLfngVN85oqxUyrDVK99DIFfFYhLpGa5K+c5uotSw==",
       "cpu": [
         "arm64"
       ],
@@ -1177,9 +1177,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "16.2.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.6.tgz",
-      "integrity": "sha512-F0+4i0h9J6C4eE3EAPWsoCk7UW/dbzOjyzxY0qnDUOYFu6FFmdZ6l97/XdV3/Nz3VYyO7UWjyEJUXkGqcoXfMA==",
+      "version": "16.2.5",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.5.tgz",
+      "integrity": "sha512-nuP7DHs4koAojsIxVPkihNgKiRUKtCU65j5X6DAbSy8VBrfT/o90bCLLHPf51JEdOZwZMFzM6e0NiGWfIWjVAg==",
       "cpu": [
         "x64"
       ],
@@ -4995,12 +4995,12 @@
       "license": "MIT"
     },
     "node_modules/next": {
-      "version": "16.2.6",
-      "resolved": "https://registry.npmjs.org/next/-/next-16.2.6.tgz",
-      "integrity": "sha512-qOVgKJg1+At15NpeUP+eJgCHvTCgXsogweq87Ri/Ix7PkqQHg4sdaXmSFqKlgaIXE4kW0g25LE68W87UANlHtw==",
+      "version": "16.2.5",
+      "resolved": "https://registry.npmjs.org/next/-/next-16.2.5.tgz",
+      "integrity": "sha512-TkVTm9F2WEulkgGljm4wPwNgvCCWCVw6StUHsZb8WZpHFRjepoUWg3d7L4IMg7IyjcJ4Co9eVhpro8e8O+KarQ==",
       "license": "MIT",
       "dependencies": {
-        "@next/env": "16.2.6",
+        "@next/env": "16.2.5",
         "@swc/helpers": "0.5.15",
         "baseline-browser-mapping": "^2.9.19",
         "caniuse-lite": "^1.0.30001579",
@@ -5014,14 +5014,14 @@
         "node": ">=20.9.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "16.2.6",
-        "@next/swc-darwin-x64": "16.2.6",
-        "@next/swc-linux-arm64-gnu": "16.2.6",
-        "@next/swc-linux-arm64-musl": "16.2.6",
-        "@next/swc-linux-x64-gnu": "16.2.6",
-        "@next/swc-linux-x64-musl": "16.2.6",
-        "@next/swc-win32-arm64-msvc": "16.2.6",
-        "@next/swc-win32-x64-msvc": "16.2.6",
+        "@next/swc-darwin-arm64": "16.2.5",
+        "@next/swc-darwin-x64": "16.2.5",
+        "@next/swc-linux-arm64-gnu": "16.2.5",
+        "@next/swc-linux-arm64-musl": "16.2.5",
+        "@next/swc-linux-x64-gnu": "16.2.5",
+        "@next/swc-linux-x64-musl": "16.2.5",
+        "@next/swc-win32-arm64-msvc": "16.2.5",
+        "@next/swc-win32-x64-msvc": "16.2.5",
         "sharp": "^0.34.5"
       },
       "peerDependencies": {

--- a/satgate-landing/package-lock.json
+++ b/satgate-landing/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "lucide-react": "^0.555.0",
-        "next": "16.2.5",
+        "next": "16.1.6",
         "react": "19.2.1",
         "react-dom": "19.2.1",
         "resend": "^6.9.3"
@@ -1037,9 +1037,9 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "16.2.5",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.5.tgz",
-      "integrity": "sha512-Lb9ElHD2klcyeVD25vW+siPFqz9QMzDUSgvFZNO+dZEKoMHex4viJhVuzBhrXKqb+UKnih7mVYbt50/7KLsSCA==",
+      "version": "16.1.6",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.1.6.tgz",
+      "integrity": "sha512-N1ySLuZjnAtN3kFnwhAwPvZah8RJxKasD7x1f8shFqhncnWZn4JMfg37diLNuoHsLAlrDfM3g4mawVdtAG8XLQ==",
       "license": "MIT"
     },
     "node_modules/@next/eslint-plugin-next": {
@@ -1053,9 +1053,9 @@
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "16.2.5",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.5.tgz",
-      "integrity": "sha512-BW+8PGVmsruomXHsitD8JG6gny9lEdobctjBwvtPF8AKtxGDR7nR35FOl/oK9UAPXBOBm+vx0k8qtpeHOXQMGQ==",
+      "version": "16.1.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.1.6.tgz",
+      "integrity": "sha512-wTzYulosJr/6nFnqGW7FrG3jfUUlEf8UjGA0/pyypJl42ExdVgC6xJgcXQ+V8QFn6niSG2Pb8+MIG1mZr2vczw==",
       "cpu": [
         "arm64"
       ],
@@ -1069,9 +1069,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "16.2.5",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.5.tgz",
-      "integrity": "sha512-ZoCGnCl9LlQJWmqXrZAUlNxvuNmclvE+7zUif+nDydkkehl9FKxHJ+wxSQMj+C37BYFerKiEdX9s9o02ir975Q==",
+      "version": "16.1.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.1.6.tgz",
+      "integrity": "sha512-BLFPYPDO+MNJsiDWbeVzqvYd4NyuRrEYVB5k2N3JfWncuHAy2IVwMAOlVQDFjj+krkWzhY2apvmekMkfQR0CUQ==",
       "cpu": [
         "x64"
       ],
@@ -1085,9 +1085,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "16.2.5",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.5.tgz",
-      "integrity": "sha512-AwcZzMChaWkOTZt3vu+2ZMIj8g4dYQY+B8VUVhlFSQ2JtvyZpefyYHTe00D6b6L7BysYw7vl3zsvs9jix8tl5Q==",
+      "version": "16.1.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.1.6.tgz",
+      "integrity": "sha512-OJYkCd5pj/QloBvoEcJ2XiMnlJkRv9idWA/j0ugSuA34gMT6f5b7vOiCQHVRpvStoZUknhl6/UxOXL4OwtdaBw==",
       "cpu": [
         "arm64"
       ],
@@ -1104,9 +1104,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "16.2.5",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.5.tgz",
-      "integrity": "sha512-QqMgqWbCBFsfiQ7BF3dUlW8HJy1LWhpcqbTpoHMWA9IV+TnWwDKozQJA5NdIAHjQ00yX2Q7AUkLr/XK4n77q8A==",
+      "version": "16.1.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.1.6.tgz",
+      "integrity": "sha512-S4J2v+8tT3NIO9u2q+S0G5KdvNDjXfAv06OhfOzNDaBn5rw84DGXWndOEB7d5/x852A20sW1M56vhC/tRVbccQ==",
       "cpu": [
         "arm64"
       ],
@@ -1123,9 +1123,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "16.2.5",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.5.tgz",
-      "integrity": "sha512-3hzeiFGZtyATVx9pCeuzTshXmh50vHZitqaeZiyJZaUmjQyrfjsVUgS8apOj1vEJCIpKJM/55F45yPAV2kpjsA==",
+      "version": "16.1.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.1.6.tgz",
+      "integrity": "sha512-2eEBDkFlMMNQnkTyPBhQOAyn2qMxyG2eE7GPH2WIDGEpEILcBPI/jdSv4t6xupSP+ot/jkfrCShLAa7+ZUPcJQ==",
       "cpu": [
         "x64"
       ],
@@ -1142,9 +1142,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "16.2.5",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.5.tgz",
-      "integrity": "sha512-0mzZV/mAt7Qj2tYNdTB6AqrS8dwng/AQLSYC5Z1YLpZdi2wxqKDPK7RY2RvjB1fXyJfOfdA3l/yTF5yLi+WfuQ==",
+      "version": "16.1.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.1.6.tgz",
+      "integrity": "sha512-oicJwRlyOoZXVlxmIMaTq7f8pN9QNbdes0q2FXfRsPhfCi8n8JmOZJm5oo1pwDaFbnnD421rVU409M3evFbIqg==",
       "cpu": [
         "x64"
       ],
@@ -1161,9 +1161,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "16.2.5",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.5.tgz",
-      "integrity": "sha512-f/H4nZ2zJBvA8/+HpsB9mNonF9zfQoAU6D0WxJrfzhJDvJLfngVN85oqxUyrDVK99DIFfFYhLpGa5K+c5uotSw==",
+      "version": "16.1.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.1.6.tgz",
+      "integrity": "sha512-gQmm8izDTPgs+DCWH22kcDmuUp7NyiJgEl18bcr8irXA5N2m2O+JQIr6f3ct42GOs9c0h8QF3L5SzIxcYAAXXw==",
       "cpu": [
         "arm64"
       ],
@@ -1177,9 +1177,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "16.2.5",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.5.tgz",
-      "integrity": "sha512-nuP7DHs4koAojsIxVPkihNgKiRUKtCU65j5X6DAbSy8VBrfT/o90bCLLHPf51JEdOZwZMFzM6e0NiGWfIWjVAg==",
+      "version": "16.1.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.1.6.tgz",
+      "integrity": "sha512-NRfO39AIrzBnixKbjuo2YiYhB6o9d8v/ymU9m/Xk8cyVk+k7XylniXkHwjs4s70wedVffc6bQNbufk5v0xEm0A==",
       "cpu": [
         "x64"
       ],
@@ -4995,14 +4995,14 @@
       "license": "MIT"
     },
     "node_modules/next": {
-      "version": "16.2.5",
-      "resolved": "https://registry.npmjs.org/next/-/next-16.2.5.tgz",
-      "integrity": "sha512-TkVTm9F2WEulkgGljm4wPwNgvCCWCVw6StUHsZb8WZpHFRjepoUWg3d7L4IMg7IyjcJ4Co9eVhpro8e8O+KarQ==",
+      "version": "16.1.6",
+      "resolved": "https://registry.npmjs.org/next/-/next-16.1.6.tgz",
+      "integrity": "sha512-hkyRkcu5x/41KoqnROkfTm2pZVbKxvbZRuNvKXLRXxs3VfyO0WhY50TQS40EuKO9SW3rBj/sF3WbVwDACeMZyw==",
       "license": "MIT",
       "dependencies": {
-        "@next/env": "16.2.5",
+        "@next/env": "16.1.6",
         "@swc/helpers": "0.5.15",
-        "baseline-browser-mapping": "^2.9.19",
+        "baseline-browser-mapping": "^2.8.3",
         "caniuse-lite": "^1.0.30001579",
         "postcss": "8.4.31",
         "styled-jsx": "5.1.6"
@@ -5014,15 +5014,15 @@
         "node": ">=20.9.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "16.2.5",
-        "@next/swc-darwin-x64": "16.2.5",
-        "@next/swc-linux-arm64-gnu": "16.2.5",
-        "@next/swc-linux-arm64-musl": "16.2.5",
-        "@next/swc-linux-x64-gnu": "16.2.5",
-        "@next/swc-linux-x64-musl": "16.2.5",
-        "@next/swc-win32-arm64-msvc": "16.2.5",
-        "@next/swc-win32-x64-msvc": "16.2.5",
-        "sharp": "^0.34.5"
+        "@next/swc-darwin-arm64": "16.1.6",
+        "@next/swc-darwin-x64": "16.1.6",
+        "@next/swc-linux-arm64-gnu": "16.1.6",
+        "@next/swc-linux-arm64-musl": "16.1.6",
+        "@next/swc-linux-x64-gnu": "16.1.6",
+        "@next/swc-linux-x64-musl": "16.1.6",
+        "@next/swc-win32-arm64-msvc": "16.1.6",
+        "@next/swc-win32-x64-msvc": "16.1.6",
+        "sharp": "^0.34.4"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.1.0",

--- a/satgate-landing/package.json
+++ b/satgate-landing/package.json
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "lucide-react": "^0.555.0",
-    "next": "^16.2.6",
+    "next": "16.2.5",
     "react": "19.2.1",
     "react-dom": "19.2.1",
     "resend": "^6.9.3"

--- a/satgate-landing/package.json
+++ b/satgate-landing/package.json
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "lucide-react": "^0.555.0",
-    "next": "16.2.5",
+    "next": "16.1.6",
     "react": "19.2.1",
     "react-dom": "19.2.1",
     "resend": "^6.9.3"

--- a/satgate-landing/seo/reports/opportunities.json
+++ b/satgate-landing/seo/reports/opportunities.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-05-19T00:37:01.226986Z",
+  "generatedAt": "2026-05-22T16:31:14.338367Z",
   "items": [
     {
       "path": "/blog/how-to-add-budget-limits-to-openai-api-calls",
@@ -192,6 +192,32 @@
       "ctrGap": 0.005,
       "score": 50,
       "priority": "P2"
+    },
+    {
+      "path": "/blog/ai-spend-governance",
+      "cluster": "ai-spend-governance",
+      "primaryKeyword": "AI spend governance",
+      "secondaryKeywords": [
+        "enterprise AI cost control",
+        "usage-based AI pricing",
+        "AI agent cost management",
+        "LLM cost governance",
+        "AI budget controls",
+        "AI FinOps"
+      ],
+      "intent": "informational-commercial",
+      "funnelStage": "problem-aware",
+      "productAngle": "SatGate provides request-path AI spend governance: observe usage, control budgets and policy before execution, and preserve Evidence Pack proof.",
+      "cta": "Learn about Economic Firewalls",
+      "status": "new",
+      "clicks": 0,
+      "impressions": 0,
+      "ctr": 0.0,
+      "position": 100.0,
+      "expectedCtr": 0.005,
+      "ctrGap": 0.005,
+      "score": 26,
+      "priority": "P3"
     },
     {
       "path": "/compare/aws-agentcore-payments",

--- a/satgate-landing/seo/reports/opportunities.md
+++ b/satgate-landing/seo/reports/opportunities.md
@@ -1,6 +1,6 @@
 # SatGate SEO Machine Report
 
-Generated: 2026-05-19T00:37:01.228056Z
+Generated: 2026-05-22T16:31:14.339376Z
 
 ## Ranked opportunities
 
@@ -49,6 +49,12 @@ Generated: 2026-05-19T00:37:01.228056Z
 ### P2 — /capability-auth
 - Score: 50
 - Query: `capability based authorization`
+- GSC: 0 clicks / 0 impressions / 0.00% CTR / pos 100.00
+- CTR gap: 0.50 pp
+
+### P3 — /blog/ai-spend-governance
+- Score: 26
+- Query: `AI spend governance`
 - GSC: 0 clicks / 0 impressions / 0.00% CTR / pos 100.00
 - CTR gap: 0.50 pp
 
@@ -153,6 +159,12 @@ Generated: 2026-05-19T00:37:01.228056Z
 - Content changes:
   - Use identity-vs-capability framing and link macaroon/API-key content into this page.
 - Links to add: /blog/macaroon-tokens-vs-api-keys, /agent-capability-tokens, /govern, /mcp-gateway, /revocable-capability-token-policy-template
+
+### /blog/ai-spend-governance
+- Title: 
+- Meta: 
+- Content changes:
+- Links to add: 
 
 ### /compare/aws-agentcore-payments
 - Title: 

--- a/satgate-landing/seo/reports/page-audit.json
+++ b/satgate-landing/seo/reports/page-audit.json
@@ -1,6 +1,56 @@
 {
-  "generatedAt": "2026-05-19T00:37:01.227531Z",
+  "generatedAt": "2026-05-22T16:31:14.338862Z",
   "items": [
+    {
+      "path": "/blog/ai-spend-governance",
+      "exists": true,
+      "title": "AI Spend Governance: Control Usage-Based AI Costs Before They Scale",
+      "titleLength": 67,
+      "metaDescription": "Why usage-based AI pricing, agentic workflows, and tool-calling systems require request-path spend governance, not just dashboards after the bill arrives.",
+      "metaDescriptionLength": 154,
+      "canonical": "/blog/ai-spend-governance",
+      "h1": [
+        "AI Spend Governance: Control Usage-Based AI Costs Before They Scale"
+      ],
+      "h1Count": 1,
+      "h2s": [
+        "Why agentic AI costs stratify",
+        "Seat management is not AI spend governance",
+        "AI governance has to answer harder questions",
+        "Dashboards are necessary. They are not sufficient.",
+        "Estimate the cost of runaway agent loops",
+        "The Observe, Control, Prove model",
+        "What enterprises should require",
+        "The operating model for enterprise AI",
+        "SatGate&apos;s view",
+        "Related reading"
+      ],
+      "internalLinks": [
+        "/blog",
+        "/blog/ai-agent-spending-limits",
+        "/blog/llm-cost-management",
+        "/blog/the-enterprise-adoption-playbook-observe-control-charge",
+        "/compare/langsmith-helicone-datadog",
+        "/economic-firewall",
+        "/policy-to-proof",
+        "/runaway-agent-cost-calculator"
+      ],
+      "schemaTypes": [
+        "Answer",
+        "FAQPage",
+        "Organization",
+        "Question",
+        "TechArticle",
+        "Thing"
+      ],
+      "wordCount": 1316,
+      "hasObserveControlProve": true,
+      "hasEvidencePack": true,
+      "hasFAQ": true,
+      "hasProductCTA": true,
+      "inSitemap": true,
+      "issues": []
+    },
     {
       "path": "/blog/how-to-add-budget-limits-to-openai-api-calls",
       "exists": true,

--- a/satgate-landing/seo/reports/recommendations.json
+++ b/satgate-landing/seo/reports/recommendations.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-05-19T00:37:01.227868Z",
+  "generatedAt": "2026-05-22T16:31:14.339200Z",
   "items": [
     {
       "path": "/blog/how-to-add-budget-limits-to-openai-api-calls",
@@ -183,6 +183,21 @@
         "FAQPage",
         "BreadcrumbList",
         "SoftwareApplication"
+      ]
+    },
+    {
+      "path": "/blog/ai-spend-governance",
+      "priority": "P3",
+      "score": 26,
+      "primaryKeyword": "AI spend governance",
+      "recommendedTitle": "",
+      "recommendedMetaDescription": "",
+      "contentChanges": [],
+      "internalLinksToAdd": [],
+      "schemaToAdd": [
+        "FAQPage",
+        "BreadcrumbList",
+        "TechArticle"
       ]
     },
     {

--- a/satgate-landing/seo/reports/recommendations.md
+++ b/satgate-landing/seo/reports/recommendations.md
@@ -1,6 +1,6 @@
 # SatGate SEO Machine Report
 
-Generated: 2026-05-19T00:37:01.228056Z
+Generated: 2026-05-22T16:31:14.339376Z
 
 ## Ranked opportunities
 
@@ -49,6 +49,12 @@ Generated: 2026-05-19T00:37:01.228056Z
 ### P2 — /capability-auth
 - Score: 50
 - Query: `capability based authorization`
+- GSC: 0 clicks / 0 impressions / 0.00% CTR / pos 100.00
+- CTR gap: 0.50 pp
+
+### P3 — /blog/ai-spend-governance
+- Score: 26
+- Query: `AI spend governance`
 - GSC: 0 clicks / 0 impressions / 0.00% CTR / pos 100.00
 - CTR gap: 0.50 pp
 
@@ -153,6 +159,12 @@ Generated: 2026-05-19T00:37:01.228056Z
 - Content changes:
   - Use identity-vs-capability framing and link macaroon/API-key content into this page.
 - Links to add: /blog/macaroon-tokens-vs-api-keys, /agent-capability-tokens, /govern, /mcp-gateway, /revocable-capability-token-policy-template
+
+### /blog/ai-spend-governance
+- Title: 
+- Meta: 
+- Content changes:
+- Links to add: 
 
 ### /compare/aws-agentcore-payments
 - Title: 

--- a/satgate-landing/seo/targets.json
+++ b/satgate-landing/seo/targets.json
@@ -1,5 +1,23 @@
 [
   {
+    "path": "/blog/ai-spend-governance",
+    "cluster": "ai-spend-governance",
+    "primaryKeyword": "AI spend governance",
+    "secondaryKeywords": [
+      "enterprise AI cost control",
+      "usage-based AI pricing",
+      "AI agent cost management",
+      "LLM cost governance",
+      "AI budget controls",
+      "AI FinOps"
+    ],
+    "intent": "informational-commercial",
+    "funnelStage": "problem-aware",
+    "productAngle": "SatGate provides request-path AI spend governance: observe usage, control budgets and policy before execution, and preserve Evidence Pack proof.",
+    "cta": "Learn about Economic Firewalls",
+    "status": "new"
+  },
+  {
     "path": "/blog/how-to-add-budget-limits-to-openai-api-calls",
     "cluster": "openai-budget-limits",
     "primaryKeyword": "openai api budget limit",


### PR DESCRIPTION
## Summary
- add `/blog/ai-spend-governance` targeting AI spend governance, usage-based AI pricing, and enterprise AI cost control
- wire the post into the blog index, sitemap, SEO targets, and generated SEO reports
- clean stale `Charge` wording from the blog index readiness-grader card

## Verification
- `npx eslint app/blog/ai-spend-governance/page.tsx app/blog/page.tsx app/sitemap.ts`
- `npm run build`
- `npm run seo:check`
- rendered local checks for `/blog/ai-spend-governance`, `/blog`, and `/sitemap.xml` confirmed canonical, title, JSON-LD, sitemap inclusion, and target phrases

## Notes
- Independent SEO and copy reviews marked this safe to ship.
