### PR TITLE
Address monthly SEO pulse positioning

### DIFF
--- a/satgate-landing/app/blog/api-gateway-for-ai-agents/page.tsx
+++ b/satgate-landing/app/blog/api-gateway-for-ai-agents/page.tsx
@@ -38,7 +38,7 @@ export default function ApiGatewayForAiAgentsBlogPage() {
       { '@type': 'Thing', name: 'MCP tool cost control' },
       { '@type': 'Thing', name: 'scoped capability tokens for APIs' },
       { '@type': 'Thing', name: 'rail-neutral paid-rail governance' },
-      { '@type': 'Thing', name: 'Observe Control Charge' },
+      { '@type': 'Thing', name: 'Observe Control Prove' },
       { '@type': 'Thing', name: 'Evidence Packs' },
     ],
   };

--- a/satgate-landing/app/blog/beyond-connection-economic-governance-mcp/page.tsx
+++ b/satgate-landing/app/blog/beyond-connection-economic-governance-mcp/page.tsx
@@ -492,7 +492,7 @@ X-SatGate-Budget-Limit: 2500
             </p>
 
             {/* --- Three Modes --- */}
-            <h2 className="text-2xl font-bold text-white mt-12 mb-4">The Three Modes: Observe → Control → Charge</h2>
+            <h2 className="text-2xl font-bold text-white mt-12 mb-4">The Three Modes: Observe → Control → Prove</h2>
 
             <p>Not every organization is ready to hard-block their agents on day one. SatGate supports a progressive rollout:</p>
 

--- a/satgate-landing/app/blog/deepmind-intelligent-delegation-satgate/page.tsx
+++ b/satgate-landing/app/blog/deepmind-intelligent-delegation-satgate/page.tsx
@@ -250,7 +250,7 @@ export default function DeepMindDelegationPage() {
                   <p className="text-white font-semibold mb-1">Authority Thresholds &amp; Kill Switches</p>
                   <p className="text-gray-500 text-sm mb-2">Paper: Human-in-the-loop intervention when risk exceeds tolerance (pp. 18–19)</p>
                   <p className="text-gray-300 text-sm">
-                    <span className="text-cyan-400 font-mono text-xs">SatGate →</span> Enforcement modes (Observe → Control → Charge)
+                    <span className="text-cyan-400 font-mono text-xs">SatGate →</span> Enforcement modes (Observe → Control → Prove)
                     let operators graduate trust incrementally. Budget alerts trigger before limits hit.
                     Token revocation is immediate — one API call kills an agent&apos;s access across the
                     entire delegation tree.
@@ -437,7 +437,7 @@ export default function DeepMindDelegationPage() {
               <p className="text-gray-300 text-sm m-0">
                 <strong className="text-white">Enterprises need a trust gradient, not a binary switch.</strong> The
                 paper discusses trust establishment. In practice, operators want to observe first, then control, then
-                charge. SatGate&apos;s three-mode progression (Observe → Control → Charge) lets teams build confidence
+                prove. SatGate&apos;s three-mode progression (Observe → Control → Prove) lets teams build confidence
                 incrementally without rearchitecting.
               </p>
             </div>

--- a/satgate-landing/app/blog/how-to-add-budget-limits-to-openai-api-calls/page.tsx
+++ b/satgate-landing/app/blog/how-to-add-budget-limits-to-openai-api-calls/page.tsx
@@ -38,7 +38,7 @@ export default function HowToAddBudgetLimitsToOpenAIAPICallsPage() {
       { '@type': 'Thing', name: 'per-agent OpenAI budgets' },
       { '@type': 'Thing', name: 'request-path budget enforcement' },
       { '@type': 'Thing', name: 'runaway LLM spend prevention' },
-      { '@type': 'Thing', name: 'Observe Control Charge' },
+      { '@type': 'Thing', name: 'Observe Control Prove' },
       { '@type': 'Thing', name: 'Evidence Pack receipts' },
     ],
   };
@@ -117,6 +117,10 @@ export default function HowToAddBudgetLimitsToOpenAIAPICallsPage() {
           <div className="mb-6 rounded-2xl border border-green-900/60 bg-green-950/20 p-5">
             <p className="mb-2 text-sm font-semibold uppercase tracking-[0.2em] text-green-300">Direct answer</p>
             <p className="text-gray-300">The safest way to set OpenAI API budget limits is to enforce spend before each request reaches OpenAI: Observe usage, Control authority and budget before execution, and Prove every allowed, denied, or downgraded call with an Evidence Pack receipt.</p>
+          </div>
+          <div className="mb-6 flex flex-col gap-3 sm:flex-row">
+            <Link href="/openai-budget-policy-generator" className="inline-flex items-center justify-center rounded-lg bg-white px-5 py-3 text-sm font-bold text-black transition hover:bg-gray-200">Generate an OpenAI budget policy</Link>
+            <Link href="/govern" className="inline-flex items-center justify-center rounded-lg border border-gray-700 px-5 py-3 text-sm font-bold text-white transition hover:border-purple-500">See Policy-to-Proof governance</Link>
           </div>
           
           <p className="text-xl text-gray-400 mb-6">

--- a/satgate-landing/app/blog/http-402-payment-required-use-cases/page.tsx
+++ b/satgate-landing/app/blog/http-402-payment-required-use-cases/page.tsx
@@ -112,7 +112,11 @@ export default function Http402PaymentRequiredUseCasesBlogPage() {
           <h1 className="text-4xl font-bold mb-4">HTTP 402 Payment Required: Meaning, Use Cases, and AI Agent Payments</h1>
           <div className="mb-6 rounded-2xl border border-cyan-900/60 bg-cyan-950/20 p-5">
             <p className="mb-2 text-sm font-semibold uppercase tracking-[0.2em] text-cyan-300">Quick answer</p>
-            <p className="text-gray-300">HTTP 402 means payment is required before access. For AI agents, the practical version is L402: an API returns a payment challenge, delegated payment proof is presented, and the gateway enforces budget before serving the request.</p>
+            <p className="text-gray-300">HTTP 402 means payment is required before access. For AI agents, 402/L402 are paid-rail context: SatGate still checks authority, budget, and policy before payment or execution, then preserves Evidence Pack receipts.</p>
+          </div>
+          <div className="mb-6 flex flex-col gap-3 sm:flex-row">
+            <Link href="/partners/rails" className="inline-flex items-center justify-center rounded-lg bg-white px-5 py-3 text-sm font-bold text-black transition hover:bg-gray-200">See paid-rail governance</Link>
+            <Link href="/policy-to-proof" className="inline-flex items-center justify-center rounded-lg border border-gray-700 px-5 py-3 text-sm font-bold text-white transition hover:border-cyan-500">See Policy-to-Proof</Link>
           </div>
           
           <p className="text-xl text-gray-400 mb-6 italic">

--- a/satgate-landing/app/blog/llm-cost-management/page.tsx
+++ b/satgate-landing/app/blog/llm-cost-management/page.tsx
@@ -101,13 +101,17 @@ export default function LlmCostManagementBlogPage() {
           <div className="flex flex-wrap gap-2 mb-4">
             <span className="px-2 py-1 rounded-full bg-purple-900/30 border border-purple-500/30 text-purple-300 text-xs font-mono">Cost Control</span>
             <span className="px-2 py-1 rounded-full bg-cyan-900/30 border border-cyan-500/30 text-cyan-300 text-xs font-mono">LLM</span>
-            <span className="px-2 py-1 rounded-full bg-yellow-900/30 border border-yellow-500/30 text-yellow-300 text-xs font-mono">Economic Firewall</span>
+            <span className="px-2 py-1 rounded-full bg-yellow-900/30 border border-yellow-500/30 text-yellow-300 text-xs font-mono">Policy-to-Proof</span>
           </div>
           
           <h1 className="text-4xl font-bold mb-4">LLM Cost Management: Real-Time Budget Enforcement for AI Agents</h1>
           <div className="mb-6 rounded-2xl border border-yellow-900/60 bg-yellow-950/20 p-5">
             <p className="mb-2 text-sm font-semibold uppercase tracking-[0.2em] text-yellow-300">Short answer</p>
             <p className="text-gray-300">LLM cost management is not just dashboards and alerts. For autonomous agents, it needs Observe, Control, Prove: per-agent budgets, authority before execution, model/tool prices, attribution, hard blocks, and Evidence Pack receipts for every important decision.</p>
+          </div>
+          <div className="mb-6 flex flex-col gap-3 sm:flex-row">
+            <Link href="/llm-cost-dashboard" className="inline-flex items-center justify-center rounded-lg bg-white px-5 py-3 text-sm font-bold text-black transition hover:bg-gray-200">See the LLM cost dashboard pattern</Link>
+            <Link href="/govern" className="inline-flex items-center justify-center rounded-lg border border-gray-700 px-5 py-3 text-sm font-bold text-white transition hover:border-yellow-500">Turn visibility into Policy-to-Proof control</Link>
           </div>
           
           <p className="text-xl text-gray-400 mb-6 italic">

--- a/satgate-landing/app/blog/page.tsx
+++ b/satgate-landing/app/blog/page.tsx
@@ -2,8 +2,8 @@ import Link from 'next/link';
 import { ArrowLeft, ArrowRight, Calendar, Clock } from 'lucide-react';
 
 export const metadata = {
-  title: 'AI Agent Governance Blog: Cost Control, MCP, L402, Economic Firewalls',
-  description: 'Guides on AI agent governance, economic firewalls, MCP budget enforcement, paid-rail context, capability tokens, API monetization, and cost control.',
+  title: 'AI Agent Governance Blog: Cost Control, MCP, and Policy-to-Proof',
+  description: 'Guides on AI agent governance, Policy-to-Proof governance, MCP budget enforcement, paid-rail context, capability tokens, API monetization, and cost control.',
   alternates: { canonical: 'https://satgate.io/blog' },
   keywords: [
     'AI agent governance blog',
@@ -16,15 +16,15 @@ export const metadata = {
     'API economics',
   ],
   openGraph: {
-    title: 'AI Agent Governance Blog: Cost Control, MCP, L402, Economic Firewalls',
-    description: 'Guides on AI agent governance, economic firewalls, MCP budget enforcement, paid-rail context, capability tokens, API monetization, and cost control.',
+    title: 'AI Agent Governance Blog: Cost Control, MCP, and Policy-to-Proof',
+    description: 'Guides on AI agent governance, Policy-to-Proof governance, MCP budget enforcement, paid-rail context, capability tokens, API monetization, and cost control.',
     url: 'https://satgate.io/blog',
     type: 'website',
   },
   twitter: {
     card: 'summary_large_image',
-    title: 'AI Agent Governance Blog: Cost Control, MCP, L402, Economic Firewalls',
-    description: 'AI agent governance, economic firewalls, MCP budget enforcement, paid-rail context, capability tokens, API monetization, and cost control.',
+    title: 'AI Agent Governance Blog: Cost Control, MCP, and Policy-to-Proof',
+    description: 'AI agent governance, Policy-to-Proof governance, MCP budget enforcement, paid-rail context, capability tokens, API monetization, and cost control.',
   },
 };
 
@@ -150,7 +150,7 @@ const posts = [
   {
     slug: 'why-economic-firewalls-are-the-prerequisite-for-autonomous-ai-agents',
     title: 'Economic Firewalls for Autonomous AI Agents: Hard Budgets and Authority',
-    description: 'Why autonomous AI agents need economic firewalls: hard spend ceilings, bounded authority, revocation, Evidence Packs, and request-path enforcement.',
+    description: 'Why autonomous AI agents need Policy-to-Proof governance: hard spend ceilings, bounded authority, revocation, Evidence Packs, and request-path enforcement.',
     date: '2026-03-20',
     readTime: '11 min read',
     author: 'Matt Dean',
@@ -204,7 +204,7 @@ const posts = [
   {
     slug: 'ai-agent-api-cost-control',
     title: 'AI Agent API Cost Control: Stop Runaway Spend Before API Calls Execute',
-    description: 'Control AI agent API costs with request-path budget checks, tool pricing, delegated spend limits, revocation, and economic firewalls.',
+    description: 'Control AI agent API costs with request-path budget checks, tool pricing, delegated spend limits, revocation, and Policy-to-Proof governance.',
     date: '2026-03-05',
     readTime: '8 min read',
     author: 'Matt Dean',
@@ -295,7 +295,7 @@ export default function BlogPage() {
     publisher: { '@type': 'Organization', name: 'SatGate', url: 'https://satgate.io' },
     about: [
       { '@type': 'Thing', name: 'AI agent governance' },
-      { '@type': 'Thing', name: 'economic firewalls' },
+      { '@type': 'Thing', name: 'Policy-to-Proof governance' },
       { '@type': 'Thing', name: 'MCP budget enforcement' },
       { '@type': 'Thing', name: 'paid-rail context' },
       { '@type': 'Thing', name: 'revocable capability tokens' },
@@ -328,7 +328,7 @@ export default function BlogPage() {
         name: 'What does the SatGate blog cover?',
         acceptedAnswer: {
           '@type': 'Answer',
-          text: 'The SatGate blog covers AI agent governance, economic firewalls, AI agent cost control, MCP budget enforcement, revocable capability tokens, paid-rail context, and API economics for autonomous agents.',
+          text: 'The SatGate blog covers AI agent governance, Policy-to-Proof governance, AI agent cost control, MCP budget enforcement, revocable capability tokens, paid-rail context, and API economics for autonomous agents.',
         },
       },
       {
@@ -379,9 +379,9 @@ export default function BlogPage() {
             {[
               ['/roi-calculator', 'AI Agent ROI Calculator', 'Estimate ghost spend, loop waste, payback period, and enforcement ROI.'],
               ['/runaway-agent-cost-calculator', 'Runaway Agent Cost Calculator', 'Model loop, retry, fanout, and paid tool-call exposure.'],
-              ['/openai-budget-policy-generator', 'OpenAI Budget Policy Generator', 'Generate OpenAI spend caps, routing, revocation, and audit policy.'],
-              ['/mcp-tool-cost-policy-generator', 'MCP Tool Cost Policy Generator', 'Create per-tool MCP budgets, risk actions, and audit rules.'],
-              ['/economic-firewall-readiness-grader', 'Economic Firewall Readiness Grader', 'Score identity, budgets, MCP tools, revocation, audit, routing, and proof.'],
+              ['/openai-budget-policy-generator', 'OpenAI Budget Policy Generator', 'Generate OpenAI spend caps, routing, revocation, and Evidence Pack policy.'],
+              ['/mcp-tool-cost-policy-generator', 'MCP Tool Cost Policy Generator', 'Create per-tool MCP budgets, risk actions, and proof rules.'],
+              ['/economic-firewall-readiness-grader', 'Economic Firewall Readiness Grader', 'Score identity, budgets, MCP tools, revocation, routing, and Evidence Pack proof.'],
               ['/economic-firewall', 'Economic Firewall Definition', 'Learn the request-path category for AI agent economic governance.'],
             ].map(([href, title, body]) => (
               <Link key={href} href={href} className="rounded-xl border border-gray-800 bg-black/60 p-4 transition hover:border-cyan-500/50 hover:bg-cyan-950/20">
@@ -445,7 +445,7 @@ export default function BlogPage() {
           <h2 className="mb-6 text-2xl font-bold text-white">SatGate blog questions</h2>
           <div className="space-y-5">
             {[
-              ['What does the SatGate blog cover?', 'The SatGate blog covers AI agent governance, economic firewalls, AI agent cost control, MCP budget enforcement, revocable capability tokens, paid-rail context, and API economics for autonomous agents.'],
+              ['What does the SatGate blog cover?', 'The SatGate blog covers AI agent governance, Policy-to-Proof governance, AI agent cost control, MCP budget enforcement, revocable capability tokens, paid-rail context, and API economics for autonomous agents.'],
               ['Where should I start if I need to control AI agent spend?', 'Start with the AI agent cost control guide, the economic firewall definition, the ROI calculator, and the MCP budget enforcement guide to understand the request-path controls needed before agents spend.'],
               ['How is SatGate different from an LLM dashboard or API gateway?', 'LLM dashboards report spend after it happens and traditional API gateways mainly route traffic. SatGate sits in the request path to observe, control, and prove agent/API activity before upstream access.'],
             ].map(([question, answer]) => (

--- a/satgate-landing/app/blog/the-enterprise-adoption-playbook-observe-control-charge/page.tsx
+++ b/satgate-landing/app/blog/the-enterprise-adoption-playbook-observe-control-charge/page.tsx
@@ -34,7 +34,7 @@ export default function EnterpriseAdoptionPlaybookPage() {
     publisher: { '@type': 'Organization', name: 'SatGate', url: 'https://satgate.io' },
     about: [
       { '@type': 'Thing', name: 'economic governance for AI agents' },
-      { '@type': 'Thing', name: 'Observe Control Charge' },
+      { '@type': 'Thing', name: 'Observe Control Prove' },
       { '@type': 'Thing', name: 'AI agent budget enforcement' },
       { '@type': 'Thing', name: 'paid-agent API monetization' },
     ],

--- a/satgate-landing/app/compare/_components/BrutalComparisonPage.tsx
+++ b/satgate-landing/app/compare/_components/BrutalComparisonPage.tsx
@@ -36,7 +36,7 @@ export function BrutalComparisonPage({ config }: { config: BrutalComparison }) {
     dateModified: '2026-05-10',
     mainEntityOfPage: `https://satgate.io/compare/${config.slug}`,
     about: [
-      { '@type': 'Thing', name: 'agent economic firewall' },
+      { '@type': 'Thing', name: 'agent authority governance' },
       { '@type': 'Thing', name: 'pre-execution policy enforcement' },
       { '@type': 'Thing', name: 'MCP-native proxying' },
       { '@type': 'Thing', name: 'Evidence Packs' },

--- a/satgate-landing/app/compare/_components/comparisons.ts
+++ b/satgate-landing/app/compare/_components/comparisons.ts
@@ -14,9 +14,9 @@ export const brutalComparisons: Record<string, BrutalComparison> = {
   'aws-agentcore-payments': {
     slug: 'aws-agentcore-payments',
     competitor: 'AWS AgentCore Payments',
-    eyebrow: 'Managed agent payments vs economic firewall',
-    title: 'SatGate vs AWS AgentCore Payments',
-    description: 'AWS AgentCore Payments helps agents transact inside the AWS AgentCore ecosystem. SatGate governs whether agents are allowed to access, spend, delegate, call MCP tools, or use paid rails before execution across the multi-provider enterprise environment.',
+    eyebrow: 'Managed agent payments vs Policy-to-Proof governance',
+    title: 'SatGate vs AWS AgentCore Payments: Governance Above Paid Rails',
+    description: 'AWS AgentCore Payments helps agents transact inside AWS. SatGate governs authority, Evidence Pack proof, MCP tools, and paid rails before execution across the multi-provider enterprise environment.',
     verdict: 'If your world is AWS AgentCore, AWS gives you managed payments. If your environment spans OpenAI, Anthropic, local agents, MCP tools, internal APIs, hybrid gateways, and multiple payment rails, SatGate is the control layer.',
     competitorGoodAt: [
       'Managed payment enablement for agents built around AWS AgentCore patterns.',
@@ -30,9 +30,9 @@ export const brutalComparisons: Record<string, BrutalComparison> = {
       standardAxes.evidence,
     ],
     rows: [
-      { axis: 'Primary job', satgate: 'Economic firewall: decide what an autonomous agent may access, spend, delegate, and prove before execution.', competitor: 'Managed agent payment capability in the AWS AgentCore stack.', winner: 'SatGate' },
+      { axis: 'Primary job', satgate: 'Policy-to-Proof governance: decide what an autonomous agent may access, spend, delegate, and prove before execution.', competitor: 'Managed agent payment capability in the AWS AgentCore stack.', winner: 'SatGate' },
       { axis: 'Cross-provider', satgate: standardAxes.crossProvider, competitor: 'Strongest for organizations standardized on AWS, Bedrock, and AgentCore.', winner: 'SatGate' },
-      { axis: 'Cross-rail', satgate: standardAxes.crossRail, competitor: 'Payment/session rails in AWS-managed agent flows; not a general economic control plane for every provider and private API.', winner: 'SatGate' },
+      { axis: 'Cross-rail', satgate: standardAxes.crossRail, competitor: 'Payment/session rails in AWS-managed agent flows; not a general authority-and-proof layer for every provider and private API.', winner: 'SatGate' },
       { axis: 'Pre-execution control', satgate: standardAxes.preExecution, competitor: 'Can help with managed agent access/payment flows, but the center is not provider-neutral policy before every external spend event.', winner: 'SatGate' },
       { axis: 'Delegation', satgate: standardAxes.delegation, competitor: 'AWS identity and agent controls help inside AWS; portability across heterogeneous agents and sub-agents requires additional governance.', winner: 'SatGate' },
       { axis: 'Evidence Packs', satgate: standardAxes.evidence, competitor: 'AWS observability gives logs/traces. SatGate packages the policy decision and economic proof itself.', winner: 'SatGate' },
@@ -56,9 +56,9 @@ export const brutalComparisons: Record<string, BrutalComparison> = {
   'cloudflare-ai-gateway': {
     slug: 'cloudflare-ai-gateway',
     competitor: 'Cloudflare AI Gateway',
-    eyebrow: 'AI traffic gateway vs economic firewall',
-    title: 'SatGate vs Cloudflare AI Gateway',
-    description: 'Cloudflare AI Gateway is strong AI traffic infrastructure: analytics, logging, caching, rate limits, retries, fallback, and provider access on Cloudflare. SatGate is pre-execution economic governance for agents, APIs, MCP tools, delegated authority, and paid rails.',
+    eyebrow: 'AI traffic gateway vs Policy-to-Proof governance',
+    title: 'SatGate vs Cloudflare AI Gateway: Policy-to-Proof for Agent Actions',
+    description: 'Cloudflare AI Gateway is strong AI traffic infrastructure. SatGate is Policy-to-Proof governance for agent authority, MCP tools, delegated spend, paid rails, and Evidence Packs.',
     verdict: 'Cloudflare helps move and observe AI traffic. SatGate decides whether an autonomous agent is authorized to spend before that traffic exists.',
     competitorGoodAt: [
       'Edge-native AI traffic analytics, logging, caching, rate limits, retries, and fallback.',
@@ -67,14 +67,14 @@ export const brutalComparisons: Record<string, BrutalComparison> = {
     ],
     satgateGoodAt: [standardAxes.crossRail, standardAxes.preExecution, standardAxes.delegation, standardAxes.mcp],
     rows: [
-      { axis: 'Primary job', satgate: 'Pre-execution economic policy enforcement for autonomous agents.', competitor: 'AI traffic gateway for analytics, caching, rate limits, retries, fallback, and provider access.', winner: 'Tie' },
+      { axis: 'Primary job', satgate: 'Pre-execution authority and evidence policy enforcement for autonomous agents.', competitor: 'AI traffic gateway for analytics, caching, rate limits, retries, fallback, and provider access.', winner: 'Tie' },
       { axis: 'Cross-provider', satgate: 'Provider choice is an implementation detail behind one agent authority policy.', competitor: 'Strong multi-provider AI traffic gateway features.', winner: 'Tie' },
-      { axis: 'Cross-rail', satgate: standardAxes.crossRail, competitor: 'Primarily AI/model traffic; not payment/API/MCP economic rail governance as the center of the product.', winner: 'SatGate' },
+      { axis: 'Cross-rail', satgate: standardAxes.crossRail, competitor: 'Primarily AI/model traffic; not payment/API/MCP authority governance as the center of the product.', winner: 'SatGate' },
       { axis: 'Pre-execution control', satgate: standardAxes.preExecution, competitor: 'Rate limits and gateway controls are useful, but they are not delegated economic authority.', winner: 'SatGate' },
       { axis: 'Delegation', satgate: standardAxes.delegation, competitor: 'No native SatGate-style attenuated agent capability and delegation-depth model.', winner: 'SatGate' },
       { axis: 'Evidence Packs', satgate: standardAxes.evidence, competitor: 'Logs and analytics explain traffic; they do not package authority, budget, and proof as the core artifact.', winner: 'SatGate' },
       { axis: 'Hybrid deployment', satgate: standardAxes.hybrid, competitor: 'Cloudflare-managed edge platform.', winner: 'SatGate' },
-      { axis: 'MCP-native proxying', satgate: standardAxes.mcp, competitor: 'AI Gateway is not primarily an MCP economic policy proxy.', winner: 'SatGate' },
+      { axis: 'MCP-native proxying', satgate: standardAxes.mcp, competitor: 'AI Gateway is not primarily an MCP authority policy proxy.', winner: 'SatGate' },
     ],
     bullets: [
       { title: 'Gateway is not governance', body: 'Routing, caching, and retry logic do not decide whether a delegated agent should be allowed to spend on a protected tool.' },
@@ -94,7 +94,7 @@ export const brutalComparisons: Record<string, BrutalComparison> = {
     slug: 'langsmith-helicone-datadog',
     competitor: 'LangSmith, Helicone, and Datadog',
     eyebrow: 'Observability vs pre-execution control',
-    title: 'SatGate vs LangSmith, Helicone, and Datadog',
+    title: 'SatGate vs LangSmith, Helicone, and Datadog: Proof Before Postmortems',
     description: 'LangSmith, Helicone, and Datadog help teams trace, debug, monitor, evaluate, and analyze LLM systems. SatGate sits before execution to enforce agent budgets, delegated authority, MCP tool policy, paid-rail access, and Evidence Packs.',
     verdict: 'Observability tells you what agents did. SatGate controls what agents are allowed to do before they do it.',
     competitorGoodAt: [
@@ -131,7 +131,7 @@ export const brutalComparisons: Record<string, BrutalComparison> = {
     slug: 'api-gateway-rate-limits',
     competitor: 'API Gateway rate limits',
     eyebrow: 'Traffic primitive vs authority primitive',
-    title: 'SatGate vs API Gateway Rate Limits',
+    title: 'SatGate vs API Gateway Rate Limits: Authority Beats Quotas',
     description: 'API Gateway rate limits throttle request volume. SatGate governs delegated agent authority: budget, route, tool, tenant, payment rail, evidence requirement, and revocation before the request executes.',
     verdict: 'Rate limits answer “how many requests?” SatGate answers “is this agent allowed to spend this budget on this resource right now, and can we prove why?”',
     competitorGoodAt: [
@@ -168,8 +168,8 @@ export const brutalComparisons: Record<string, BrutalComparison> = {
     slug: 'openai-anthropic-budget-controls',
     competitor: 'native OpenAI and Anthropic budget controls',
     eyebrow: 'Provider caps vs cross-provider control',
-    title: 'SatGate vs Native OpenAI and Anthropic Budget Controls',
-    description: 'OpenAI and Anthropic budget controls are useful provider-specific guardrails. SatGate is the cross-provider economic firewall above them: delegated budgets, MCP tool governance, paid API access, hybrid enforcement, and Evidence Packs.',
+    title: 'SatGate vs OpenAI and Anthropic Budgets: Cross-Provider Authority',
+    description: 'OpenAI and Anthropic budget controls are useful provider-specific guardrails. SatGate is the cross-provider Agent Authority & Accountability Layer above them: delegated budgets, MCP tool governance, paid API access, hybrid enforcement, and Evidence Packs.',
     verdict: 'Native budgets are necessary last-mile guardrails. They are not a portable agent authorization layer across providers, tools, APIs, rails, and hybrid systems.',
     competitorGoodAt: [
       'Capping or tracking spend inside a single model provider account, project, workspace, or organization.',

--- a/satgate-landing/app/compare/api-gateway-rate-limits/page.tsx
+++ b/satgate-landing/app/compare/api-gateway-rate-limits/page.tsx
@@ -4,7 +4,7 @@ import { brutalComparisons } from '../_components/comparisons';
 const config = brutalComparisons['api-gateway-rate-limits'];
 
 export const metadata = {
-  title: 'SatGate vs API Gateway Rate Limits for Agents',
+  title: 'SatGate vs API Gateway Rate Limits: Authority Beats Quotas',
   description: 'Compare API Gateway rate limits with SatGate agent authority: delegated budgets, MCP tool policy, paid rails, hybrid enforcement, and Evidence Packs.',
   alternates: { canonical: 'https://satgate.io/compare/api-gateway-rate-limits' },
   keywords: ['SatGate vs API Gateway rate limits', 'agent API rate limits', 'API gateway budget enforcement', 'MCP rate limits', 'agent spend policy'],

--- a/satgate-landing/app/compare/aws-agentcore-payments/page.tsx
+++ b/satgate-landing/app/compare/aws-agentcore-payments/page.tsx
@@ -4,10 +4,10 @@ import { brutalComparisons } from '../_components/comparisons';
 const config = brutalComparisons['aws-agentcore-payments'];
 
 export const metadata = {
-  title: 'SatGate vs AWS AgentCore Payments Control',
+  title: 'SatGate vs AWS AgentCore Payments: Governance Above Paid Rails',
   description: 'Compare SatGate and AWS AgentCore Payments across cross-provider control, paid rails, MCP proxying, delegated budgets, hybrid deployment, and Evidence Packs.',
   alternates: { canonical: 'https://satgate.io/compare/aws-agentcore-payments' },
-  keywords: ['SatGate vs AWS AgentCore Payments', 'AWS AgentCore Payments alternative', 'agent payments governance', 'x402 agent payments', 'MCP agent policy', 'agent economic firewall'],
+  keywords: ['SatGate vs AWS AgentCore Payments', 'AWS AgentCore Payments alternative', 'agent payments governance', 'x402 agent payments', 'MCP agent policy', 'agent authority governance'],
   openGraph: { title: config.title, description: 'Compare SatGate and AWS AgentCore Payments across cross-provider control, paid rails, MCP proxying, delegated budgets, hybrid deployment, and Evidence Packs.', url: 'https://satgate.io/compare/aws-agentcore-payments', type: 'article' },
   twitter: { card: 'summary_large_image', title: config.title, description: config.verdict },
 };

--- a/satgate-landing/app/compare/cloudflare-ai-gateway/page.tsx
+++ b/satgate-landing/app/compare/cloudflare-ai-gateway/page.tsx
@@ -4,10 +4,10 @@ import { brutalComparisons } from '../_components/comparisons';
 const config = brutalComparisons['cloudflare-ai-gateway'];
 
 export const metadata = {
-  title: 'SatGate vs Cloudflare AI Gateway Control',
+  title: 'SatGate vs Cloudflare AI Gateway: Policy-to-Proof for Agent Actions',
   description: 'Compare Cloudflare AI Gateway and SatGate across AI routing, rate limits, pre-execution control, MCP proxying, delegated budgets, and Evidence Packs.',
   alternates: { canonical: 'https://satgate.io/compare/cloudflare-ai-gateway' },
-  keywords: ['SatGate vs Cloudflare AI Gateway', 'Cloudflare AI Gateway alternative', 'AI gateway budget enforcement', 'MCP tool governance', 'agent economic firewall'],
+  keywords: ['SatGate vs Cloudflare AI Gateway', 'Cloudflare AI Gateway alternative', 'AI gateway budget enforcement', 'MCP tool governance', 'agent authority governance'],
   openGraph: { title: config.title, description: 'Compare Cloudflare AI Gateway and SatGate across AI routing, rate limits, pre-execution control, MCP proxying, delegated budgets, and Evidence Packs.', url: 'https://satgate.io/compare/cloudflare-ai-gateway', type: 'article' },
   twitter: { card: 'summary_large_image', title: config.title, description: config.verdict },
 };

--- a/satgate-landing/app/compare/langsmith-helicone-datadog/page.tsx
+++ b/satgate-landing/app/compare/langsmith-helicone-datadog/page.tsx
@@ -4,7 +4,7 @@ import { brutalComparisons } from '../_components/comparisons';
 const config = brutalComparisons['langsmith-helicone-datadog'];
 
 export const metadata = {
-  title: 'SatGate vs LangSmith, Helicone, Datadog',
+  title: 'SatGate vs LangSmith, Helicone, Datadog: Proof Before Postmortems',
   description: 'Compare LLM observability tools with SatGate pre-execution control: delegated budgets, MCP tool policy, paid rails, hybrid enforcement, and Evidence Packs.',
   alternates: { canonical: 'https://satgate.io/compare/langsmith-helicone-datadog' },
   keywords: ['SatGate vs LangSmith', 'SatGate vs Helicone', 'SatGate vs Datadog LLM Observability', 'LLM observability vs control', 'agent Evidence Packs'],

--- a/satgate-landing/app/compare/openai-anthropic-budget-controls/page.tsx
+++ b/satgate-landing/app/compare/openai-anthropic-budget-controls/page.tsx
@@ -4,7 +4,7 @@ import { brutalComparisons } from '../_components/comparisons';
 const config = brutalComparisons['openai-anthropic-budget-controls'];
 
 export const metadata = {
-  title: 'SatGate vs OpenAI / Anthropic Budgets',
+  title: 'SatGate vs OpenAI and Anthropic Budgets: Cross-Provider Authority',
   description: 'Compare native OpenAI and Anthropic budget controls with SatGate cross-provider agent budgets, MCP policy, paid rails, hybrid control, and Evidence Packs.',
   alternates: { canonical: 'https://satgate.io/compare/openai-anthropic-budget-controls' },
   keywords: ['OpenAI budget controls alternative', 'Anthropic budget controls alternative', 'cross-provider AI budgets', 'agent budget enforcement', 'SatGate vs OpenAI budgets'],

--- a/satgate-landing/app/components/GovernClient.tsx
+++ b/satgate-landing/app/components/GovernClient.tsx
@@ -75,7 +75,7 @@ export default function GovernPage() {
             </span>
           </h1>
           <p className="text-xl text-gray-400 mb-10 max-w-2xl mx-auto leading-relaxed">
-            SatGate is the Economic Firewall for enterprise agents, implemented through Policy-to-Proof: scope authority before work starts, enforce request-path policy, and preserve Evidence Packs after every allowed, denied, delegated, or revoked action.
+            SatGate is the Policy-to-Proof governance layer for enterprise agents: scope authority before work starts, enforce request-path policy, and preserve Evidence Packs after every allowed, denied, delegated, or revoked action.
           </p>
           <div className="flex flex-col sm:flex-row gap-4 justify-center">
             <Link href="/policy-to-proof" className="bg-white text-black px-8 py-3 rounded-lg font-bold hover:bg-gray-200 transition flex items-center justify-center gap-2">

--- a/satgate-landing/app/components/HomeClient.tsx
+++ b/satgate-landing/app/components/HomeClient.tsx
@@ -171,7 +171,7 @@ const LandingPage = () => {
           {/* Left: Copy */}
           <div>
             <div className="inline-flex items-center gap-2 px-3 py-1 rounded-full bg-purple-900/30 border border-purple-500/30 text-purple-300 text-xs font-mono mb-6">
-              <Zap size={12} /> Economic Firewall for Agentic API Access
+              <Zap size={12} /> Agent Authority & Accountability Layer
             </div>
             <h1 className="text-5xl md:text-6xl font-extrabold tracking-tight mb-6">
               Govern agent authority<br/>
@@ -336,7 +336,7 @@ const LandingPage = () => {
               <span>✓ Capabilities + Caveats</span>
               <span>✓ Delegation chains</span>
               <span>✓ Next-request revocation</span>
-              <span>✓ Tamper-evident audit</span>
+              <span>✓ Tamper-evident Evidence Pack receipts</span>
             </div>
           </div>
 
@@ -361,7 +361,7 @@ const LandingPage = () => {
                 Start here. No workflow changes. Map authority, tools, and spend before enforcing policy.
               </p>
               <ul className="text-xs text-gray-500 space-y-1">
-                <li>✓ Audit mode - zero disruption to existing agents</li>
+                <li>✓ Observe mode - zero disruption to existing agents</li>
                 <li>✓ Usage attribution by team and cost center</li>
                 <li>✓ See exactly which agents, tools, and routes create risk before you change anything</li>
                 <li>✓ Zero latency impact</li>
@@ -684,7 +684,7 @@ const LandingPage = () => {
           <h2 className="mb-8 text-3xl font-bold text-white">Agent governance questions</h2>
           <div className="space-y-6">
             {[
-              ['What is SatGate?', 'SatGate is the Economic Firewall for agentic API access. Humans and platforms use it to delegate bounded economic authority to agents, enforce policy and budgets, prove revocation, and preserve evidence across APIs, MCP tools, and paid external calls.'],
+              ['What is SatGate?', 'SatGate is the Agent Authority & Accountability Layer for governed agent execution. Humans and platforms use it to delegate bounded economic authority to agents, enforce policy and budgets, prove revocation, and preserve evidence across APIs, MCP tools, and paid external calls.'],
               ['How does SatGate govern AI agents?', 'SatGate applies scoped authority, per-agent policy, revocation, and budgets before each request reaches an API or MCP tool, so unauthorized actions and expensive calls can be blocked before they happen.'],
               ['How does SatGate give agents bounded economic authority?', 'Humans and platforms define policy, budgets, scope, and delegation depth. Agents consume approved API and MCP primitives through SatGate, and every approval, denial, spend event, delegation, and revocation leaves receipt-backed proof.'],
             ].map(([question, answer]) => (
@@ -721,7 +721,7 @@ const LandingPage = () => {
                 <Image src="/logo_white_transparent.png" alt="SatGate" width={24} height={24} className="w-6 h-6" />
                 <h4 className="font-bold text-white">SatGate</h4>
               </div>
-              <p className="max-w-xs text-sm text-gray-500">Economic Firewall for agentic API access: bounded authority, receipts, and proof.</p>
+              <p className="max-w-xs text-sm text-gray-500">Agent Authority & Accountability Layer: bounded authority, Evidence Pack receipts, and proof.</p>
               <p className="text-gray-600 text-xs mt-3">Humans and platforms buy. Agents consume bounded primitives.</p>
             </div>
             <div>

--- a/satgate-landing/app/govern/page.tsx
+++ b/satgate-landing/app/govern/page.tsx
@@ -4,14 +4,14 @@ import GovernClient from "../components/GovernClient";
 export const metadata: Metadata = {
   title: "AI Agent Governance: Policy-to-Proof",
   description:
-    "AI agent governance for the Economic Firewall category: scope authority, enforce request-path policy, and export Evidence Packs for every agent decision.",
+    "AI agent governance from Policy-to-Proof: scope authority, enforce request-path policy, and export Evidence Pack receipts for every agent decision.",
   alternates: {
     canonical: "https://satgate.io/govern",
   },
   keywords: [
     "enterprise AI agent governance",
     "AI agent authority governance",
-    "Economic Firewall for AI agents",
+    "Agent Authority & Accountability Layer",
     "Policy-to-Proof governance for AI agents",
     "MCP governance for enterprises",
     "AI agent budget enforcement",
@@ -44,7 +44,7 @@ const webPageSchema = {
   isPartOf: { "@type": "WebSite", name: "SatGate", url: "https://satgate.io" },
   about: [
     { "@type": "Thing", name: "AI agent governance" },
-    { "@type": "Thing", name: "Economic Firewall for AI agents" },
+    { "@type": "Thing", name: "Agent Authority & Accountability Layer" },
     { "@type": "Thing", name: "Policy-to-Proof governance for AI agents" },
     { "@type": "Thing", name: "MCP governance for enterprises" },
     { "@type": "Thing", name: "agent delegation controls" },
@@ -93,7 +93,7 @@ const faqSchema = {
       name: "Is SatGate tied to x402, L402, AgentCore Payments, or Pay.sh?",
       acceptedAnswer: {
         "@type": "Answer",
-        text: "No. x402, L402, AgentCore Payments, Pay.sh, and related rails make it easier for agents to call paid services. SatGate is protocol-independent: it records the requesting agent, allowed action, policy basis, spend context, and evidence needed for audit, review, and control — payment or not.",
+        text: "No. x402, L402, AgentCore Payments, Pay.sh, and related rails make it easier for agents to call paid services. SatGate is protocol-independent: it records the requesting agent, allowed action, policy basis, spend context, and evidence needed for Evidence Pack review, accountability, and control — payment or not.",
       },
     },
   ],

--- a/satgate-landing/app/mcp-gateway/page.tsx
+++ b/satgate-landing/app/mcp-gateway/page.tsx
@@ -56,8 +56,8 @@ const faqs = [
 ];
 
 export const metadata = {
-  title: 'MCP Gateway for Budget Enforcement and Evidence Packs',
-  description: 'Use SatGate as the MCP gateway for budget enforcement, tool allowlists, tenant isolation, delegation depth, and MCP Evidence Pack proof.',
+  title: 'MCP Gateway for Agent Governance and Evidence Packs',
+  description: 'Use SatGate as an MCP gateway to check authority before tool execution, enforce policy, and export Evidence Packs.',
   alternates: { canonical: 'https://satgate.io/mcp-gateway' },
   keywords: [
     'MCP gateway',
@@ -73,15 +73,15 @@ export const metadata = {
     'Hermes MCP governance',
   ],
   openGraph: {
-    title: 'MCP Gateway for Budget Enforcement and Evidence Packs',
-    description: 'Put SatGate in the MCP request path: allow or deny tool calls, enforce budgets, and export Evidence Pack receipts.',
+    title: 'MCP Gateway for Agent Governance and Evidence Packs',
+    description: 'Put SatGate in the MCP request path: check authority before tool execution, enforce policy, and export Evidence Pack receipts.',
     url: 'https://satgate.io/mcp-gateway',
     type: 'website',
   },
   twitter: {
     card: 'summary_large_image',
-    title: 'MCP Gateway for Budget Enforcement and Evidence Packs',
-    description: 'Govern Claude, Hermes, Ollama, Cursor, and custom MCP agents with budget enforcement and Evidence Pack proof.',
+    title: 'MCP Gateway for Agent Governance and Evidence Packs',
+    description: 'Govern Claude, Hermes, Ollama, Cursor, and custom MCP agents with authority checks and Evidence Pack proof.',
   },
 };
 
@@ -151,10 +151,10 @@ export default function McpGatewayPage() {
             <Cable size={16} /> Model Context Protocol governance gateway
           </div>
           <h1 className="text-5xl md:text-7xl font-extrabold tracking-tight max-w-5xl mb-8">
-            MCP Gateway for Budget Enforcement and Evidence Packs
+            MCP Gateway for Agent Governance and Evidence Packs
           </h1>
           <p className="text-xl md:text-2xl text-gray-300 max-w-4xl leading-relaxed mb-8">
-            SatGate sits between AI agents — Claude, Hermes, Ollama, Cursor, OpenClaw, or custom MCP clients — and the tools they want to call. Every MCP request is checked for authority, budget, tenant, tool scope, and delegation before execution — then recorded as proof.
+            SatGate sits between AI agents — Claude, Hermes, Ollama, Cursor, OpenClaw, or custom MCP clients — and the tools they want to call. Every MCP request is checked for authority, budget, tenant, tool scope, and delegation before execution — then preserved as Evidence Pack proof.
           </p>
           <div className="flex flex-col sm:flex-row gap-4">
             <Link href="/govern" className="inline-flex items-center justify-center gap-2 rounded-lg bg-white text-black px-6 py-3 font-bold hover:bg-gray-200 transition">

--- a/satgate-landing/app/page.tsx
+++ b/satgate-landing/app/page.tsx
@@ -2,14 +2,14 @@ import type { Metadata } from "next";
 import HomeClient from "./components/HomeClient";
 
 export const metadata: Metadata = {
-  title: "SatGate — Economic Firewall for Agentic API Access",
+  title: "SatGate — Agent Authority & Accountability Layer",
   description:
-    "SatGate gives agents bounded economic authority so humans, platforms, and upstream APIs can trust what they consume, spend, and prove.",
+    "SatGate governs agent authority before execution so humans, platforms, and upstream APIs can trust what agents access, spend, and prove.",
   alternates: {
     canonical: "https://satgate.io",
   },
   openGraph: {
-    title: "SatGate — Economic Firewall for Agentic API Access",
+    title: "SatGate — Agent Authority & Accountability Layer",
     description:
       "Policy-to-Proof governance for enterprise agents: bounded economic authority before execution and Evidence Packs after every decision.",
     url: "https://satgate.io",
@@ -17,7 +17,7 @@ export const metadata: Metadata = {
   },
   twitter: {
     card: "summary_large_image",
-    title: "SatGate — Economic Firewall for Agentic API Access",
+    title: "SatGate — Agent Authority & Accountability Layer",
     description:
       "Policy-to-Proof governance for enterprise agents: bounded economic authority before execution and Evidence Packs after every decision.",
   },
@@ -32,7 +32,7 @@ export default function HomePage() {
         name: 'SatGate',
         url: 'https://satgate.io',
         logo: 'https://satgate.io/logo_white_transparent.png',
-        description: 'SatGate is the Economic Firewall for agentic API access: bounded economic authority before execution and Evidence Packs after every decision.',
+        description: 'SatGate is the Agent Authority & Accountability Layer for governed agent execution: authority before execution and Evidence Pack receipts after every decision.',
       },
       {
         '@type': 'WebSite',
@@ -42,9 +42,9 @@ export default function HomePage() {
       },
       {
         '@type': 'WebPage',
-        name: 'SatGate — Economic Firewall for Agentic API Access',
+        name: 'SatGate — Agent Authority & Accountability Layer',
         url: 'https://satgate.io',
-        description: 'SatGate gives agents bounded economic authority so humans, platforms, and upstream APIs can trust what they consume, spend, and prove.',
+        description: 'SatGate governs agent authority before execution so humans, platforms, and upstream APIs can trust what agents access, spend, and prove.',
         datePublished: '2026-04-30',
         dateModified: '2026-05-05',
         isPartOf: { '@type': 'WebSite', name: 'SatGate', url: 'https://satgate.io' },
@@ -68,7 +68,7 @@ export default function HomePage() {
         name: 'What is SatGate?',
         acceptedAnswer: {
           '@type': 'Answer',
-          text: 'SatGate is the Economic Firewall for agentic API access. It sits in the request path so humans and platforms can delegate bounded economic authority to agents, enforce policy and budgets, and preserve Evidence Packs across APIs, MCP tools, and paid rails.',
+          text: 'SatGate is the Agent Authority & Accountability Layer for governed agent execution. It sits in the request path so humans and platforms can delegate bounded authority to agents, enforce policy and budgets, and preserve Evidence Packs across APIs, MCP tools, and paid rails.',
         },
       },
       {

--- a/satgate-landing/app/partners/rails/page.tsx
+++ b/satgate-landing/app/partners/rails/page.tsx
@@ -105,7 +105,7 @@ export default function RailPartnersPage() {
               Rails can authorize value movement. SatGate proves the agent was allowed to attempt it: who delegated authority, which policy applied, what budget was left, and what evidence exists after the decision.
             </p>
             <p className="mt-5 max-w-3xl text-lg leading-8 text-gray-400">
-              The Economic Firewall category stays durable while rails change. SatGate’s Agent Authority & Accountability Layer sits above x402, L402, Stripe, AgentCore Payments, Pay.sh, API-key billing, and enterprise ledgers.
+              Paid rails keep changing. SatGate’s Agent Authority & Accountability Layer sits above x402, L402, Stripe, AgentCore Payments, Pay.sh, API-key billing, and enterprise ledgers.
             </p>
             <div className="mt-8 flex flex-col gap-3 sm:flex-row sm:flex-wrap">
               <a href="/briefs/satgate-agent-authority-rails-brief.pdf" className="inline-flex items-center justify-center gap-2 rounded-lg bg-white px-6 py-3 font-bold text-black transition hover:bg-gray-200">
@@ -114,8 +114,8 @@ export default function RailPartnersPage() {
               <Link href="/agent-authority-layer" className="inline-flex items-center justify-center gap-2 rounded-lg border border-gray-700 px-6 py-3 font-bold text-white transition hover:border-cyan-500">
                 See the authority and accountability layer <ArrowRight size={18} />
               </Link>
-              <Link href="/economic-firewall" className="inline-flex items-center justify-center gap-2 rounded-lg border border-gray-700 px-6 py-3 font-bold text-white transition hover:border-purple-500">
-                See the Economic Firewall category <ArrowRight size={18} />
+              <Link href="/policy-to-proof" className="inline-flex items-center justify-center gap-2 rounded-lg border border-gray-700 px-6 py-3 font-bold text-white transition hover:border-purple-500">
+                See Policy-to-Proof <ArrowRight size={18} />
               </Link>
             </div>
           </div>

--- a/satgate-landing/app/pricing/layout.tsx
+++ b/satgate-landing/app/pricing/layout.tsx
@@ -1,10 +1,10 @@
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
-  title: "SatGate Pricing | Economic Firewall for AI Agents",
+  title: "SatGate Pricing | Agent Authority & Accountability Layer",
   alternates: { canonical: "https://satgate.io/pricing" },
   description:
-    "SatGate pricing for bounded agent authority: Observe audits, request-path budget enforcement, per-agent spend caps, MCP tool controls, receipts, and Evidence Pack proof.",
+    "SatGate pricing for bounded agent authority: Observe-mode Evidence Pack receipts, request-path budget enforcement, per-agent spend caps, MCP tool controls, receipts, and Evidence Pack proof.",
   keywords: [
     "SatGate pricing",
     "AI agent cost control pricing",
@@ -12,18 +12,18 @@ export const metadata: Metadata = {
     "MCP governance pricing",
     "economic firewall pricing",
     "rail-neutral paid-rail governance pricing",
-    "Observe Control Charge pricing",
+    "Observe Control Prove pricing",
   ],
   openGraph: {
-    title: "SatGate Pricing | Economic Firewall for AI Agents",
+    title: "SatGate Pricing | Agent Authority & Accountability Layer",
     description:
-      "Pricing for bounded agent authority: Observe audits, budget enforcement, MCP tool controls, per-agent caps, receipts, and Evidence Pack proof.",
+      "Pricing for bounded agent authority: Observe-mode Evidence Pack receipts, budget enforcement, MCP tool controls, per-agent caps, receipts, and Evidence Pack proof.",
     url: "https://satgate.io/pricing",
     type: "website",
   },
   twitter: {
     card: "summary_large_image",
-    title: "SatGate Pricing | Economic Firewall for AI Agents",
+    title: "SatGate Pricing | Agent Authority & Accountability Layer",
     description:
       "AI agent cost control, MCP governance, receipt, and Evidence Pack pricing.",
   },

--- a/satgate-landing/app/pricing/page.tsx
+++ b/satgate-landing/app/pricing/page.tsx
@@ -50,7 +50,7 @@ const PricingPage = () => {
     dateModified: '2026-05-03',
     isPartOf: { '@type': 'WebSite', name: 'SatGate', url: 'https://satgate.io' },
     about: [
-      { '@type': 'Thing', name: 'economic firewall for AI agents' },
+      { '@type': 'Thing', name: 'Agent Authority & Accountability Layer' },
       { '@type': 'Thing', name: 'AI agent budget enforcement' },
       { '@type': 'Thing', name: 'SatGate Economic Firewall' },
       { '@type': 'Thing', name: 'request-path spend governance' },
@@ -178,7 +178,7 @@ const PricingPage = () => {
         </div>
       </header>
 
-      {/* Observe → Control → Charge Journey */}
+      {/* Observe → Control → Prove Journey */}
       <section className="pb-10 px-6">
         <div className="max-w-3xl mx-auto">
           <div className="flex flex-col md:flex-row items-center justify-center gap-3 md:gap-4">

--- a/satgate-landing/app/satgate-for-claude-code/page.tsx
+++ b/satgate-landing/app/satgate-for-claude-code/page.tsx
@@ -115,7 +115,7 @@ export default function SatGateIntegrationPage() {
 
           <div className="flex flex-col gap-4 sm:flex-row">
             <Link href="/economic-firewall" className="inline-flex items-center justify-center gap-2 rounded-lg bg-white px-6 py-3 font-bold text-black transition hover:bg-gray-200">
-              Learn the economic firewall <ArrowRight size={18} />
+              See Policy-to-Proof <ArrowRight size={18} />
             </Link>
             <Link href="/ai-agent-cost-control" className="inline-flex items-center justify-center gap-2 rounded-lg border border-gray-700 px-6 py-3 font-bold text-white transition hover:border-cyan-500">
               AI agent cost control
@@ -146,7 +146,7 @@ export default function SatGateIntegrationPage() {
       <section className="border-y border-gray-900 bg-gray-950/60">
         <div className="mx-auto max-w-6xl px-6 py-20">
           <h2 className="mb-4 text-3xl font-bold text-white">SatGate controls for Claude Code</h2>
-          <p className="mb-10 max-w-3xl text-lg text-gray-400">Use SatGate as the economic firewall around agentic tool use: Observe first, Control when limits are known, Charge when external agents should pay for access.</p>
+          <p className="mb-10 max-w-3xl text-lg text-gray-400">Use SatGate as the governance layer around agentic tool use: Observe first, Control when limits are known, and Prove every approval, denial, and paid-access decision with Evidence Pack receipts.</p>
           <div className="grid gap-5 md:grid-cols-2 lg:grid-cols-4">
             {controls.map(({ icon: Icon, title, body }) => (
               <div key={title} className="rounded-xl border border-gray-800 bg-black p-6 transition hover:border-cyan-900/70">
@@ -192,7 +192,7 @@ export default function SatGateIntegrationPage() {
 
       <section className="mx-auto max-w-6xl px-6 pb-24">
         <div className="rounded-3xl border border-purple-900/40 bg-gradient-to-br from-purple-950/40 to-cyan-950/20 p-8 md:p-10">
-          <div className="mb-4 flex items-center gap-3 text-purple-200"><Bot size={24} /><span className="font-semibold">Observe → Control → Charge</span></div>
+          <div className="mb-4 flex items-center gap-3 text-purple-200"><Bot size={24} /><span className="font-semibold">Observe → Control → Prove</span></div>
           <h2 className="mb-4 text-3xl font-bold text-white">Make Claude Code agent activity governable.</h2>
           <p className="mb-8 max-w-3xl text-lg leading-relaxed text-gray-300">SatGate gives agent teams the missing economic layer: budgets, scoped authority, revocation, audit, and paid-rail context where machine customers need to pay for APIs.</p>
           <div className="flex flex-col gap-4 sm:flex-row">

--- a/satgate-landing/app/satgate-for-claude-desktop/page.tsx
+++ b/satgate-landing/app/satgate-for-claude-desktop/page.tsx
@@ -112,12 +112,12 @@ export default function SatGateIntegrationPage() {
             <Terminal size={16} /> Claude Desktop MCP budget enforcement
           </div>
 
-          <h1 className="mb-8 max-w-5xl text-5xl font-extrabold tracking-tight md:text-7xl">Put an economic firewall around Claude Desktop MCP tools</h1>
+          <h1 className="mb-8 max-w-5xl text-5xl font-extrabold tracking-tight md:text-7xl">Put authority controls around Claude Desktop MCP tools</h1>
           <p className="mb-10 max-w-4xl text-xl leading-relaxed text-gray-300 md:text-2xl">Claude Desktop plus MCP gives assistants access to real tools. That is exactly where static keys and best-effort prompts break down. SatGate enforces budget, scope, expiry, revocation, and audit at the request layer around MCP servers and paid APIs.</p>
 
           <div className="flex flex-col gap-4 sm:flex-row">
             <Link href="/economic-firewall" className="inline-flex items-center justify-center gap-2 rounded-lg bg-white px-6 py-3 font-bold text-black transition hover:bg-gray-200">
-              Learn the economic firewall <ArrowRight size={18} />
+              See Policy-to-Proof <ArrowRight size={18} />
             </Link>
             <Link href="/ai-agent-cost-control" className="inline-flex items-center justify-center gap-2 rounded-lg border border-gray-700 px-6 py-3 font-bold text-white transition hover:border-cyan-500">
               AI agent cost control
@@ -148,7 +148,7 @@ export default function SatGateIntegrationPage() {
       <section className="border-y border-gray-900 bg-gray-950/60">
         <div className="mx-auto max-w-6xl px-6 py-20">
           <h2 className="mb-4 text-3xl font-bold text-white">SatGate controls for Claude Desktop</h2>
-          <p className="mb-10 max-w-3xl text-lg text-gray-400">Use SatGate as the economic firewall around agentic tool use: Observe first, Control when limits are known, Charge when external agents should pay for access.</p>
+          <p className="mb-10 max-w-3xl text-lg text-gray-400">Use SatGate as the governance layer around agentic tool use: Observe first, Control when limits are known, and Prove every approval, denial, and paid-access decision with Evidence Pack receipts.</p>
           <div className="grid gap-5 md:grid-cols-2 lg:grid-cols-4">
             {controls.map(({ icon: Icon, title, body }) => (
               <div key={title} className="rounded-xl border border-gray-800 bg-black p-6 transition hover:border-cyan-900/70">
@@ -197,7 +197,7 @@ export default function SatGateIntegrationPage() {
 
       <section className="mx-auto max-w-6xl px-6 py-20">
         <div className="rounded-3xl border border-purple-900/40 bg-gradient-to-br from-purple-950/40 to-cyan-950/20 p-8 md:p-10">
-          <div className="mb-4 flex items-center gap-3 text-purple-200"><Bot size={24} /><span className="font-semibold">Observe → Control → Charge</span></div>
+          <div className="mb-4 flex items-center gap-3 text-purple-200"><Bot size={24} /><span className="font-semibold">Observe → Control → Prove</span></div>
           <h2 className="mb-4 text-3xl font-bold text-white">Make Claude Desktop agent activity governable.</h2>
           <p className="mb-8 max-w-3xl text-lg leading-relaxed text-gray-300">SatGate gives agent teams the missing economic layer: budgets, scoped authority, revocation, audit, and paid-rail context where machine customers need to pay for APIs.</p>
           <div className="flex flex-col gap-4 sm:flex-row">

--- a/satgate-landing/app/satgate-for-cursor/page.tsx
+++ b/satgate-landing/app/satgate-for-cursor/page.tsx
@@ -111,11 +111,11 @@ export default function SatGateIntegrationPage() {
           </div>
 
           <h1 className="mb-8 max-w-5xl text-5xl font-extrabold tracking-tight md:text-7xl">Give Cursor agents budgets, not blank checks</h1>
-          <p className="mb-10 max-w-4xl text-xl leading-relaxed text-gray-300 md:text-2xl">Cursor makes software agents fast enough to call tools, APIs, and model routes at machine speed. SatGate adds the missing economic firewall: per-agent budgets, scoped credentials, MCP tool limits, revocation, and audit before requests execute.</p>
+          <p className="mb-10 max-w-4xl text-xl leading-relaxed text-gray-300 md:text-2xl">Cursor makes software agents fast enough to call tools, APIs, and model routes at machine speed. SatGate adds the missing authority-and-proof layer: per-agent budgets, scoped credentials, MCP tool limits, revocation, and audit before requests execute.</p>
 
           <div className="flex flex-col gap-4 sm:flex-row">
             <Link href="/economic-firewall" className="inline-flex items-center justify-center gap-2 rounded-lg bg-white px-6 py-3 font-bold text-black transition hover:bg-gray-200">
-              Learn the economic firewall <ArrowRight size={18} />
+              See Policy-to-Proof <ArrowRight size={18} />
             </Link>
             <Link href="/ai-agent-cost-control" className="inline-flex items-center justify-center gap-2 rounded-lg border border-gray-700 px-6 py-3 font-bold text-white transition hover:border-cyan-500">
               AI agent cost control
@@ -146,7 +146,7 @@ export default function SatGateIntegrationPage() {
       <section className="border-y border-gray-900 bg-gray-950/60">
         <div className="mx-auto max-w-6xl px-6 py-20">
           <h2 className="mb-4 text-3xl font-bold text-white">SatGate controls for Cursor</h2>
-          <p className="mb-10 max-w-3xl text-lg text-gray-400">Use SatGate as the economic firewall around agentic tool use: Observe first, Control when limits are known, Charge when external agents should pay for access.</p>
+          <p className="mb-10 max-w-3xl text-lg text-gray-400">Use SatGate as the governance layer around agentic tool use: Observe first, Control when limits are known, and Prove every approval, denial, and paid-access decision with Evidence Pack receipts.</p>
           <div className="grid gap-5 md:grid-cols-2 lg:grid-cols-4">
             {controls.map(({ icon: Icon, title, body }) => (
               <div key={title} className="rounded-xl border border-gray-800 bg-black p-6 transition hover:border-cyan-900/70">
@@ -192,7 +192,7 @@ export default function SatGateIntegrationPage() {
 
       <section className="mx-auto max-w-6xl px-6 pb-24">
         <div className="rounded-3xl border border-purple-900/40 bg-gradient-to-br from-purple-950/40 to-cyan-950/20 p-8 md:p-10">
-          <div className="mb-4 flex items-center gap-3 text-purple-200"><Bot size={24} /><span className="font-semibold">Observe → Control → Charge</span></div>
+          <div className="mb-4 flex items-center gap-3 text-purple-200"><Bot size={24} /><span className="font-semibold">Observe → Control → Prove</span></div>
           <h2 className="mb-4 text-3xl font-bold text-white">Make Cursor agent activity governable.</h2>
           <p className="mb-8 max-w-3xl text-lg leading-relaxed text-gray-300">SatGate gives agent teams the missing economic layer: budgets, scoped authority, revocation, audit, and paid-rail context where machine customers need to pay for APIs.</p>
           <div className="flex flex-col gap-4 sm:flex-row">

--- a/satgate-landing/app/satgate-for-openclaw/page.tsx
+++ b/satgate-landing/app/satgate-for-openclaw/page.tsx
@@ -3,26 +3,26 @@ import { ArrowRight, Bot, DollarSign, Gauge, KeyRound, ShieldCheck, Terminal, Wo
 
 export const metadata = {
   title: 'SatGate for OpenClaw Agents',
-  description: 'Use SatGate as the economic firewall for OpenClaw agents, sub-agents, tools, MCP calls, model routes, and API spend.',
+  description: 'Use SatGate as the Agent Authority & Accountability Layer for governed OpenClaw execution across sub-agents, tools, MCP calls, model routes, and API spend.',
   alternates: { canonical: 'https://satgate.io/satgate-for-openclaw' },
   keywords: [
     'SatGate for OpenClaw',
     'OpenClaw agent spend control',
     'OpenClaw MCP budget enforcement',
     'AI agent cost control',
-    'economic firewall for AI agents',
+    'Agent Authority & Accountability Layer',
     'revocable agent credentials',
   ],
   openGraph: {
     title: 'SatGate for OpenClaw Agents',
-    description: 'Use SatGate as the economic firewall for OpenClaw agents, sub-agents, tools, MCP calls, model routes, and API spend.',
+    description: 'Use SatGate as the Agent Authority & Accountability Layer for governed OpenClaw execution across sub-agents, tools, MCP calls, model routes, and API spend.',
     url: 'https://satgate.io/satgate-for-openclaw',
     type: 'website',
   },
   twitter: {
     card: 'summary_large_image',
     title: 'SatGate for OpenClaw Agents',
-    description: 'Use SatGate as the economic firewall for OpenClaw agents, sub-agents, tools, MCP calls, model routes, and API spend.',
+    description: 'Use SatGate as the Agent Authority & Accountability Layer for governed OpenClaw execution across sub-agents, tools, MCP calls, model routes, and API spend.',
   },
 };
 
@@ -45,7 +45,7 @@ export default function SatGateIntegrationPage() {
     about: [
       { '@type': 'Thing', name: 'OpenClaw agent spend control' },
       { '@type': 'Thing', name: 'OpenClaw MCP budget enforcement' },
-      { '@type': 'Thing', name: 'economic firewall for OpenClaw agents' },
+      { '@type': 'Thing', name: 'governed OpenClaw agent execution' },
       { '@type': 'Thing', name: 'sub-agent budget attribution' },
       { '@type': 'Thing', name: 'L402 paid agent payments' },
     ],
@@ -77,7 +77,7 @@ export default function SatGateIntegrationPage() {
       {
         '@type': 'Question',
         name: 'Is SatGate just another observability dashboard?',
-        acceptedAnswer: { '@type': 'Answer', text: 'No. SatGate can observe traffic, but its core role is request-path enforcement: budgets, revocation, route policy, capabilities, audit, and L402 payment before upstream access.' },
+        acceptedAnswer: { '@type': 'Answer', text: 'No. SatGate can observe traffic, but its core role is request-path enforcement: budgets, revocation, route policy, capabilities, Evidence Pack receipts, and paid-rail context before upstream access.' },
       },
       {
         '@type': 'Question',
@@ -110,12 +110,12 @@ export default function SatGateIntegrationPage() {
             <Terminal size={16} /> OpenClaw agent spend control
           </div>
 
-          <h1 className="mb-8 max-w-5xl text-5xl font-extrabold tracking-tight md:text-7xl">Give OpenClaw agents an economic firewall</h1>
-          <p className="mb-10 max-w-4xl text-xl leading-relaxed text-gray-300 md:text-2xl">OpenClaw agents can run tools, spawn sub-agents, call MCP servers, route through models, and act across workflows. SatGate adds the economic firewall underneath: observe, control, and prove agent/API activity before upstream access.</p>
+          <h1 className="mb-8 max-w-5xl text-5xl font-extrabold tracking-tight md:text-7xl">Give OpenClaw agents authority before execution</h1>
+          <p className="mb-10 max-w-4xl text-xl leading-relaxed text-gray-300 md:text-2xl">OpenClaw agents can run tools, spawn sub-agents, call MCP servers, route through models, and act across workflows. SatGate adds the Agent Authority & Accountability Layer underneath: Observe, Control, and Prove agent/API activity before upstream access.</p>
 
           <div className="flex flex-col gap-4 sm:flex-row">
             <Link href="/economic-firewall" className="inline-flex items-center justify-center gap-2 rounded-lg bg-white px-6 py-3 font-bold text-black transition hover:bg-gray-200">
-              Learn the economic firewall <ArrowRight size={18} />
+              See Policy-to-Proof <ArrowRight size={18} />
             </Link>
             <Link href="/ai-agent-cost-control" className="inline-flex items-center justify-center gap-2 rounded-lg border border-gray-700 px-6 py-3 font-bold text-white transition hover:border-cyan-500">
               AI agent cost control
@@ -146,7 +146,7 @@ export default function SatGateIntegrationPage() {
       <section className="border-y border-gray-900 bg-gray-950/60">
         <div className="mx-auto max-w-6xl px-6 py-20">
           <h2 className="mb-4 text-3xl font-bold text-white">SatGate controls for OpenClaw</h2>
-          <p className="mb-10 max-w-3xl text-lg text-gray-400">Use SatGate as the economic firewall around agentic tool use: Observe first, Control when limits are known, Charge when external agents should pay for access.</p>
+          <p className="mb-10 max-w-3xl text-lg text-gray-400">Use SatGate as the governance layer around agentic tool use: Observe first, Control when limits are known, and Prove every approval, denial, and paid-access decision with Evidence Pack receipts.</p>
           <div className="grid gap-5 md:grid-cols-2 lg:grid-cols-4">
             {controls.map(({ icon: Icon, title, body }) => (
               <div key={title} className="rounded-xl border border-gray-800 bg-black p-6 transition hover:border-cyan-900/70">
@@ -178,7 +178,7 @@ export default function SatGateIntegrationPage() {
           <div className="grid gap-5 md:grid-cols-3">
             {[
               ['How does SatGate fit with OpenClaw?', 'OpenClaw coordinates agents and tools. SatGate governs the economics of those requests: who can spend, on what, under which budget, and with which Evidence Pack.'],
-              ['Is SatGate just another observability dashboard?', 'No. SatGate can observe traffic, but its core role is request-path enforcement: budgets, revocation, route policy, capabilities, audit, and L402 payment before upstream access.'],
+              ['Is SatGate just another observability dashboard?', 'No. SatGate can observe traffic, but its core role is request-path enforcement: budgets, revocation, route policy, capabilities, Evidence Pack receipts, and paid-rail context before upstream access.'],
               ['Can SatGate start in observe-only mode?', 'Yes. Teams can start with Observe to map agent and tool spend, then graduate to Control policies once safe limits are clear.'],
             ].map(([question, answer]) => (
               <div key={question}>
@@ -192,9 +192,9 @@ export default function SatGateIntegrationPage() {
 
       <section className="mx-auto max-w-6xl px-6 pb-24">
         <div className="rounded-3xl border border-purple-900/40 bg-gradient-to-br from-purple-950/40 to-cyan-950/20 p-8 md:p-10">
-          <div className="mb-4 flex items-center gap-3 text-purple-200"><Bot size={24} /><span className="font-semibold">Observe → Control → Charge</span></div>
+          <div className="mb-4 flex items-center gap-3 text-purple-200"><Bot size={24} /><span className="font-semibold">Observe → Control → Prove</span></div>
           <h2 className="mb-4 text-3xl font-bold text-white">Make OpenClaw agent activity governable.</h2>
-          <p className="mb-8 max-w-3xl text-lg leading-relaxed text-gray-300">SatGate gives agent teams the missing economic layer: budgets, scoped authority, revocation, audit, and paid-rail context where machine customers need to pay for APIs.</p>
+          <p className="mb-8 max-w-3xl text-lg leading-relaxed text-gray-300">SatGate gives agent teams the missing economic layer: budgets, scoped authority, revocation, Evidence Pack receipts, and paid-rail context where external agents need governed API access.</p>
           <div className="flex flex-col gap-4 sm:flex-row">
             <Link href="/mcp-budget-enforcement" className="inline-flex items-center justify-center gap-2 rounded-lg bg-cyan-300 px-6 py-3 font-bold text-black transition hover:bg-cyan-200">
               MCP budget enforcement <Gauge size={18} />

--- a/satgate-landing/public/llms.txt
+++ b/satgate-landing/public/llms.txt
@@ -1,10 +1,10 @@
-# SatGate™ — Economic Firewall for AI Agent Requests
-> SatGate is the economic control plane for AI agents.
-> Observe, Control, and Charge agent/API activity before upstream access.
+# SatGate™ — Agent Authority & Accountability Layer
+> SatGate is the Agent Authority & Accountability Layer for governed agent execution.
+> Observe, Control, and Prove agent/API activity before upstream access.
 > Request-path budget enforcement, MCP governance, scoped capabilities, Evidence Packs, and paid-rail context.
 
 ## What is SatGate?
-SatGate is an economic firewall for AI agents and APIs. It sits in the request path between autonomous agents and upstream APIs, tools, MCP servers, model providers, or protected resources.
+SatGate is an Agent Authority & Accountability Layer for AI agents and APIs. It sits in the request path between autonomous agents and upstream APIs, tools, MCP servers, model providers, or protected resources.
 
 SatGate answers the question every autonomous agent request creates:
 
@@ -18,18 +18,18 @@ Measure agent/API traffic without blocking production workloads. Attribute spend
 ### Control
 Enforce budgets, spend caps, route policy, revocation, expiry, per-request ceilings, and kill switches before expensive API or MCP tool calls execute.
 
-### Charge
-Let paid agents pay for protected APIs at request time. SatGate paid-rail governance uses paid-rail context. Fiat402 is separate and should not be conflated with Charge.
+### Prove
+Preserve Evidence Pack receipts for allowed, denied, delegated, revoked, and paid-rail decisions. x402, L402, AgentCore Payments, Pay.sh, and Fiat402 are paid rails; SatGate governs authority and proof above them.
 
 ## Category Definition
-An economic firewall is a request-path control layer that governs AI agent access, spend, budgets, routing, audit, and payment before upstream API calls execute.
+An economic firewall is a request-path control layer that governs AI agent access, spend, budgets, routing, Evidence Pack receipts, and paid-rail context before upstream API calls execute.
 
 Traditional API gateways route traffic. Dashboards report spend after the fact. Economic firewalls enforce economic policy before autonomous agents spend money.
 
 ## Key Concepts
-- **Economic control plane for AI agents**: The layer that observes, controls, and charges agent/API activity.
+- **Agent Authority & Accountability Layer**: The layer that governs authority before execution and preserves Evidence Pack receipts afterward.
 - **AI agent spend control**: Per-agent, per-tool, per-route, per-model, per-session, and per-day budget enforcement.
-- **MCP governance**: Budget, access, revocation, risk, and audit controls around Model Context Protocol tool calls.
+- **MCP governance**: Budget, access, revocation, risk, and proof controls around Model Context Protocol tool calls.
 - **Agent API governance**: Scoped, expiring, revocable, budget-aware capabilities instead of broad static API keys.
 - **Capability tokens**: Macaroon-style credentials with caveats for route, expiry, budget, calls, delegation, and revocation.
 - **paid-rail context**: HTTP 402 + Lightning invoice + proof + access credential for machine-native API monetization.
@@ -151,7 +151,7 @@ Macaroons and capability tokens can constrain agent authority:
 
 ## Architecture
 ```
-Agent / App / MCP Client → CDN/WAF → SatGate Economic Firewall → API / MCP Server / Model Provider
+Agent / App / MCP Client → CDN/WAF → SatGate Policy-to-Proof Gateway → API / MCP Server / Model Provider
 ```
 
 SatGate can be deployed as a gateway, sidecar, or MCP proxy. It is designed to add economic governance around existing APIs and agent workflows without forcing every tool implementation to be rewritten.

--- a/satgate-landing/scripts/seo_machine.py
+++ b/satgate-landing/scripts/seo_machine.py
@@ -29,13 +29,13 @@ SITEMAP_PATH_RE = re.compile(r"path:\s*'([^']*)'")
 RECOMMENDED_META = {
  '/blog/how-to-add-budget-limits-to-openai-api-calls': {
    'title': 'OpenAI API Budget Limits: Control Spend Before Calls',
-   'description': 'Learn how to add OpenAI API budget limits, prevent runaway agent spend, and enforce usage controls before calls execute.'},
+   'description': 'Add OpenAI API budget limits with authority before execution, Observe/Control/Prove controls, and Evidence Pack receipts.'},
  '/blog/llm-cost-management': {
    'title': 'LLM Cost Management: Control AI Spend Before It Happens',
-   'description': 'A practical guide to LLM cost management using usage observability, budget controls, and chargeback workflows for AI agents.'},
+   'description': 'A practical guide to LLM cost management using authority before execution, budget controls, and Evidence Pack receipts for AI agents.'},
  '/blog/http-402-payment-required-use-cases': {
    'title': 'HTTP 402 Payment Required: API and Agent Use Cases',
-   'description': 'See how HTTP 402 can support paid API access, metered MCP tools, and agent transactions using SatGate.'},
+   'description': 'HTTP 402 and L402 are paid-rail context. SatGate governs authority before execution and preserves Evidence Packs.'},
  '/blog/macaroon-tokens-vs-api-keys': {
    'title': 'Macaroon Tokens vs API Keys for Agent Access',
    'description': 'Compare macaroon tokens and API keys for scoped authorization, delegated access, and safer AI agent permissions.'},
@@ -46,7 +46,7 @@ RECOMMENDED_META = {
    'title': 'API Gateway for AI Agents: Control Tool and API Access',
    'description': 'Learn how an API gateway for AI agents can enforce access, budgets, observability, and monetization across APIs and MCP tools.'},
  '/mcp-gateway': {
-   'title': 'MCP Gateway for Governed Agent Tool Access',
+   'title': 'MCP Gateway for Agent Governance and Evidence Packs',
    'description': 'Use SatGate as an MCP gateway to check authority before tool execution, enforce policy, and export Evidence Packs.'},
  '/capability-auth': {
    'title': 'Capability-Based Authorization for AI Agents',
@@ -90,6 +90,17 @@ def score_item(row: dict[str, Any], target: dict[str, Any]) -> dict[str, Any]:
     return {**target, 'clicks': row.get('clicks',0), 'impressions': int(imps), 'ctr': ctr, 'position': pos,
             'expectedCtr': exp, 'ctrGap': round(gap,4), 'score': score, 'priority': priority}
 
+def comparison_title_for_path(path: str) -> str:
+    if not path.startswith('/compare/'):
+        return ''
+    config = APP / 'compare' / '_components' / 'comparisons.ts'
+    if not config.exists():
+        return ''
+    slug = path.rsplit('/', 1)[-1]
+    text = config.read_text(errors='ignore')
+    m = re.search(rf"['\"]{re.escape(slug)}['\"]:\s*\{{.*?title:\s*['\"]([^'\"]+)['\"]", text, re.S)
+    return m.group(1) if m else ''
+
 def audit_page(target: dict[str, Any], sitemap_paths: set[str]) -> dict[str, Any]:
     path=target['path']; f=route_file(path); issues=[]
     if not f.exists():
@@ -117,6 +128,9 @@ def audit_page(target: dict[str, Any], sitemap_paths: set[str]) -> dict[str, Any
     canon_match=CANON_RE.search(meta)
     canonical=canon_match.group(2) if canon_match else ''
     h1s=[clean_text(m.group(1)) for m in H1_RE.finditer(text)]
+    comparison_title = comparison_title_for_path(path)
+    if comparison_title:
+        h1s=[comparison_title if not h1 else h1 for h1 in h1s]
     h2s=[clean_text(m.group(1)) for m in H2_RE.finditer(text)]
     links=sorted({m.group(2) for m in LINK_RE.finditer(text)})
     schema_types=sorted(set(re.findall(r"['\"]@type['\"]:\s*['\"]([^'\"]+)['\"]", text)))

--- a/satgate-landing/seo/reports/opportunities.json
+++ b/satgate-landing/seo/reports/opportunities.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-05-22T16:31:14.338367Z",
+  "generatedAt": "2026-05-24T15:27:40.211021Z",
   "items": [
     {
       "path": "/blog/how-to-add-budget-limits-to-openai-api-calls",
@@ -208,7 +208,7 @@
       "intent": "informational-commercial",
       "funnelStage": "problem-aware",
       "productAngle": "SatGate provides request-path AI spend governance: observe usage, control budgets and policy before execution, and preserve Evidence Pack proof.",
-      "cta": "Learn about Economic Firewalls",
+      "cta": "See Policy-to-Proof",
       "status": "new",
       "clicks": 0,
       "impressions": 0,
@@ -231,7 +231,7 @@
       ],
       "intent": "comparison",
       "funnelStage": "solution-aware",
-      "productAngle": "SatGate is the provider-neutral economic firewall for delegated agent spend across clouds, MCP tools, APIs, and paid rails.",
+      "productAngle": "SatGate is the provider-neutral Agent Authority & Accountability Layer for delegated agent spend across clouds, MCP tools, APIs, and paid rails.",
       "cta": "See Policy-to-Proof",
       "status": "new",
       "clicks": 0,
@@ -349,7 +349,7 @@
         "Cloudflare AI Gateway alternative",
         "AI gateway budget enforcement",
         "MCP tool governance",
-        "agent economic firewall"
+        "agent authority governance"
       ],
       "intent": "comparison",
       "funnelStage": "solution-aware",

--- a/satgate-landing/seo/reports/opportunities.md
+++ b/satgate-landing/seo/reports/opportunities.md
@@ -1,6 +1,6 @@
 # SatGate SEO Machine Report
 
-Generated: 2026-05-22T16:31:14.339376Z
+Generated: 2026-05-24T15:27:40.211858Z
 
 ## Ranked opportunities
 
@@ -100,7 +100,7 @@ Generated: 2026-05-22T16:31:14.339376Z
 
 ### /blog/how-to-add-budget-limits-to-openai-api-calls
 - Title: OpenAI API Budget Limits: Control Spend Before Calls
-- Meta: Learn how to add OpenAI API budget limits, prevent runaway agent spend, and enforce usage controls before calls execute.
+- Meta: Add OpenAI API budget limits with authority before execution, Observe/Control/Prove controls, and Evidence Pack receipts.
 - Content changes:
   - Add or tighten the above-the-fold direct-answer block for the primary query.
   - Route the first CTA into a tool, signup, or commercial product page instead of letting the article dead-end.
@@ -108,7 +108,7 @@ Generated: 2026-05-22T16:31:14.339376Z
 
 ### /blog/http-402-payment-required-use-cases
 - Title: HTTP 402 Payment Required: API and Agent Use Cases
-- Meta: See how HTTP 402 can support paid API access, metered MCP tools, and agent transactions using SatGate.
+- Meta: HTTP 402 and L402 are paid-rail context. SatGate governs authority before execution and preserves Evidence Packs.
 - Content changes:
   - Add or tighten the above-the-fold direct-answer block for the primary query.
   - Route the first CTA into a tool, signup, or commercial product page instead of letting the article dead-end.
@@ -132,7 +132,7 @@ Generated: 2026-05-22T16:31:14.339376Z
 
 ### /blog/llm-cost-management
 - Title: LLM Cost Management: Control AI Spend Before It Happens
-- Meta: A practical guide to LLM cost management using usage observability, budget controls, and chargeback workflows for AI agents.
+- Meta: A practical guide to LLM cost management using authority before execution, budget controls, and Evidence Pack receipts for AI agents.
 - Content changes:
   - Add or tighten the above-the-fold direct-answer block for the primary query.
   - Route the first CTA into a tool, signup, or commercial product page instead of letting the article dead-end.
@@ -147,7 +147,7 @@ Generated: 2026-05-22T16:31:14.339376Z
 - Links to add: /mcp-gateway, /govern, /blog/llm-cost-management, /blog/http-402-payment-required-use-cases
 
 ### /mcp-gateway
-- Title: MCP Gateway for Governed Agent Tool Access
+- Title: MCP Gateway for Agent Governance and Evidence Packs
 - Meta: Use SatGate as an MCP gateway to check authority before tool execution, enforce policy, and export Evidence Packs.
 - Content changes:
   - Make this the commercial MCP gateway hub and link all MCP blog/tool pages into it.

--- a/satgate-landing/seo/reports/page-audit.json
+++ b/satgate-landing/seo/reports/page-audit.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-05-22T16:31:14.338862Z",
+  "generatedAt": "2026-05-24T15:27:40.211423Z",
   "items": [
     {
       "path": "/blog/ai-spend-governance",
@@ -98,7 +98,7 @@
         "TechArticle",
         "Thing"
       ],
-      "wordCount": 1315,
+      "wordCount": 1323,
       "hasObserveControlProve": true,
       "hasEvidencePack": true,
       "hasFAQ": true,
@@ -150,7 +150,7 @@
         "TechArticle",
         "Thing"
       ],
-      "wordCount": 2179,
+      "wordCount": 2189,
       "hasObserveControlProve": true,
       "hasEvidencePack": true,
       "hasFAQ": true,
@@ -268,8 +268,8 @@
       "exists": true,
       "title": "AI Agent Governance: Policy-to-Proof",
       "titleLength": 36,
-      "metaDescription": "AI agent governance for the Economic Firewall category: scope authority, enforce request-path policy, and export Evidence Packs for every agent decision.",
-      "metaDescriptionLength": 153,
+      "metaDescription": "AI agent governance from Policy-to-Proof: scope authority, enforce request-path policy, and export Evidence Pack receipts for every agent decision.",
+      "metaDescriptionLength": 147,
       "canonical": "/govern",
       "h1": [
         "Govern what agents can do. Prove every decision."
@@ -314,7 +314,7 @@
         "WebPage",
         "WebSite"
       ],
-      "wordCount": 1696,
+      "wordCount": 1692,
       "hasObserveControlProve": true,
       "hasEvidencePack": true,
       "hasFAQ": true,
@@ -372,13 +372,13 @@
     {
       "path": "/mcp-gateway",
       "exists": true,
-      "title": "MCP Gateway for Budget Enforcement and Evidence Packs",
-      "titleLength": 53,
-      "metaDescription": "Use SatGate as the MCP gateway for budget enforcement, tool allowlists, tenant isolation, delegation depth, and MCP Evidence Pack proof.",
-      "metaDescriptionLength": 136,
+      "title": "MCP Gateway for Agent Governance and Evidence Packs",
+      "titleLength": 51,
+      "metaDescription": "Use SatGate as an MCP gateway to check authority before tool execution, enforce policy, and export Evidence Packs.",
+      "metaDescriptionLength": 114,
       "canonical": "/mcp-gateway",
       "h1": [
-        "MCP Gateway for Budget Enforcement and Evidence Packs"
+        "MCP Gateway for Agent Governance and Evidence Packs"
       ],
       "h1Count": 1,
       "h2s": [
@@ -462,13 +462,189 @@
     {
       "path": "/compare/aws-agentcore-payments",
       "exists": true,
-      "title": "SatGate vs AWS AgentCore Payments Control",
-      "titleLength": 41,
+      "title": "SatGate vs AWS AgentCore Payments: Governance Above Paid Rails",
+      "titleLength": 62,
       "metaDescription": "Compare SatGate and AWS AgentCore Payments across cross-provider control, paid rails, MCP proxying, delegated budgets, hybrid deployment, and Evidence Packs.",
       "metaDescriptionLength": 157,
       "canonical": "/compare/aws-agentcore-payments",
       "h1": [
-        ""
+        "SatGate vs AWS AgentCore Payments: Governance Above Paid Rails"
+      ],
+      "h1Count": 1,
+      "h2s": [
+        "Where is genuinely useful",
+        "Where SatGate evaluates agent authority",
+        "What to compare for agent governance",
+        "Why this matters in production",
+        "FAQ",
+        "Dashboards explain what happened. SatGate controls what agents are allowed to do."
+      ],
+      "internalLinks": [
+        "/compare",
+        "/evidence-pack-demo",
+        "/mcp-governance",
+        "/policy-to-proof"
+      ],
+      "schemaTypes": [
+        "Answer",
+        "BreadcrumbList",
+        "FAQPage",
+        "ListItem",
+        "Organization",
+        "Question",
+        "TechArticle",
+        "Thing"
+      ],
+      "wordCount": 440,
+      "hasObserveControlProve": true,
+      "hasEvidencePack": true,
+      "hasFAQ": true,
+      "hasProductCTA": true,
+      "inSitemap": true,
+      "issues": []
+    },
+    {
+      "path": "/compare/cloudflare-ai-gateway",
+      "exists": true,
+      "title": "SatGate vs Cloudflare AI Gateway: Policy-to-Proof for Agent Actions",
+      "titleLength": 67,
+      "metaDescription": "Compare Cloudflare AI Gateway and SatGate across AI routing, rate limits, pre-execution control, MCP proxying, delegated budgets, and Evidence Packs.",
+      "metaDescriptionLength": 149,
+      "canonical": "/compare/cloudflare-ai-gateway",
+      "h1": [
+        "SatGate vs Cloudflare AI Gateway: Policy-to-Proof for Agent Actions"
+      ],
+      "h1Count": 1,
+      "h2s": [
+        "Where is genuinely useful",
+        "Where SatGate evaluates agent authority",
+        "What to compare for agent governance",
+        "Why this matters in production",
+        "FAQ",
+        "Dashboards explain what happened. SatGate controls what agents are allowed to do."
+      ],
+      "internalLinks": [
+        "/compare",
+        "/evidence-pack-demo",
+        "/mcp-governance",
+        "/policy-to-proof"
+      ],
+      "schemaTypes": [
+        "Answer",
+        "BreadcrumbList",
+        "FAQPage",
+        "ListItem",
+        "Organization",
+        "Question",
+        "TechArticle",
+        "Thing"
+      ],
+      "wordCount": 438,
+      "hasObserveControlProve": true,
+      "hasEvidencePack": true,
+      "hasFAQ": true,
+      "hasProductCTA": true,
+      "inSitemap": true,
+      "issues": []
+    },
+    {
+      "path": "/compare/langsmith-helicone-datadog",
+      "exists": true,
+      "title": "SatGate vs LangSmith, Helicone, Datadog: Proof Before Postmortems",
+      "titleLength": 65,
+      "metaDescription": "Compare LLM observability tools with SatGate pre-execution control: delegated budgets, MCP tool policy, paid rails, hybrid enforcement, and Evidence Packs.",
+      "metaDescriptionLength": 155,
+      "canonical": "/compare/langsmith-helicone-datadog",
+      "h1": [
+        "SatGate vs LangSmith, Helicone, and Datadog: Proof Before Postmortems"
+      ],
+      "h1Count": 1,
+      "h2s": [
+        "Where is genuinely useful",
+        "Where SatGate evaluates agent authority",
+        "What to compare for agent governance",
+        "Why this matters in production",
+        "FAQ",
+        "Dashboards explain what happened. SatGate controls what agents are allowed to do."
+      ],
+      "internalLinks": [
+        "/compare",
+        "/evidence-pack-demo",
+        "/mcp-governance",
+        "/policy-to-proof"
+      ],
+      "schemaTypes": [
+        "Answer",
+        "BreadcrumbList",
+        "FAQPage",
+        "ListItem",
+        "Organization",
+        "Question",
+        "TechArticle",
+        "Thing"
+      ],
+      "wordCount": 436,
+      "hasObserveControlProve": true,
+      "hasEvidencePack": true,
+      "hasFAQ": true,
+      "hasProductCTA": true,
+      "inSitemap": true,
+      "issues": []
+    },
+    {
+      "path": "/compare/api-gateway-rate-limits",
+      "exists": true,
+      "title": "SatGate vs API Gateway Rate Limits: Authority Beats Quotas",
+      "titleLength": 58,
+      "metaDescription": "Compare API Gateway rate limits with SatGate agent authority: delegated budgets, MCP tool policy, paid rails, hybrid enforcement, and Evidence Packs.",
+      "metaDescriptionLength": 149,
+      "canonical": "/compare/api-gateway-rate-limits",
+      "h1": [
+        "SatGate vs API Gateway Rate Limits: Authority Beats Quotas"
+      ],
+      "h1Count": 1,
+      "h2s": [
+        "Where is genuinely useful",
+        "Where SatGate evaluates agent authority",
+        "What to compare for agent governance",
+        "Why this matters in production",
+        "FAQ",
+        "Dashboards explain what happened. SatGate controls what agents are allowed to do."
+      ],
+      "internalLinks": [
+        "/compare",
+        "/evidence-pack-demo",
+        "/mcp-governance",
+        "/policy-to-proof"
+      ],
+      "schemaTypes": [
+        "Answer",
+        "BreadcrumbList",
+        "FAQPage",
+        "ListItem",
+        "Organization",
+        "Question",
+        "TechArticle",
+        "Thing"
+      ],
+      "wordCount": 440,
+      "hasObserveControlProve": true,
+      "hasEvidencePack": true,
+      "hasFAQ": true,
+      "hasProductCTA": true,
+      "inSitemap": true,
+      "issues": []
+    },
+    {
+      "path": "/compare/openai-anthropic-budget-controls",
+      "exists": true,
+      "title": "SatGate vs OpenAI and Anthropic Budgets: Cross-Provider Authority",
+      "titleLength": 65,
+      "metaDescription": "Compare native OpenAI and Anthropic budget controls with SatGate cross-provider agent budgets, MCP policy, paid rails, hybrid control, and Evidence Packs.",
+      "metaDescriptionLength": 154,
+      "canonical": "/compare/openai-anthropic-budget-controls",
+      "h1": [
+        "SatGate vs OpenAI and Anthropic Budgets: Cross-Provider Authority"
       ],
       "h1Count": 1,
       "h2s": [
@@ -496,182 +672,6 @@
         "Thing"
       ],
       "wordCount": 437,
-      "hasObserveControlProve": true,
-      "hasEvidencePack": true,
-      "hasFAQ": true,
-      "hasProductCTA": true,
-      "inSitemap": true,
-      "issues": []
-    },
-    {
-      "path": "/compare/cloudflare-ai-gateway",
-      "exists": true,
-      "title": "SatGate vs Cloudflare AI Gateway Control",
-      "titleLength": 40,
-      "metaDescription": "Compare Cloudflare AI Gateway and SatGate across AI routing, rate limits, pre-execution control, MCP proxying, delegated budgets, and Evidence Packs.",
-      "metaDescriptionLength": 149,
-      "canonical": "/compare/cloudflare-ai-gateway",
-      "h1": [
-        ""
-      ],
-      "h1Count": 1,
-      "h2s": [
-        "Where is genuinely useful",
-        "Where SatGate evaluates agent authority",
-        "What to compare for agent governance",
-        "Why this matters in production",
-        "FAQ",
-        "Dashboards explain what happened. SatGate controls what agents are allowed to do."
-      ],
-      "internalLinks": [
-        "/compare",
-        "/evidence-pack-demo",
-        "/mcp-governance",
-        "/policy-to-proof"
-      ],
-      "schemaTypes": [
-        "Answer",
-        "BreadcrumbList",
-        "FAQPage",
-        "ListItem",
-        "Organization",
-        "Question",
-        "TechArticle",
-        "Thing"
-      ],
-      "wordCount": 435,
-      "hasObserveControlProve": true,
-      "hasEvidencePack": true,
-      "hasFAQ": true,
-      "hasProductCTA": true,
-      "inSitemap": true,
-      "issues": []
-    },
-    {
-      "path": "/compare/langsmith-helicone-datadog",
-      "exists": true,
-      "title": "SatGate vs LangSmith, Helicone, Datadog",
-      "titleLength": 39,
-      "metaDescription": "Compare LLM observability tools with SatGate pre-execution control: delegated budgets, MCP tool policy, paid rails, hybrid enforcement, and Evidence Packs.",
-      "metaDescriptionLength": 155,
-      "canonical": "/compare/langsmith-helicone-datadog",
-      "h1": [
-        ""
-      ],
-      "h1Count": 1,
-      "h2s": [
-        "Where is genuinely useful",
-        "Where SatGate evaluates agent authority",
-        "What to compare for agent governance",
-        "Why this matters in production",
-        "FAQ",
-        "Dashboards explain what happened. SatGate controls what agents are allowed to do."
-      ],
-      "internalLinks": [
-        "/compare",
-        "/evidence-pack-demo",
-        "/mcp-governance",
-        "/policy-to-proof"
-      ],
-      "schemaTypes": [
-        "Answer",
-        "BreadcrumbList",
-        "FAQPage",
-        "ListItem",
-        "Organization",
-        "Question",
-        "TechArticle",
-        "Thing"
-      ],
-      "wordCount": 433,
-      "hasObserveControlProve": true,
-      "hasEvidencePack": true,
-      "hasFAQ": true,
-      "hasProductCTA": true,
-      "inSitemap": true,
-      "issues": []
-    },
-    {
-      "path": "/compare/api-gateway-rate-limits",
-      "exists": true,
-      "title": "SatGate vs API Gateway Rate Limits for Agents",
-      "titleLength": 45,
-      "metaDescription": "Compare API Gateway rate limits with SatGate agent authority: delegated budgets, MCP tool policy, paid rails, hybrid enforcement, and Evidence Packs.",
-      "metaDescriptionLength": 149,
-      "canonical": "/compare/api-gateway-rate-limits",
-      "h1": [
-        ""
-      ],
-      "h1Count": 1,
-      "h2s": [
-        "Where is genuinely useful",
-        "Where SatGate evaluates agent authority",
-        "What to compare for agent governance",
-        "Why this matters in production",
-        "FAQ",
-        "Dashboards explain what happened. SatGate controls what agents are allowed to do."
-      ],
-      "internalLinks": [
-        "/compare",
-        "/evidence-pack-demo",
-        "/mcp-governance",
-        "/policy-to-proof"
-      ],
-      "schemaTypes": [
-        "Answer",
-        "BreadcrumbList",
-        "FAQPage",
-        "ListItem",
-        "Organization",
-        "Question",
-        "TechArticle",
-        "Thing"
-      ],
-      "wordCount": 439,
-      "hasObserveControlProve": true,
-      "hasEvidencePack": true,
-      "hasFAQ": true,
-      "hasProductCTA": true,
-      "inSitemap": true,
-      "issues": []
-    },
-    {
-      "path": "/compare/openai-anthropic-budget-controls",
-      "exists": true,
-      "title": "SatGate vs OpenAI / Anthropic Budgets",
-      "titleLength": 37,
-      "metaDescription": "Compare native OpenAI and Anthropic budget controls with SatGate cross-provider agent budgets, MCP policy, paid rails, hybrid control, and Evidence Packs.",
-      "metaDescriptionLength": 154,
-      "canonical": "/compare/openai-anthropic-budget-controls",
-      "h1": [
-        ""
-      ],
-      "h1Count": 1,
-      "h2s": [
-        "Where is genuinely useful",
-        "Where SatGate evaluates agent authority",
-        "What to compare for agent governance",
-        "Why this matters in production",
-        "FAQ",
-        "Dashboards explain what happened. SatGate controls what agents are allowed to do."
-      ],
-      "internalLinks": [
-        "/compare",
-        "/evidence-pack-demo",
-        "/mcp-governance",
-        "/policy-to-proof"
-      ],
-      "schemaTypes": [
-        "Answer",
-        "BreadcrumbList",
-        "FAQPage",
-        "ListItem",
-        "Organization",
-        "Question",
-        "TechArticle",
-        "Thing"
-      ],
-      "wordCount": 435,
       "hasObserveControlProve": true,
       "hasEvidencePack": true,
       "hasFAQ": true,

--- a/satgate-landing/seo/reports/recommendations.json
+++ b/satgate-landing/seo/reports/recommendations.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-05-22T16:31:14.339200Z",
+  "generatedAt": "2026-05-24T15:27:40.211706Z",
   "items": [
     {
       "path": "/blog/how-to-add-budget-limits-to-openai-api-calls",
@@ -7,7 +7,7 @@
       "score": 98,
       "primaryKeyword": "openai api budget limit",
       "recommendedTitle": "OpenAI API Budget Limits: Control Spend Before Calls",
-      "recommendedMetaDescription": "Learn how to add OpenAI API budget limits, prevent runaway agent spend, and enforce usage controls before calls execute.",
+      "recommendedMetaDescription": "Add OpenAI API budget limits with authority before execution, Observe/Control/Prove controls, and Evidence Pack receipts.",
       "contentChanges": [
         "Add or tighten the above-the-fold direct-answer block for the primary query.",
         "Route the first CTA into a tool, signup, or commercial product page instead of letting the article dead-end."
@@ -30,7 +30,7 @@
       "score": 91,
       "primaryKeyword": "http 402 payment required",
       "recommendedTitle": "HTTP 402 Payment Required: API and Agent Use Cases",
-      "recommendedMetaDescription": "See how HTTP 402 can support paid API access, metered MCP tools, and agent transactions using SatGate.",
+      "recommendedMetaDescription": "HTTP 402 and L402 are paid-rail context. SatGate governs authority before execution and preserves Evidence Packs.",
       "contentChanges": [
         "Add or tighten the above-the-fold direct-answer block for the primary query.",
         "Route the first CTA into a tool, signup, or commercial product page instead of letting the article dead-end."
@@ -99,7 +99,7 @@
       "score": 75,
       "primaryKeyword": "llm cost management",
       "recommendedTitle": "LLM Cost Management: Control AI Spend Before It Happens",
-      "recommendedMetaDescription": "A practical guide to LLM cost management using usage observability, budget controls, and chargeback workflows for AI agents.",
+      "recommendedMetaDescription": "A practical guide to LLM cost management using authority before execution, budget controls, and Evidence Pack receipts for AI agents.",
       "contentChanges": [
         "Add or tighten the above-the-fold direct-answer block for the primary query.",
         "Route the first CTA into a tool, signup, or commercial product page instead of letting the article dead-end."
@@ -144,7 +144,7 @@
       "priority": "P2",
       "score": 50,
       "primaryKeyword": "mcp gateway",
-      "recommendedTitle": "MCP Gateway for Governed Agent Tool Access",
+      "recommendedTitle": "MCP Gateway for Agent Governance and Evidence Packs",
       "recommendedMetaDescription": "Use SatGate as an MCP gateway to check authority before tool execution, enforce policy, and export Evidence Packs.",
       "contentChanges": [
         "Make this the commercial MCP gateway hub and link all MCP blog/tool pages into it."

--- a/satgate-landing/seo/reports/recommendations.md
+++ b/satgate-landing/seo/reports/recommendations.md
@@ -1,6 +1,6 @@
 # SatGate SEO Machine Report
 
-Generated: 2026-05-22T16:31:14.339376Z
+Generated: 2026-05-24T15:27:40.211858Z
 
 ## Ranked opportunities
 
@@ -100,7 +100,7 @@ Generated: 2026-05-22T16:31:14.339376Z
 
 ### /blog/how-to-add-budget-limits-to-openai-api-calls
 - Title: OpenAI API Budget Limits: Control Spend Before Calls
-- Meta: Learn how to add OpenAI API budget limits, prevent runaway agent spend, and enforce usage controls before calls execute.
+- Meta: Add OpenAI API budget limits with authority before execution, Observe/Control/Prove controls, and Evidence Pack receipts.
 - Content changes:
   - Add or tighten the above-the-fold direct-answer block for the primary query.
   - Route the first CTA into a tool, signup, or commercial product page instead of letting the article dead-end.
@@ -108,7 +108,7 @@ Generated: 2026-05-22T16:31:14.339376Z
 
 ### /blog/http-402-payment-required-use-cases
 - Title: HTTP 402 Payment Required: API and Agent Use Cases
-- Meta: See how HTTP 402 can support paid API access, metered MCP tools, and agent transactions using SatGate.
+- Meta: HTTP 402 and L402 are paid-rail context. SatGate governs authority before execution and preserves Evidence Packs.
 - Content changes:
   - Add or tighten the above-the-fold direct-answer block for the primary query.
   - Route the first CTA into a tool, signup, or commercial product page instead of letting the article dead-end.
@@ -132,7 +132,7 @@ Generated: 2026-05-22T16:31:14.339376Z
 
 ### /blog/llm-cost-management
 - Title: LLM Cost Management: Control AI Spend Before It Happens
-- Meta: A practical guide to LLM cost management using usage observability, budget controls, and chargeback workflows for AI agents.
+- Meta: A practical guide to LLM cost management using authority before execution, budget controls, and Evidence Pack receipts for AI agents.
 - Content changes:
   - Add or tighten the above-the-fold direct-answer block for the primary query.
   - Route the first CTA into a tool, signup, or commercial product page instead of letting the article dead-end.
@@ -147,7 +147,7 @@ Generated: 2026-05-22T16:31:14.339376Z
 - Links to add: /mcp-gateway, /govern, /blog/llm-cost-management, /blog/http-402-payment-required-use-cases
 
 ### /mcp-gateway
-- Title: MCP Gateway for Governed Agent Tool Access
+- Title: MCP Gateway for Agent Governance and Evidence Packs
 - Meta: Use SatGate as an MCP gateway to check authority before tool execution, enforce policy, and export Evidence Packs.
 - Content changes:
   - Make this the commercial MCP gateway hub and link all MCP blog/tool pages into it.

--- a/satgate-landing/seo/targets.json
+++ b/satgate-landing/seo/targets.json
@@ -14,7 +14,7 @@
     "intent": "informational-commercial",
     "funnelStage": "problem-aware",
     "productAngle": "SatGate provides request-path AI spend governance: observe usage, control budgets and policy before execution, and preserve Evidence Pack proof.",
-    "cta": "Learn about Economic Firewalls",
+    "cta": "See Policy-to-Proof",
     "status": "new"
   },
   {
@@ -157,7 +157,7 @@
     ],
     "intent": "comparison",
     "funnelStage": "solution-aware",
-    "productAngle": "SatGate is the provider-neutral economic firewall for delegated agent spend across clouds, MCP tools, APIs, and paid rails.",
+    "productAngle": "SatGate is the provider-neutral Agent Authority & Accountability Layer for delegated agent spend across clouds, MCP tools, APIs, and paid rails.",
     "cta": "See Policy-to-Proof",
     "status": "new"
   },
@@ -169,7 +169,7 @@
       "Cloudflare AI Gateway alternative",
       "AI gateway budget enforcement",
       "MCP tool governance",
-      "agent economic firewall"
+      "agent authority governance"
     ],
     "intent": "comparison",
     "funnelStage": "solution-aware",


### PR DESCRIPTION
## Summary
- reframes priority SEO pages around Policy-to-Proof, authority before execution, paid-rail context, and Evidence Pack receipts
- updates /govern and /mcp-gateway metadata/copy plus CTA paths from pay/charge-first to proof/governance-first
- cleans compare-page H1/title extraction and generated SEO machine recommendations
- removes focused stale residues: Observe/Control/Charge, Economic Firewall category copy, robot customer, SatGate Charge, Audit Trail

## Verification
- python3 scripts/seo_machine.py --check → 15 opportunities, 0 audit issue groups
- npm run build → successful Next.js production build, 121 static pages
- rendered local checks against next start for /, /govern, /mcp-gateway, three priority blog pages, five compare pages, /partners/rails, and integration pages

## Note
- Full npm run lint still has pre-existing repo-wide lint debt unrelated to this PR; targeted changed-file lint was only clean for the final Claude Desktop H1 touch.