### PR TITLE
fix(seo): tighten weekly telemetry positioning

### DIFF
--- a/satgate-landing/app/blog/what-is-an-economic-firewall/page.tsx
+++ b/satgate-landing/app/blog/what-is-an-economic-firewall/page.tsx
@@ -272,21 +272,21 @@ const agentBToken = attenuate(agentAToken, {
                 <Zap className="text-yellow-400" size={20} />
               </div>
               <div>
-                <p className="text-white font-semibold text-lg">Charge</p>
-                <p className="text-gray-400">Monetize API access via paid-rail context. Agents pay per call using cryptographic payment proofs &mdash; no accounts, no invoices, no billing portals.</p>
+                <p className="text-white font-semibold text-lg">Prove</p>
+                <p className="text-gray-400">Preserve Evidence Pack receipts for allowed, denied, delegated, revoked, and paid-rail decisions. Paid rails such as L402 or x402 can move value; the governance layer proves why access was allowed.</p>
               </div>
             </div>
           </div>
 
           <p className="text-gray-300 leading-relaxed">
-            A critical distinction: <strong>Control and Charge are parallel use cases, not sequential stages.</strong> They both build on the Observe layer, but they serve different audiences:
+            A critical distinction: <strong>paid rails are context, not the product center.</strong> Enterprises need request-path authority before execution and Evidence Pack proof after the decision, whether the call is internal or crosses a paid rail.
           </p>
           <ul className="text-gray-300 space-y-2">
-            <li><strong>Observe → Control</strong> is the enterprise path. You&rsquo;re running agents internally and need to govern their spending. Budget enforcement, cost attribution, delegation hierarchies.</li>
-            <li><strong>Observe → Charge</strong> is the API monetization path. You&rsquo;re exposing APIs or MCP tools to external agents and want to get paid per call. L402 micropayments, usage-based billing, no signup required.</li>
+            <li><strong>Observe → Control</strong> is the enterprise path: identify the agent, bind budget and scope, and block over-budget work before it executes.</li>
+            <li><strong>Observe → Prove</strong> is the accountability path: preserve receipts for policy decisions, spend, delegation, denials, revocation, and paid-rail context.</li>
           </ul>
           <p className="text-gray-300 leading-relaxed">
-            Most organizations will start with Observe (because you need visibility before you can set sensible limits), then branch into Control, Charge, or both depending on whether they&rsquo;re consuming or selling API access.
+            Most organizations will start with Observe, then move high-risk routes into Control and export Evidence Packs when security, finance, or compliance asks what happened.
           </p>
 
           {/* --- Why Now --- */}

--- a/satgate-landing/app/components/GovernClient.tsx
+++ b/satgate-landing/app/components/GovernClient.tsx
@@ -75,7 +75,7 @@ export default function GovernPage() {
             </span>
           </h1>
           <p className="text-xl text-gray-400 mb-10 max-w-2xl mx-auto leading-relaxed">
-            SatGate is the Policy-to-Proof governance layer for enterprise agents: scope authority before work starts, enforce request-path policy, and preserve Evidence Packs after every allowed, denied, delegated, or revoked action.
+            SatGate governs AI agents with authority before execution, Observe/Control/Prove controls, MCP governance, paid-rail context, and Evidence Pack receipts for every allowed, denied, delegated, or revoked action.
           </p>
           <div className="flex flex-col sm:flex-row gap-4 justify-center">
             <Link href="/policy-to-proof" className="bg-white text-black px-8 py-3 rounded-lg font-bold hover:bg-gray-200 transition flex items-center justify-center gap-2">
@@ -137,7 +137,7 @@ export default function GovernPage() {
           <div className="text-center mt-8">
             <div className="inline-flex items-center gap-3 px-5 py-2.5 bg-gray-900 border border-gray-800 rounded-full text-sm">
               <Key size={16} className="text-purple-400" />
-              <span className="text-gray-400">Same <span className="text-white font-semibold">macaroon capability</span> — same authority chain — one evidence trail</span>
+              <span className="text-gray-400">Same <span className="text-white font-semibold">macaroon capability</span> — same authority chain — one Evidence Pack</span>
             </div>
           </div>
         </div>
@@ -148,7 +148,7 @@ export default function GovernPage() {
         <div className="max-w-5xl mx-auto">
           <h2 className="text-3xl font-bold text-center mb-4">Built for enterprise control owners</h2>
           <p className="text-gray-500 text-center mb-4">Security. Finance. Platform.</p>
-          <p className="text-xs text-gray-600 text-center mb-12">Scoped authority, enforceable limits, and audit-ready evidence for autonomous agent work.</p>
+          <p className="text-xs text-gray-600 text-center mb-12">Scoped authority, enforceable limits, and Evidence Pack proof for autonomous agent work.</p>
 
           <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
             {/* CFO — Margins (Observe) */}
@@ -173,7 +173,7 @@ export default function GovernPage() {
                 <p className="text-xs text-gray-400">Attribute spend to agent, token, route, tool, and policy before finance has to reconstruct it</p>
               </div>
               <div className="mt-4">
-                <Link href="/policy-to-proof" className="text-xs text-cyan-400 hover:text-cyan-300 transition">See the evidence pack →</Link>
+                <Link href="/policy-to-proof" className="text-xs text-cyan-400 hover:text-cyan-300 transition">See the Evidence Pack →</Link>
               </div>
             </div>
 
@@ -236,7 +236,7 @@ export default function GovernPage() {
       <section id="observe" className="py-20 px-6 border-t border-gray-800 bg-gradient-to-b from-gray-900/30 to-black">
         <div className="max-w-5xl mx-auto">
           <h2 className="text-3xl font-bold text-center mb-4">Govern, enforce, prove.</h2>
-          <p className="text-gray-500 text-center mb-12">Start with visibility, move enforcement into the request path, then export the evidence when security, finance, or audit asks what happened.</p>
+          <p className="text-gray-500 text-center mb-12">Start with visibility, move enforcement into the request path, then export the Evidence Pack when security, finance, or compliance asks what happened.</p>
 
           <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
             {/* Observe */}
@@ -292,7 +292,7 @@ export default function GovernPage() {
                 <li className="text-yellow-400">✓ Evidence Pack exports</li>
                 <li className="text-yellow-400">✓ Signed denial and revocation trail</li>
                 <li className="text-yellow-400">✓ x402/L402/API-key billing context</li>
-                <li className="text-yellow-400">✓ Audit-ready authority timeline</li>
+                <li className="text-yellow-400">✓ Evidence Pack authority timeline</li>
               </ul>
             </div>
           </div>
@@ -473,7 +473,7 @@ export default function GovernPage() {
                 icon: <Shield size={24} className="text-red-400" />,
               },
               {
-                title: 'Audit Evidence Export',
+                title: 'Evidence Pack Export',
                 description: 'Export mint receipts, delegation chains, spend ledger entries, denial reasons, and revocation proof in one Evidence Pack.',
                 gradient: 'from-cyan-600 to-blue-600',
                 icon: <FileSearch size={24} className="text-cyan-400" />,
@@ -531,7 +531,7 @@ export default function GovernPage() {
               {[
                 { name: 'Finance Parent Agent', scope: 'invoice:*', budget: '$10k/mo', color: 'cyan' },
                 { name: 'Approval Agent', scope: 'payment:approve', budget: '$5k/mo', color: 'green' },
-                { name: 'Audit Export Agent', scope: 'evidence:export', budget: 'read-only', color: 'yellow' },
+                { name: 'Evidence Pack Export Agent', scope: 'evidence:export', budget: 'read-only', color: 'yellow' },
               ].map((dept) => (
                 <div key={dept.name} className={`p-4 rounded-xl bg-gray-900 border border-${dept.color}-800/30 text-center`}>
                   <div className="flex items-center justify-center gap-2 mb-1">
@@ -652,7 +652,7 @@ export default function GovernPage() {
                 <li>• Delegation happens outside the control plane</li>
                 <li>• Spend and access are reconstructed after the fact</li>
                 <li>• Revocation requires rotating shared secrets</li>
-                <li className="text-red-400 font-medium">• Audit depends on screenshots and log joins</li>
+                <li className="text-red-400 font-medium">• Proof depends on screenshots and log joins</li>
               </ul>
             </div>
             <div className="p-6 rounded-xl bg-green-950/20 border border-green-900/30">
@@ -798,13 +798,13 @@ export SATGATE_TOKEN=$TOKEN
           <p className="mb-2 text-sm font-mono uppercase tracking-wide text-cyan-300">Governance rollout kit</p>
           <h2 className="mb-4 text-3xl font-bold text-white">Turn enterprise governance into request-path controls</h2>
           <p className="mb-8 max-w-3xl text-gray-400 leading-relaxed">
-            High-level AI governance only matters when it becomes enforceable policy: identity, budgets, scoped credentials, MCP tool limits, audit, revocation, and evidence before agents act.
+            High-level AI governance only matters when it becomes enforceable policy: identity, budgets, scoped credentials, MCP tool limits, revocation, and Evidence Pack proof before agents act.
           </p>
           <div className="grid gap-4 md:grid-cols-2">
             {[
               ['/agent-api-key-risk-assessment', 'Agent API key risk assessment', 'Find static-key blast radius before autonomous agents inherit unlimited API access.'],
-              ['/economic-firewall-readiness-grader', 'Agent governance readiness grader', 'Score identity, budgets, MCP governance, revocation, delegation, audit, routing, and rail-aware readiness.'],
-              ['/agent-spend-policy-template', 'Agent spend policy template', 'Generate YAML/JSON policy for per-agent budgets, MCP caps, delegation, revocation, and audit.'],
+              ['/economic-firewall-readiness-grader', 'Agent governance readiness grader', 'Score identity, budgets, MCP governance, revocation, delegation, Evidence Pack proof, routing, and rail-aware readiness.'],
+              ['/agent-spend-policy-template', 'Agent spend policy template', 'Generate YAML/JSON policy for per-agent budgets, MCP caps, delegation, revocation, and Evidence Pack fields.'],
               ['/mcp-cost-control', 'MCP cost control', 'Treat MCP tool calls as governed events with per-tool prices, caps, denial reasons, and evidence.'],
             ].map(([href, title, body]) => (
               <Link key={href} href={href} className="rounded-xl border border-gray-800 bg-black/50 p-5 transition hover:border-cyan-500/50 hover:bg-cyan-950/20">
@@ -826,7 +826,7 @@ export SATGATE_TOKEN=$TOKEN
               ['What is Policy-to-Proof governance for AI agents?', 'Policy-to-Proof governance sits in the request path, applies scopes, budgets, delegation rules, and revocation before an agent reaches an upstream API, model, or MCP tool, then preserves Evidence Packs so the decision can be verified later.'],
               ['How should enterprises govern MCP tool usage?', 'Enterprises should govern MCP tools with per-tool budgets, scoped capability tokens, task and tenant attribution, Evidence Packs, revocation, and hard request-path policy decisions. Rate limits and dashboards are useful, but they do not replace enforcement before tool calls execute.'],
               ['What is the difference between AI governance and AI agent governance?', 'AI governance usually covers model risk, data policy, compliance, and human review. AI agent governance adds request-path controls for autonomous actions: scopes, budgets, delegated authority, revocation, denial reasons, spend attribution, and proof before APIs or MCP tools execute.'],
-              ['Is SatGate tied to x402, L402, AgentCore Payments, or Pay.sh?', 'No. x402, L402, AgentCore Payments, Pay.sh, and related rails make it easier for agents to call paid services. SatGate is protocol-independent: it records the requesting agent, allowed action, policy basis, spend context, and evidence needed for audit, review, and control — payment or not.'],
+              ['Is SatGate tied to x402, L402, AgentCore Payments, or Pay.sh?', 'No. x402, L402, AgentCore Payments, Pay.sh, and related rails make it easier for agents to call paid services. SatGate is protocol-independent: it records the requesting agent, allowed action, policy basis, spend context, and Evidence Pack receipts needed for accountability and control — payment or not.'],
             ].map(([question, answer]) => (
               <div key={question} className="border-t border-gray-800 pt-6 first:border-t-0 first:pt-0">
                 <h3 className="mb-2 text-xl font-bold text-white">{question}</h3>

--- a/satgate-landing/app/economic-firewall/page.tsx
+++ b/satgate-landing/app/economic-firewall/page.tsx
@@ -188,16 +188,22 @@ export default function EconomicFirewallPage() {
             Economic Firewall for AI Agents
           </h1>
 
-          <p className="text-xl md:text-2xl text-gray-300 max-w-3xl leading-relaxed mb-10">
+          <p className="text-xl md:text-2xl text-gray-300 max-w-3xl leading-relaxed mb-6">
             An economic firewall controls what autonomous agents can access, how much they can spend, what they can delegate, and which Evidence Pack artifacts are captured before each API request reaches the upstream provider.
+          </p>
+          <p className="max-w-3xl rounded-2xl border border-purple-900/50 bg-purple-950/20 p-5 text-lg leading-relaxed text-purple-100 mb-10">
+            Think of this as the legacy SEO/category term. The current SatGate product narrative is Policy-to-Proof governance: authority before execution, Observe/Control/Prove, and Evidence Pack receipts after every agent action.
           </p>
 
           <div className="flex flex-col sm:flex-row gap-4">
-            <Link href="/economic-firewall-readiness-grader" className="inline-flex items-center justify-center gap-2 rounded-lg bg-white text-black px-6 py-3 font-bold hover:bg-gray-200 transition">
-              Grade your readiness <ArrowRight size={18} />
+            <Link href="/policy-to-proof" className="inline-flex items-center justify-center gap-2 rounded-lg bg-white text-black px-6 py-3 font-bold hover:bg-gray-200 transition">
+              See Policy-to-Proof <ArrowRight size={18} />
             </Link>
-            <Link href="/blog/what-is-an-economic-firewall" className="inline-flex items-center justify-center gap-2 rounded-lg border border-gray-700 px-6 py-3 font-bold text-white hover:border-cyan-500 transition">
-              Read the deep-dive
+            <Link href="/govern" className="inline-flex items-center justify-center gap-2 rounded-lg border border-gray-700 px-6 py-3 font-bold text-white hover:border-cyan-500 transition">
+              Govern AI agents
+            </Link>
+            <Link href="/mcp-governance" className="inline-flex items-center justify-center gap-2 rounded-lg border border-gray-700 px-6 py-3 font-bold text-white hover:border-cyan-500 transition">
+              Govern MCP tools
             </Link>
           </div>
         </div>

--- a/satgate-landing/app/govern/page.tsx
+++ b/satgate-landing/app/govern/page.tsx
@@ -4,7 +4,7 @@ import GovernClient from "../components/GovernClient";
 export const metadata: Metadata = {
   title: "AI Agent Governance: Policy-to-Proof",
   description:
-    "AI agent governance from Policy-to-Proof: scope authority, enforce request-path policy, and export Evidence Pack receipts for every agent decision.",
+    "Govern AI agents with SatGate: authority before execution, Observe/Control/Prove, MCP governance, paid-rail context, and Evidence Packs.",
   alternates: {
     canonical: "https://satgate.io/govern",
   },
@@ -22,7 +22,7 @@ export const metadata: Metadata = {
   openGraph: {
     title: "AI Agent Governance: Policy-to-Proof",
     description:
-      "Give enterprise agents bounded economic authority with request-path enforcement and Evidence Pack proof.",
+      "Govern enterprise agents with authority before execution, Observe/Control/Prove, MCP governance, paid-rail context, and Evidence Packs.",
     url: "https://satgate.io/govern",
     type: "website",
   },
@@ -30,7 +30,7 @@ export const metadata: Metadata = {
     card: "summary_large_image",
     title: "AI Agent Governance: Policy-to-Proof",
     description:
-      "Delegate bounded authority, enforce policy, and export Policy-to-Proof evidence for enterprise AI agents with SatGate.",
+      "AI agent governance with authority before execution, Observe/Control/Prove, MCP governance, and Evidence Pack proof.",
   },
 };
 
@@ -40,7 +40,7 @@ const webPageSchema = {
   name: "AI Agent Governance Platform",
   description: metadata.description,
   url: "https://satgate.io/govern",
-  dateModified: "2026-05-18",
+  dateModified: "2026-05-24",
   isPartOf: { "@type": "WebSite", name: "SatGate", url: "https://satgate.io" },
   about: [
     { "@type": "Thing", name: "AI agent governance" },
@@ -61,7 +61,7 @@ const faqSchema = {
       name: "What is AI agent governance?",
       acceptedAnswer: {
         "@type": "Answer",
-        text: "AI agent governance is the set of controls that determines which agents can call which APIs, tools, and models; how much they can spend; what authority they can delegate; and when access must be revoked. For autonomous agents, governance needs request-path enforcement, not just logs and dashboards.",
+        text: "AI agent governance is the set of controls that determines which agents can call which APIs, tools, and models; how much they can spend; what authority they can delegate; and when access must be revoked. For autonomous agents, governance needs request-path enforcement, not just logs, dashboards, and postmortems.",
       },
     },
     {
@@ -93,7 +93,7 @@ const faqSchema = {
       name: "Is SatGate tied to x402, L402, AgentCore Payments, or Pay.sh?",
       acceptedAnswer: {
         "@type": "Answer",
-        text: "No. x402, L402, AgentCore Payments, Pay.sh, and related rails make it easier for agents to call paid services. SatGate is protocol-independent: it records the requesting agent, allowed action, policy basis, spend context, and evidence needed for Evidence Pack review, accountability, and control — payment or not.",
+        text: "No. x402, L402, AgentCore Payments, Pay.sh, and related rails make it easier for agents to call paid services. SatGate is protocol-independent: it records the requesting agent, allowed action, policy basis, spend context, and Evidence Pack receipts needed for accountability and control — payment or not.",
       },
     },
   ],

--- a/satgate-landing/app/llm-cost-monitoring/page.tsx
+++ b/satgate-landing/app/llm-cost-monitoring/page.tsx
@@ -88,7 +88,7 @@ export default function LlmCostMonitoringPage() {
         name: 'How do you turn LLM cost monitoring signals into controls?',
         acceptedAnswer: {
           '@type': 'Answer',
-          text: 'Convert monitoring signals into policy objects: per-agent and per-route budgets, MCP tool caps, model-routing rules, scoped capability tokens, revocation triggers, and audit requirements enforced before upstream calls execute.',
+          text: 'Convert monitoring signals into policy objects: per-agent and per-route budgets, MCP tool caps, model-routing rules, scoped capability tokens, revocation triggers, and Evidence Pack requirements enforced before upstream calls execute.',
         },
       },
     ],
@@ -208,10 +208,10 @@ export default function LlmCostMonitoringPage() {
           </p>
           <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
             {[
-              ['/agent-spend-policy-template', 'Agent spend policy', 'Budgets, delegation, revocation, MCP tool caps, and audit fields.'],
+              ['/agent-spend-policy-template', 'Agent spend policy', 'Budgets, delegation, revocation, MCP tool caps, and Evidence Pack fields.'],
               ['/mcp-tool-cost-policy-generator', 'MCP tool cost policy', 'Per-tool prices, risk tiers, limits, and deny behavior.'],
               ['/revocable-capability-token-policy-template', 'Capability-token policy', 'Scoped, expiring, revocable agent authority with budget caveats.'],
-              ['/economic-firewall-readiness-grader', 'Readiness grader', 'Find gaps across identity, budgets, routing, revocation, audit, and Charge.'],
+              ['/economic-firewall-readiness-grader', 'Readiness grader', 'Find gaps across identity, budgets, routing, revocation, Evidence Pack proof, and paid-rail context.'],
             ].map(([href, title, body]) => (
               <Link key={href} href={href} className="rounded-xl border border-gray-800 bg-black p-5 transition hover:border-purple-500/50 hover:bg-purple-950/20">
                 <h3 className="mb-2 font-bold text-white">{title}</h3>
@@ -241,7 +241,7 @@ export default function LlmCostMonitoringPage() {
             </div>
             <div className="rounded-xl border border-gray-800 bg-gray-950 p-6">
               <h3 className="mb-2 text-xl font-bold text-white">How do you turn LLM cost monitoring signals into controls?</h3>
-              <p className="leading-relaxed text-gray-400">Convert monitoring signals into policy objects: per-agent and per-route budgets, MCP tool caps, model-routing rules, scoped capability tokens, revocation triggers, and audit requirements enforced before upstream calls execute.</p>
+              <p className="leading-relaxed text-gray-400">Convert monitoring signals into policy objects: per-agent and per-route budgets, MCP tool caps, model-routing rules, scoped capability tokens, revocation triggers, and Evidence Pack requirements enforced before upstream calls execute.</p>
             </div>
           </div>
         </div>
@@ -260,7 +260,7 @@ export default function LlmCostMonitoringPage() {
             </Link>
             <Link href="/agent-spend-policy-template" className="rounded-2xl border border-gray-800 bg-black/70 p-6 transition hover:border-purple-600">
               <h3 className="mb-2 text-lg font-bold text-white">Agent spend policy →</h3>
-              <p className="text-gray-400">Turn monitoring signals into budget, revocation, and audit policy.</p>
+              <p className="text-gray-400">Turn monitoring signals into budget, revocation, and Evidence Pack policy.</p>
             </Link>
           </div>
         </div>

--- a/satgate-landing/app/openai-budget-policy-generator/page.tsx
+++ b/satgate-landing/app/openai-budget-policy-generator/page.tsx
@@ -172,20 +172,20 @@ export default function OpenAiBudgetPolicyGeneratorPage() {
         <div className="absolute inset-0 bg-[radial-gradient(circle_at_25%_0%,rgba(34,211,238,0.18),transparent_30%),radial-gradient(circle_at_80%_10%,rgba(168,85,247,0.14),transparent_32%)]" />
         <div className="relative mx-auto max-w-6xl px-6 py-24">
           <div className="mb-8 inline-flex items-center gap-2 rounded-full border border-cyan-500/30 bg-cyan-950/30 px-4 py-2 text-sm text-cyan-200">
-            <ClipboardList size={16} /> OpenAI spend policy generator
+            <ClipboardList size={16} /> OpenAI authority policy generator
           </div>
           <h1 className="mb-8 max-w-5xl text-5xl font-extrabold tracking-tight md:text-7xl">
             OpenAI API Budget Limit Generator
           </h1>
           <p className="mb-10 max-w-4xl text-xl leading-relaxed text-gray-300 md:text-2xl">
-            Generate a request-path budget policy for AI agents calling OpenAI: per-request caps, daily spend limits, session budgets, model routing, revocation, and Evidence Pack receipts.
+            Generate request-path authority policy for AI agents calling OpenAI: per-request caps, daily spend limits, session budgets, model routing, revocation, and Evidence Pack receipts.
           </p>
           <div className="flex flex-col gap-4 sm:flex-row">
             <Link href="/blog/how-to-add-budget-limits-to-openai-api-calls" className="inline-flex items-center justify-center gap-2 rounded-lg bg-white px-6 py-3 font-bold text-black transition hover:bg-gray-200">
               Read the OpenAI budget guide <ArrowRight size={18} />
             </Link>
-            <Link href="/ai-agent-cost-control" className="inline-flex items-center justify-center gap-2 rounded-lg border border-gray-700 px-6 py-3 font-bold text-white transition hover:border-cyan-500">
-              See agent cost control
+            <Link href="/policy-to-proof" className="inline-flex items-center justify-center gap-2 rounded-lg border border-gray-700 px-6 py-3 font-bold text-white transition hover:border-cyan-500">
+              See Policy-to-Proof governance
             </Link>
           </div>
         </div>

--- a/satgate-landing/app/sitemap.ts
+++ b/satgate-landing/app/sitemap.ts
@@ -42,7 +42,6 @@ const staticRoutes: SitemapEntry[] = [
   { path: '/capability-lifecycle-demo', lastModified: '2026-05-10', changeFrequency: 'weekly', priority: 0.9 },
   { path: '/l402-agent-payments', lastModified: '2026-05-03', changeFrequency: 'weekly', priority: 0.9 },
   { path: '/paid-agent-payments', lastModified: '2026-05-10', changeFrequency: 'weekly', priority: 0.9 },
-  { path: '/robot-customer-payments', lastModified: '2026-05-03', changeFrequency: 'weekly', priority: 0.6 },
   { path: '/satgate-for-cursor', lastModified: '2026-05-04', changeFrequency: 'monthly', priority: 0.8 },
   { path: '/satgate-for-claude-code', lastModified: '2026-05-04', changeFrequency: 'monthly', priority: 0.8 },
   { path: '/satgate-for-claude-desktop', lastModified: '2026-05-03', changeFrequency: 'monthly', priority: 0.8 },

--- a/satgate-landing/seo/reports/opportunities.json
+++ b/satgate-landing/seo/reports/opportunities.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-05-24T15:27:40.211021Z",
+  "generatedAt": "2026-05-25T14:23:18.275897Z",
   "items": [
     {
       "path": "/blog/how-to-add-budget-limits-to-openai-api-calls",

--- a/satgate-landing/seo/reports/opportunities.md
+++ b/satgate-landing/seo/reports/opportunities.md
@@ -1,6 +1,6 @@
 # SatGate SEO Machine Report
 
-Generated: 2026-05-24T15:27:40.211858Z
+Generated: 2026-05-25T14:23:18.277119Z
 
 ## Ranked opportunities
 

--- a/satgate-landing/seo/reports/page-audit.json
+++ b/satgate-landing/seo/reports/page-audit.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-05-24T15:27:40.211423Z",
+  "generatedAt": "2026-05-25T14:23:18.276329Z",
   "items": [
     {
       "path": "/blog/ai-spend-governance",
@@ -268,8 +268,8 @@
       "exists": true,
       "title": "AI Agent Governance: Policy-to-Proof",
       "titleLength": 36,
-      "metaDescription": "AI agent governance from Policy-to-Proof: scope authority, enforce request-path policy, and export Evidence Pack receipts for every agent decision.",
-      "metaDescriptionLength": 147,
+      "metaDescription": "Govern AI agents with SatGate: authority before execution, Observe/Control/Prove, MCP governance, paid-rail context, and Evidence Packs.",
+      "metaDescriptionLength": 136,
       "canonical": "/govern",
       "h1": [
         "Govern what agents can do. Prove every decision."
@@ -314,7 +314,7 @@
         "WebPage",
         "WebSite"
       ],
-      "wordCount": 1692,
+      "wordCount": 1690,
       "hasObserveControlProve": true,
       "hasEvidencePack": true,
       "hasFAQ": true,

--- a/satgate-landing/seo/reports/recommendations.json
+++ b/satgate-landing/seo/reports/recommendations.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-05-24T15:27:40.211706Z",
+  "generatedAt": "2026-05-25T14:23:18.276970Z",
   "items": [
     {
       "path": "/blog/how-to-add-budget-limits-to-openai-api-calls",

--- a/satgate-landing/seo/reports/recommendations.md
+++ b/satgate-landing/seo/reports/recommendations.md
@@ -1,6 +1,6 @@
 # SatGate SEO Machine Report
 
-Generated: 2026-05-24T15:27:40.211858Z
+Generated: 2026-05-25T14:23:18.277119Z
 
 ## Ranked opportunities
 


### PR DESCRIPTION
## Summary
- tightens `/govern` title/meta/social/schema copy around Policy-to-Proof, authority before execution, Observe/Control/Prove, MCP governance, paid-rail context, and Evidence Packs
- removes `/robot-customer-payments` from the sitemap while preserving the route/redirect for legacy traffic
- replaces stale audit/Charge phrasing on priority governance, monitoring, OpenAI budget, and economic-firewall archive pages
- contains the economic-firewall archive as legacy/category SEO and routes readers toward `/policy-to-proof`, `/govern`, and `/mcp-governance`
- refreshes checked-in SEO reports after `seo_machine.py --check`

## Verification
- `python3 scripts/seo_machine.py --check`
- `npm run build`
- rendered local probes on `:3108` for `/govern`, `/economic-firewall`, `/blog/what-is-an-economic-firewall`, `/openai-budget-policy-generator`, `/llm-cost-monitoring`, and `/sitemap.xml`
- stale-term sweep across `app`, `public`, and `seo` for Charge/robot-customer/audit-trail/spend-first terms
