### PR TITLE
fix(seo): complete weekly telemetry recommendations

### DIFF
--- a/satgate-landing/SEO-CONTENT-CALENDAR.md
+++ b/satgate-landing/SEO-CONTENT-CALENDAR.md
@@ -30,7 +30,7 @@
 - [ ] "API cost attribution by team and department"
 - [ ] "How to monetize your API with Lightning payments"
 - [ ] "Prevent AI agent runaway costs"
-- [ ] "AI agent audit trail compliance"
+- [ ] "AI agent Evidence Pack compliance"
 - [ ] "Compare API gateways for AI workloads"
 
 ### Thought Leadership
@@ -59,7 +59,7 @@
 - 2026-04-02: "L402 Protocol Explained"
 - 2026-04-02: "HTTP 402 Payment Required: The Dormant Status Code That Powers the Agent Economy" (also on dev.to)
 - 2026-04-03: "Zero Trust for AI Agents: Why Identity-Based Security Collapses When Machines Call the Shots" (also on dev.to)
-- 2026-04-09: "Cursor MCP Proxy Setup Guide: Add Budget Controls and Audit Trails to Your Tools"
+- 2026-04-09: "Cursor MCP Proxy Setup Guide: Add Budget Controls and Evidence Packs to Your Tools"
 
 ## dev.to Account
 - Handle: @mattdeangit

--- a/satgate-landing/app/.well-known/satgate/route.ts
+++ b/satgate-landing/app/.well-known/satgate/route.ts
@@ -6,7 +6,7 @@ const metadata = {
   issuer: {
     name: "SatGate",
     issuer_id: "https://satgate.io",
-    product: "Economic Firewall for AI agents",
+    product: "Policy-to-Proof governance for enterprise agents",
     contact: "contact@satgate.io",
     key_discovery: {
       method: "jwks_uri",

--- a/satgate-landing/app/agent-api-governance/page.tsx
+++ b/satgate-landing/app/agent-api-governance/page.tsx
@@ -388,7 +388,7 @@ evidence:
               ['/policy-to-proof', 'Policy-to-Proof', 'See how agent API decisions become Evidence Pack proof.'],
               ['/blog/macaroon-tokens-vs-api-keys', 'Macaroons vs API keys', 'Why attenuated capabilities beat static API keys for agents.'],
               ['/agent-control-plane', 'Agent control plane', 'Govern enterprise agent authority, delegation lineage, spend, audit, and revocation.'],
-              ['/economic-firewall', 'Economic firewall', 'The request-path control layer for agent access, spend, and proof.'],
+              ['/evidence-pack-demo', 'Evidence Pack demo', 'Show how allow, deny, budget, delegation, and revocation decisions become receipts.'],
               ['/mcp-governance', 'MCP governance', 'Apply authority, budgets, revocation, and Evidence Pack receipts to agent tool calls.'],
             ].map(([href, title, body]) => (
               <Link key={href} href={href} className="rounded-xl border border-gray-800 bg-gray-950 p-5 transition hover:border-yellow-500/50 hover:bg-yellow-950/10">

--- a/satgate-landing/app/agent-authority-layer/page.tsx
+++ b/satgate-landing/app/agent-authority-layer/page.tsx
@@ -293,8 +293,8 @@ export default function AgentAuthorityLayerPage() {
             <Link href="/build" className="inline-flex items-center justify-center gap-2 rounded-lg bg-white px-6 py-3 font-bold text-black transition hover:bg-gray-200">
               Build with SatGate <ArrowRight size={18} />
             </Link>
-            <Link href="/economic-firewall" className="inline-flex items-center justify-center gap-2 rounded-lg border border-gray-700 px-6 py-3 font-bold text-white transition hover:border-cyan-500">
-              See the defensive frame
+            <Link href="/policy-to-proof" className="inline-flex items-center justify-center gap-2 rounded-lg border border-gray-700 px-6 py-3 font-bold text-white transition hover:border-cyan-500">
+              See Policy-to-Proof
             </Link>
           </div>
         </div>

--- a/satgate-landing/app/blog/ai-agent-api-cost-control/page.tsx
+++ b/satgate-landing/app/blog/ai-agent-api-cost-control/page.tsx
@@ -173,7 +173,7 @@ export default function AiAgentApiCostControlPage() {
           <h2 className="text-2xl font-bold text-white mt-12 mb-4">Economic firewalls: budget enforcement at the gateway layer</h2>
 
           <p className="text-gray-300 leading-relaxed">
-            An <Link href="/economic-firewall" className="text-cyan-400 hover:text-cyan-300">economic firewall</Link> is the missing layer between autonomous agents and billable APIs. It sits inline, checks the policy attached to the agent capability, and decides whether the request should be observed, controlled, charged, routed, or blocked.
+            An <Link href="/govern" className="text-cyan-400 hover:text-cyan-300">AI agent governance layer</Link> is the missing layer between autonomous agents and billable APIs. It sits inline, checks the policy attached to the agent capability, and decides whether the request should be observed, controlled, proved, routed, or blocked.
           </p>
 
           <p className="text-gray-300 leading-relaxed">

--- a/satgate-landing/app/blog/ai-spend-governance/page.tsx
+++ b/satgate-landing/app/blog/ai-spend-governance/page.tsx
@@ -297,8 +297,8 @@ export default function AiSpendGovernanceBlogPage() {
               SatGate is Economic Firewall infrastructure for enterprise agents. It gives teams a Policy-to-Proof control layer for AI, API, MCP, and paid-tool usage: observe the call, control the policy before execution, and prove what happened afterward with Evidence Pack receipts.
             </p>
             <div className="mt-6 flex flex-col sm:flex-row gap-3">
-              <Link href="/economic-firewall" className="inline-flex items-center justify-center rounded-lg bg-cyan-400 px-5 py-3 font-bold text-black transition hover:bg-cyan-300">
-                Learn about Economic Firewalls
+              <Link href="/policy-to-proof" className="inline-flex items-center justify-center rounded-lg bg-cyan-400 px-5 py-3 font-bold text-black transition hover:bg-cyan-300">
+                See Policy-to-Proof governance
               </Link>
               <Link href="/policy-to-proof" className="inline-flex items-center justify-center rounded-lg border border-gray-700 px-5 py-3 font-bold text-white transition hover:border-cyan-500">
                 See Policy-to-Proof
@@ -310,7 +310,7 @@ export default function AiSpendGovernanceBlogPage() {
           <ul className="text-gray-300 space-y-2">
             <li><Link href="/blog/llm-cost-management" className="text-cyan-400 hover:text-cyan-300 underline">LLM cost management: dashboards vs real-time budget enforcement</Link></li>
             <li><Link href="/blog/ai-agent-spending-limits" className="text-cyan-400 hover:text-cyan-300 underline">AI agent spending limits: hard budgets by agent, tool, and workflow</Link></li>
-            <li><Link href="/blog/the-enterprise-adoption-playbook-observe-control-charge" className="text-cyan-400 hover:text-cyan-300 underline">The enterprise adoption playbook: Observe, Control, Prove</Link></li>
+            <li><Link href="/blog/the-enterprise-adoption-playbook-observe-control-prove" className="text-cyan-400 hover:text-cyan-300 underline">The enterprise adoption playbook: Observe, Control, Prove</Link></li>
             <li><Link href="/compare/langsmith-helicone-datadog" className="text-cyan-400 hover:text-cyan-300 underline">LLM observability vs agent control</Link></li>
           </ul>
         </article>

--- a/satgate-landing/app/blog/api-gateway-for-ai-agents/page.tsx
+++ b/satgate-landing/app/blog/api-gateway-for-ai-agents/page.tsx
@@ -4,7 +4,7 @@ import { ArrowLeft, Calendar, Clock } from 'lucide-react';
 
 export const metadata = {
   title: "API Gateway for AI Agents: Control Tool and API Access",
-  description: "Learn how AI agent gateways enforce authority before execution with Observe/Control/Prove, budgets, MCP governance, and Evidence Packs.",
+  description: "Learn how AI agent gateways enforce authority before execution with Observe/Control/Prove, budgets, MCP governance, Evidence Packs, and paid rails.",
   alternates: { canonical: 'https://satgate.io/blog/api-gateway-for-ai-agents' },
   keywords: ['API gateway for AI agents', 'AI agent gateway', 'API gateway comparison', 'agent economy gateway', 'AI API management', 'economic firewall gateway'],
   openGraph: {

--- a/satgate-landing/app/blog/http-402-payment-required-use-cases/page.tsx
+++ b/satgate-landing/app/blog/http-402-payment-required-use-cases/page.tsx
@@ -2,8 +2,8 @@ import Link from 'next/link';
 import { ArrowLeft, Calendar, Clock } from 'lucide-react';
 
 export const metadata = {
-  title: "HTTP 402 Payment Required: Meaning, Use Cases, and AI Agents",
-  description: "HTTP 402 Payment Required explained: why it was reserved, how L402 works for paid APIs, and how agents need budget authority before paid access.",
+  title: "HTTP 402 Payment Required: API and Agent Use Cases",
+  description: "HTTP 402 and L402 are paid-rail context. SatGate governs authority before execution and preserves Evidence Packs.",
   alternates: { canonical: 'https://satgate.io/blog/http-402-payment-required-use-cases' },
   keywords: ['HTTP 402 Payment Required', 'HTTP 402 use cases', 'API payments', 'machine-to-machine payments', 'L402 protocol', 'AI agent payments', 'API monetization', 'pay-per-call API'],
   openGraph: {
@@ -115,7 +115,7 @@ export default function Http402PaymentRequiredUseCasesBlogPage() {
             <p className="text-gray-300">HTTP 402 means access is available after payment. For AI agents, 402 and L402 are paid-rail context: authority, budget, and policy should be checked before value moves, with Evidence Pack proof after the request.</p>
           </div>
           <div className="mb-6 flex flex-col gap-3 sm:flex-row">
-            <Link href="/partners/rails" className="inline-flex items-center justify-center rounded-lg bg-white px-5 py-3 text-sm font-bold text-black transition hover:bg-gray-200">See paid-rail governance</Link>
+            <Link href="/govern" className="inline-flex items-center justify-center rounded-lg bg-white px-5 py-3 text-sm font-bold text-black transition hover:bg-gray-200">Govern paid agent access</Link>
             <Link href="/policy-to-proof" className="inline-flex items-center justify-center rounded-lg border border-gray-700 px-5 py-3 text-sm font-bold text-white transition hover:border-cyan-500">See Policy-to-Proof</Link>
           </div>
           

--- a/satgate-landing/app/blog/page.tsx
+++ b/satgate-landing/app/blog/page.tsx
@@ -139,7 +139,7 @@ const posts = [
     tags: ['Security', 'Economic Firewall', 'Adversarial AI', 'Macaroons'],
   },
   {
-    slug: 'the-enterprise-adoption-playbook-observe-control-charge',
+    slug: 'the-enterprise-adoption-playbook-observe-control-prove',
     title: 'The Enterprise Adoption Playbook: Observe, Control, Prove',
     description: 'Observe, Control, Prove is an enterprise change management strategy for adopting economic governance incrementally, building trust at each stage.',
     date: '2026-03-20',

--- a/satgate-landing/app/blog/the-enterprise-adoption-playbook-observe-control-prove/page.tsx
+++ b/satgate-landing/app/blog/the-enterprise-adoption-playbook-observe-control-prove/page.tsx
@@ -3,11 +3,11 @@ import { ArrowLeft, Calendar, Clock, Eye, Shield, Zap, CheckCircle, ArrowRight }
 
 export const metadata = {
   title: 'Enterprise Adoption Playbook: Observe, Control, Prove',
-  description: 'Observe, Control, Prove is an enterprise change management strategy. Learn how to adopt economic governance for AI agents incrementally, building trust at each stage.',
+  description: 'Observe, Control, Prove is the enterprise rollout path for Policy-to-Proof governance: start with visibility, add controls, then preserve Evidence Pack proof.',
   openGraph: {
     title: 'The Enterprise Adoption Playbook: Observe, Control, Prove',
-    description: 'A three-stage framework for adopting economic governance for AI agents — without breaking anything along the way.',
-    url: 'https://satgate.io/blog/the-enterprise-adoption-playbook-observe-control-charge',
+    description: 'A three-stage framework for adopting Policy-to-Proof governance for AI agents — without breaking anything along the way.',
+    url: 'https://satgate.io/blog/the-enterprise-adoption-playbook-observe-control-prove',
     type: 'article',
 
     publishedTime: '2026-03-20T00:00:00Z',
@@ -15,10 +15,10 @@ export const metadata = {
   twitter: {
     card: 'summary_large_image',
     title: 'The Enterprise Adoption Playbook: Observe, Control, Prove',
-    description: 'A three-stage framework for adopting economic governance for AI agents — without breaking anything along the way.',
+    description: 'A three-stage framework for adopting Policy-to-Proof governance for AI agents — without breaking anything along the way.',
   },
   keywords: ['AI agent governance', 'enterprise AI adoption', 'economic firewall', 'AI cost control', 'AI agent budget enforcement', 'L402', 'macaroons', 'MCP governance', 'agent economy', 'AI change management'],
-  alternates: { canonical: 'https://satgate.io/blog/the-enterprise-adoption-playbook-observe-control-charge' },
+  alternates: { canonical: 'https://satgate.io/blog/the-enterprise-adoption-playbook-observe-control-prove' },
 };
 
 export default function EnterpriseAdoptionPlaybookPage() {
@@ -26,17 +26,17 @@ export default function EnterpriseAdoptionPlaybookPage() {
     '@context': 'https://schema.org',
     '@type': 'TechArticle',
     headline: 'The Enterprise Adoption Playbook: Observe, Control, Prove',
-    description: 'A three-stage framework for adopting economic governance for AI agents: observe spend, control internal agent budgets, then charge external paid agents.',
-    url: 'https://satgate.io/blog/the-enterprise-adoption-playbook-observe-control-charge',
+    description: 'A three-stage framework for adopting Policy-to-Proof governance for AI agents: observe agent activity, control authority before execution, then prove every decision with Evidence Packs.',
+    url: 'https://satgate.io/blog/the-enterprise-adoption-playbook-observe-control-prove',
     datePublished: '2026-03-20',
-    dateModified: '2026-05-02',
+    dateModified: '2026-06-01',
     author: { '@type': 'Organization', name: 'SatGate' },
     publisher: { '@type': 'Organization', name: 'SatGate', url: 'https://satgate.io' },
     about: [
-      { '@type': 'Thing', name: 'economic governance for AI agents' },
+      { '@type': 'Thing', name: 'Policy-to-Proof governance for AI agents' },
       { '@type': 'Thing', name: 'Observe Control Prove' },
       { '@type': 'Thing', name: 'AI agent budget enforcement' },
-      { '@type': 'Thing', name: 'paid-agent API monetization' },
+      { '@type': 'Thing', name: 'Policy-to-Proof governance' },
     ],
   };
 
@@ -49,7 +49,7 @@ export default function EnterpriseAdoptionPlaybookPage() {
         name: 'What are Observe, Control, and Prove in AI agent governance?',
         acceptedAnswer: {
           '@type': 'Answer',
-          text: 'Observe tracks agent usage and costs without blocking. Control enforces budgets and scoped policy for internal agents. Charge monetizes external agent access with paid-rail context.',
+          text: 'Observe tracks agent usage and costs without blocking. Control enforces budgets and scoped policy for internal agents. Prove preserves Evidence Pack receipts for allow, deny, budget, delegation, and paid-rail decisions.',
         },
       },
       {
@@ -62,7 +62,7 @@ export default function EnterpriseAdoptionPlaybookPage() {
       },
       {
         '@type': 'Question',
-        name: 'Is Charge the same as internal budget enforcement?',
+        name: 'Is Prove the same as internal budget enforcement?',
         acceptedAnswer: {
           '@type': 'Answer',
           text: 'No. Internal budget enforcement controls spend for agents you own. Paid-rail governance is the monetization path for external delegated agents consuming your APIs under policy.',
@@ -208,32 +208,32 @@ export default function EnterpriseAdoptionPlaybookPage() {
             This transforms governance from an IT oversight exercise into a hard business constraint. The budget isn&apos;t a guideline — it&apos;s a wall.
           </p>
 
-          {/* Stage 3: Charge */}
+          {/* Stage 3: Prove */}
           <div className="my-12 p-6 bg-gradient-to-r from-yellow-900/20 to-yellow-800/10 border border-yellow-500/20 rounded-xl">
             <div className="flex items-center gap-3 mb-4">
               <Zap className="text-yellow-400" size={28} />
-              <h2 className="text-2xl font-bold text-white m-0">Stage 3: Charge</h2>
-              <span className="px-3 py-1 rounded-full bg-yellow-900/40 border border-yellow-500/30 text-yellow-300 text-sm font-mono">L402 Mode</span>
+              <h2 className="text-2xl font-bold text-white m-0">Stage 3: Prove</h2>
+              <span className="px-3 py-1 rounded-full bg-yellow-900/40 border border-yellow-500/30 text-yellow-300 text-sm font-mono">Evidence Pack Mode</span>
             </div>
-            <p className="text-yellow-200 text-lg font-medium mb-0">Autonomous micropayments. Payment receipt is the auth token.</p>
+            <p className="text-yellow-200 text-lg font-medium mb-0">Every allow, deny, budget, delegation, and paid-rail decision leaves a receipt.</p>
           </div>
 
           <p className="text-gray-300 leading-relaxed">
-            L402 mode is a fundamentally different paradigm — and an important clarification: it&apos;s not necessarily sequential with Control. While Observe → Control is a linear progression for internal governance, Charge operates as a parallel path designed for a different problem: API monetization.
+            Prove is the stage where governance stops being a dashboard claim and becomes an artifact. SatGate preserves the policy basis, requesting agent, delegated scope, budget state, route, paid-rail context when present, and final decision as an Evidence Pack receipt that finance, security, and compliance can inspect later.
           </p>
           <p className="text-gray-300 leading-relaxed">
-            In L402 mode, SatGate enables real-time, per-transaction settlement via the Lightning Network. External agents discover your API, negotiate the price, and pay — all in a single HTTP flow. No account creation. No API key provisioning. No billing cycles or invoice reconciliation. The payment receipt <em>is</em> the authentication token.
+            Paid rails such as L402 can still matter, but they are not the center of the framework. They are one context SatGate can govern before value moves. The product job is broader: prove why an autonomous agent was allowed, denied, downgraded, routed, or required to seek approval before execution.
           </p>
           <p className="text-gray-300 leading-relaxed">
-            This unlocks pricing models that were previously impossible at scale:
+            This unlocks proof models that traditional API governance rarely captures:
           </p>
           <ul className="text-gray-300 space-y-2">
-            <li><strong>Pay-per-token:</strong> Charge downstream consumers based on actual LLM token consumption, not flat monthly tiers.</li>
-            <li><strong>Pay-per-call:</strong> Every API invocation carries its own economic settlement. No prepaid credits, no overages, no true-up at month-end.</li>
-            <li><strong>Dynamic pricing:</strong> Adjust prices based on demand, model costs, or priority tiers — in real time.</li>
+            <li><strong>Budget receipts:</strong> show which cap, tenant, workflow, or delegated token authorized the spend.</li>
+            <li><strong>Delegation receipts:</strong> preserve parent/child authority, caveats, expiration, and revocation state.</li>
+            <li><strong>Paid-rail receipts:</strong> record when payment context was checked before access without making payment the product center.</li>
           </ul>
           <p className="text-gray-300 leading-relaxed">
-            The implications for the agent economy are significant. When agents can autonomously discover, evaluate, and pay for services without human intervention, the friction of machine-to-machine commerce drops to near zero. Your API becomes accessible to any agent with a Lightning wallet — which, in the emerging ecosystem, is increasingly all of them.
+            The result is accountability that survives vendor dashboards and postmortem guesswork. You can answer not just what happened, but who had authority, which policy applied, and what proof was preserved when the agent acted.
           </p>
 
           {/* Strategic Benefits */}
@@ -249,7 +249,7 @@ export default function EnterpriseAdoptionPlaybookPage() {
                 <CheckCircle className="text-green-400" size={18} />
                 <h4 className="font-bold text-white m-0">Incremental Trust Building</h4>
               </div>
-              <p className="text-gray-400 text-sm m-0">Each stage produces evidence that justifies the next. Observe proves the need for Control. Control demonstrates the maturity for Charge. You&apos;re not asking leadership to trust a theoretical model — you&apos;re showing them data from your own environment.</p>
+              <p className="text-gray-400 text-sm m-0">Each stage produces evidence that justifies the next. Observe proves the need for Control. Control produces the receipts that make Prove credible. You&apos;re not asking leadership to trust a theoretical model — you&apos;re showing them data and Evidence Packs from your own environment.</p>
             </div>
             <div className="p-4 bg-gray-900 border border-gray-800 rounded-lg">
               <div className="flex items-center gap-2 mb-2">
@@ -270,7 +270,7 @@ export default function EnterpriseAdoptionPlaybookPage() {
                 <CheckCircle className="text-green-400" size={18} />
                 <h4 className="font-bold text-white m-0">Future-Proofing for the Agent Economy</h4>
               </div>
-              <p className="text-gray-400 text-sm m-0">The organizations that figure out economic governance first will be the ones positioned to monetize their APIs in a world where the buyers are machines. L402 readiness isn&apos;t a nice-to-have — it&apos;s the on-ramp to the next generation of API commerce.</p>
+              <p className="text-gray-400 text-sm m-0">The organizations that figure out Policy-to-Proof governance first will be the ones positioned to let agents act with real autonomy. Paid rails can be added where useful, but the durable advantage is proof: every request has authority, policy, decision, and receipt context.</p>
             </div>
           </div>
 
@@ -296,19 +296,19 @@ export default function EnterpriseAdoptionPlaybookPage() {
             <div className="p-6 bg-gradient-to-b from-yellow-900/20 to-transparent border border-yellow-500/20 rounded-xl">
               <h3 className="text-lg font-bold text-yellow-300 mb-3">Their Agents (External)</h3>
               <div className="flex items-center gap-2 mb-4">
-                <span className="text-yellow-300 font-mono text-sm">Charge</span>
+                <span className="text-yellow-300 font-mono text-sm">Prove</span>
               </div>
               <p className="text-gray-400 text-sm">
-                For external agents consuming your APIs, the path is monetization. L402 turns your endpoints into pay-per-use services that any agent can discover and transact with — no onboarding, no contracts, no invoicing.
+                For external agents consuming your APIs, the path is governed proof. Paid rails such as L402 may handle value movement, but SatGate decides whether access is allowed and preserves the Evidence Pack that explains the decision.
               </p>
             </div>
           </div>
 
           <p className="text-gray-300 leading-relaxed">
-            The principle is straightforward: <strong>first, govern your own house. Then open the gates — on your terms.</strong>
+            The principle is straightforward: <strong>first, govern your own house. Then expand access — with proof.</strong>
           </p>
           <p className="text-gray-300 leading-relaxed">
-            Organizations that try to monetize externally before they&apos;ve governed internally are building on a shaky foundation. If you don&apos;t know what your own agents cost, you can&apos;t price your APIs accurately. If you haven&apos;t stress-tested your budget enforcement, you can&apos;t trust it to protect your margins when external traffic scales.
+            Organizations that expose agent-facing APIs before they can prove internal governance are building on a shaky foundation. If you don&apos;t know what your own agents cost, delegate, and touch, you can&apos;t safely govern external agents either. If you haven&apos;t stress-tested budget enforcement and Evidence Pack proof, you can&apos;t trust the same controls when external traffic scales.
           </p>
 
           {/* Getting Started */}
@@ -322,14 +322,14 @@ export default function EnterpriseAdoptionPlaybookPage() {
             <li><strong>Let it run for two weeks.</strong> Collect baseline data. Identify your top spenders, noisiest agents, and most expensive tool calls.</li>
             <li><strong>Present the data to stakeholders.</strong> You now have an evidence-based case for budget enforcement — with specific numbers, not hypotheticals.</li>
             <li><strong>Activate Fiat402 (Control) mode.</strong> Set budgets based on your observed baselines plus a reasonable margin. Monitor for the first week and adjust.</li>
-            <li><strong>Evaluate L402 (Charge) readiness.</strong> If you have APIs that external agents should pay for, the monetization layer is ready when you are.</li>
+            <li><strong>Activate Prove mode.</strong> Preserve Evidence Pack receipts for allow, deny, budget, delegation, revocation, and paid-rail decisions.</li>
           </ol>
 
           <p className="text-gray-300 leading-relaxed mt-6">
             No big bang. No analysis paralysis. No $47,000 surprises on a Monday morning.
           </p>
           <p className="text-gray-300 leading-relaxed">
-            Just a clear path from visibility to control to revenue — at whatever pace your organization is ready for.
+            Just a clear path from visibility to control to proof — at whatever pace your organization is ready for.
           </p>
 
           <section className="not-prose mt-16 rounded-2xl border border-gray-800 bg-gray-950 p-8">
@@ -337,9 +337,9 @@ export default function EnterpriseAdoptionPlaybookPage() {
             <h2 className="mb-6 text-2xl font-bold text-white">Observe, Control, Prove adoption questions</h2>
             <div className="space-y-5">
               {[
-                ['What are Observe, Control, and Prove in AI agent governance?', 'Observe tracks agent usage and costs without blocking. Control enforces budgets and scoped policy for internal agents. Charge monetizes external agent access with paid-rail context.'],
+                ['What are Observe, Control, and Prove in AI agent governance?', 'Observe tracks agent usage and costs without blocking. Control enforces budgets and scoped policy for internal agents. Prove preserves Evidence Pack receipts for allow, deny, budget, delegation, and paid-rail decisions.'],
                 ['Why should enterprises start AI agent governance in Observe mode?', 'Observe mode gives teams real baseline data on agent spend, tool usage, retry loops, and cost outliers before hard caps are introduced, making later enforcement safer and easier to justify.'],
-                ['Is Charge the same as internal budget enforcement?', 'No. Internal budget enforcement controls spend for agents you own. Paid-rail governance is the monetization path for external delegated agents consuming your APIs under policy.'],
+                ['Is Prove the same as internal budget enforcement?', 'No. Internal budget enforcement controls spend for agents you own. Prove is the evidence layer that preserves receipts for budget, authority, delegation, revocation, and paid-rail decisions.'],
               ].map(([question, answer]) => (
                 <div key={question} className="border-t border-gray-800 pt-5 first:border-t-0 first:pt-0">
                   <h3 className="mb-2 text-lg font-bold text-white">{question}</h3>

--- a/satgate-landing/app/build/page.tsx
+++ b/satgate-landing/app/build/page.tsx
@@ -26,7 +26,7 @@ export const metadata: Metadata = {
     "agent governance receipts",
     "MCP capability tokens",
     "AI agent SDK",
-    "Economic Firewall for AI agents",
+    "Agent Authority & Accountability Layer",
   ],
   alternates: {
     canonical: "https://satgate.io/build",
@@ -209,7 +209,7 @@ const jsonLd = {
       dateModified: "2026-05-12",
       isPartOf: { "@type": "WebSite", name: "SatGate", url: "https://satgate.io" },
       about: [
-        { "@type": "Thing", name: "Economic Firewall for AI agents" },
+        { "@type": "Thing", name: "Agent Authority & Accountability Layer" },
         { "@type": "Thing", name: "agent capabilities" },
         { "@type": "Thing", name: "verifiable receipts" },
         { "@type": "Thing", name: "rail-neutral payment governance" },
@@ -250,7 +250,7 @@ export default function BuildPage() {
               Issue scoped capabilities, enforce max budgets before upstream access, and return verifiable receipts your principal can trust.
             </p>
             <p className="mt-5 max-w-3xl text-lg leading-8 text-gray-400">
-              SatGate is the <strong className="font-semibold text-white">Economic Firewall for AI agents</strong>. This is the developer surface: <strong className="font-semibold text-white">Capabilities in. Receipts out. Rails abstracted.</strong>
+              SatGate is the <strong className="font-semibold text-white">Agent Authority &amp; Accountability Layer</strong>. This is the developer surface: <strong className="font-semibold text-white">Capabilities in. Receipts out. Rails abstracted.</strong>
             </p>
             <div className="mt-8 flex flex-col gap-3 sm:flex-row sm:flex-wrap">
               <a

--- a/satgate-landing/app/compare/_components/BrutalComparisonPage.tsx
+++ b/satgate-landing/app/compare/_components/BrutalComparisonPage.tsx
@@ -163,6 +163,32 @@ export function BrutalComparisonPage({ config }: { config: BrutalComparison }) {
         </div>
       </section>
 
+      <section className="border-y border-gray-900 bg-black">
+        <div className="mx-auto grid max-w-6xl gap-8 px-6 py-16 lg:grid-cols-[1.1fr_.9fr]">
+          <div>
+            <p className="mb-3 text-sm font-mono uppercase tracking-wide text-cyan-300">Policy-to-Proof layer</p>
+            <h2 className="mb-5 text-3xl font-bold text-white">The hard question is not routing. It is who had authority before execution.</h2>
+            <div className="space-y-4 text-lg leading-relaxed text-gray-300">
+              <p>
+                Most gateways, observability tools, and payment rails explain a narrow part of the transaction: where a request went, how much it cost, or whether a token was valid. Enterprise agent governance needs a pre-execution decision that binds identity, tenant, delegated scope, budget, tool, payment context, and revocation state before the upstream system sees the call.
+              </p>
+              <p>
+                That is the SatGate distinction in these comparisons. SatGate is not trying to replace every model router, tracing stack, API gateway, or paid rail. It sits above them as an Agent Authority &amp; Accountability Layer: Observe the agent request, Control what it is allowed to do, and Prove the decision with an Evidence Pack that security, finance, and compliance can inspect later.
+              </p>
+            </div>
+          </div>
+          <div className="rounded-2xl border border-cyan-900/50 bg-cyan-950/10 p-6">
+            <h3 className="mb-4 text-xl font-bold text-white">What an Evidence Pack should preserve</h3>
+            <ul className="space-y-3 text-gray-300">
+              <li><strong className="text-white">Authority:</strong> the agent, user, tenant, token caveats, and delegated depth behind the request.</li>
+              <li><strong className="text-white">Policy:</strong> the budget, tool, paid-rail, allowlist, and revocation checks evaluated before execution.</li>
+              <li><strong className="text-white">Decision:</strong> whether SatGate allowed, denied, downgraded, routed, or required additional approval.</li>
+              <li><strong className="text-white">Proof:</strong> signed receipt metadata that can survive dashboards, vendor logs, and postmortem guesswork.</li>
+            </ul>
+          </div>
+        </div>
+      </section>
+
       <section className="border-y border-gray-900 bg-gray-950/60">
         <div className="mx-auto max-w-6xl px-6 py-16">
           <h2 className="mb-8 text-3xl font-bold text-white">FAQ</h2>

--- a/satgate-landing/app/compare/apigee/page.tsx
+++ b/satgate-landing/app/compare/apigee/page.tsx
@@ -2,49 +2,49 @@ import Link from 'next/link';
 import { ArrowLeft, ArrowRight, Check, DollarSign, Gauge, KeyRound, Minus, ShieldCheck, Zap } from 'lucide-react';
 
 export const metadata = {
-  title: 'SatGate vs Apigee - API Management vs Economic Firewall',
+  title: 'SatGate vs Apigee: API Management vs Policy-to-Proof',
   description: 'Compare SatGate and Google Apigee. Apigee is enterprise API management; SatGate adds economic governance for AI agents, MCP budgets, and paid-rail context.',
   alternates: { canonical: 'https://satgate.io/compare/apigee' },
   keywords: [
     'SatGate vs Apigee',
     'Apigee alternative',
     'Apigee AI agent governance',
-    'API management vs economic firewall',
+    'API management vs Policy-to-Proof governance',
     'AI agent API governance',
     'SatGate comparison',
-    'economic firewall',
+    'Policy-to-Proof governance',
     'AI agent cost control',
     'MCP budget enforcement',
   ],
   openGraph: {
-    title: 'SatGate vs Apigee - API Management vs Economic Firewall',
+    title: 'SatGate vs Apigee: API Management vs Policy-to-Proof',
     description: 'Compare SatGate and Google Apigee for API management, AI agent economic governance, MCP budgets, revocation, and paid-rail context.',
     url: 'https://satgate.io/compare/apigee',
     type: 'article',
   },
   twitter: {
     card: 'summary_large_image',
-    title: 'SatGate vs Apigee - API Management vs Economic Firewall',
+    title: 'SatGate vs Apigee: API Management vs Policy-to-Proof',
     description: 'Apigee manages APIs. SatGate enforces AI agent budgets, MCP tool costs, scoped credentials, revocation, and paid-rail context.',
   },
 };
 
 const rows: Array<[string, string, string]> = [
-  ['Primary job', 'Economic Firewall for AI agents', 'Enterprise API management, API products, developer portals, analytics, policy, monetization, and Google Cloud integration'],
-  ['Best fit', 'Agent/API spend governance, MCP tool budgets, scoped credentials, revocation, audit, and paid-rail context', 'Enterprise API management, API products, developer portals, analytics, policy, monetization, and Google Cloud integration'],
+  ['Primary job', 'Policy-to-Proof governance for enterprise agents', 'Enterprise API management, API products, developer portals, analytics, policy, monetization, and Google Cloud integration'],
+  ['Best fit', 'Agent/API spend governance, MCP tool budgets, scoped credentials, revocation, Evidence Packs, and paid-rail context', 'Enterprise API management, API products, developer portals, analytics, policy, monetization, and Google Cloud integration'],
   ['Request-path hard budget enforcement', 'Yes: before upstream API, model, or MCP tool access', 'Partial / depends on gateway policy and traffic type'],
   ['MCP tool budget enforcement', 'Yes: per-tool budgets, cost attribution, and deny decisions', 'Not the primary category focus'],
   ['Scoped revocable agent capabilities', 'Yes: route, tool, call, budget, expiry, delegation, and revocation caveats', 'Typically API keys, policies, tokens, or platform auth primitives'],
   ['Runaway agent spend benchmark/data', 'Yes: benchmark page plus JSON/CSV dataset', 'No direct equivalent'],
-  ['L402 paid-agent API payments', 'Yes: Charge uses paid-rail context payment before access', 'No native SatGate-style paid-rail governance focus'],
+  ['L402 paid-agent API payments', 'Yes: governs paid-rail context before access and preserves Evidence Pack proof', 'No native SatGate-style paid-rail governance focus'],
   ['Broad API/AI platform management', 'Focused on economic governance layer', 'Yes / stronger fit'],
 ];
 
 const satgateWins = [
-  { icon: ShieldCheck, title: 'Economic firewall for agents', body: 'SatGate decides whether an autonomous agent can spend, access, delegate, route, revoke, or pay before the next request executes.' },
+  { icon: ShieldCheck, title: 'Policy-to-Proof for agents', body: 'SatGate decides whether an autonomous agent can spend, access, delegate, route, revoke, or pay before the next request executes.' },
   { icon: Gauge, title: 'Budgets beyond LLM tokens', body: 'Enforce cost controls across APIs, MCP tools, models, routes, workflows, tenants, agents, and delegated sub-agents.' },
   { icon: KeyRound, title: 'Scoped, revocable authority', body: 'Replace broad static keys with expiring capabilities constrained by route, tool, budget, calls, expiry, and delegation.' },
-  { icon: Zap, title: 'Charge paid agents', body: 'Use paid-rail context when external agents should pay for APIs, tools, datasets, or premium capabilities at request time.' },
+  { icon: Zap, title: 'Govern paid-rail access', body: 'Govern paid-rail context before external agents access APIs, tools, datasets, or premium capabilities at request time.' },
 ];
 
 const competitorWins = [
@@ -56,7 +56,7 @@ export default function ComparePage() {
   const articleJsonLd = {
     '@context': 'https://schema.org',
     '@type': 'TechArticle',
-    headline: 'SatGate vs Apigee - API Management vs Economic Firewall',
+    headline: 'SatGate vs Apigee: API Management vs Policy-to-Proof',
     description: metadata.description,
     author: { '@type': 'Organization', name: 'SatGate' },
     publisher: { '@type': 'Organization', name: 'SatGate', url: 'https://satgate.io' },
@@ -69,7 +69,7 @@ export default function ComparePage() {
     '@context': 'https://schema.org',
     '@type': 'FAQPage',
     mainEntity: [
-      { '@type': 'Question', name: 'Is SatGate a Google Apigee replacement?', acceptedAnswer: { '@type': 'Answer', text: 'Not directly. Apigee is a full enterprise API management platform. SatGate is an economic firewall for AI agents, API spend, MCP tools, scoped capabilities, revocation, audit, and paid-rail context.' } },
+      { '@type': 'Question', name: 'Is SatGate a Google Apigee replacement?', acceptedAnswer: { '@type': 'Answer', text: 'Not directly. Apigee is a full enterprise API management platform. SatGate is an Policy-to-Proof governance for AI agents, API spend, MCP tools, scoped capabilities, revocation, Evidence Packs, and paid-rail context.' } },
       { '@type': 'Question', name: 'Can SatGate and Google Apigee work together?', acceptedAnswer: { '@type': 'Answer', text: 'Yes. SatGate can sit in front of or alongside gateway, API management, or observability infrastructure to enforce agent economics before upstream access.' } },
       { '@type': 'Question', name: 'When should I choose SatGate?', acceptedAnswer: { '@type': 'Answer', text: 'Choose SatGate when the core problem is autonomous agent economic governance: hard budgets, MCP tool spend, revocable credentials, delegated authority, Evidence Packs, and paid-agent payment.' } },
       { '@type': 'Question', name: 'When should I choose Google Apigee?', acceptedAnswer: { '@type': 'Answer', text: 'Choose Apigee when the primary need is broad enterprise API management across human and application consumers.' } },
@@ -86,7 +86,7 @@ export default function ComparePage() {
         <div className="mb-12 max-w-4xl">
           <div className="mb-6 inline-flex rounded-full border border-cyan-500/30 bg-cyan-950/25 px-4 py-2 text-sm text-cyan-200">Comparison</div>
           <h1 className="mb-5 text-5xl font-extrabold tracking-tight md:text-7xl">SatGate vs Google Apigee</h1>
-          <p className="text-xl leading-relaxed text-gray-300 md:text-2xl">Apigee is a full enterprise API management platform. SatGate is different: it is the request-path economic firewall for autonomous agents, API spend, MCP tools, scoped credentials, audit, and L402 paid-agent payments.</p>
+          <p className="text-xl leading-relaxed text-gray-300 md:text-2xl">Apigee is a full enterprise API management platform. SatGate is different: it is the request-path Policy-to-Proof governance layer for autonomous agents, API spend, MCP tools, scoped credentials, Evidence Packs, and paid-rail context.</p>
         </div>
 
         <section className="mb-14 overflow-hidden rounded-2xl border border-gray-800">
@@ -105,7 +105,7 @@ export default function ComparePage() {
           <h2 className="mb-6 text-3xl font-bold text-white">SatGate vs Apigee FAQ</h2>
           <div className="grid gap-5 md:grid-cols-2">
             {[
-              ['Is SatGate a Google Apigee replacement?', 'Not directly. Apigee is a full enterprise API management platform. SatGate is an economic firewall for AI agents, API spend, MCP tools, scoped capabilities, revocation, audit, and paid-rail context.'],
+              ['Is SatGate a Google Apigee replacement?', 'Not directly. Apigee is a full enterprise API management platform. SatGate is an Policy-to-Proof governance for AI agents, API spend, MCP tools, scoped capabilities, revocation, Evidence Packs, and paid-rail context.'],
               ['Can SatGate and Google Apigee work together?', 'Yes. SatGate can sit in front of or alongside gateway, API management, or observability infrastructure to enforce agent economics before upstream access.'],
               ['When should I choose SatGate?', 'Choose SatGate when the core problem is autonomous agent economic governance: hard budgets, MCP tool spend, revocable credentials, delegated authority, Evidence Packs, and paid-agent payment.'],
               ['When should I choose Google Apigee?', 'Choose Apigee when the primary need is broad enterprise API management across human and application consumers.'],
@@ -122,7 +122,7 @@ export default function ComparePage() {
           <h2 className="mb-4 text-3xl font-bold text-white">Use the right layer.</h2>
           <p className="mb-8 max-w-3xl text-lg leading-relaxed text-gray-300">Gateways, API management, and observability tools are useful. They do not automatically solve agent economics. SatGate adds the pre-request decision layer: should this agent spend, access, delegate, revoke, route, or pay right now?</p>
           <div className="flex flex-col gap-4 sm:flex-row">
-            <Link href="/economic-firewall" className="inline-flex items-center justify-center gap-2 rounded-lg bg-white px-6 py-3 font-bold text-black transition hover:bg-gray-200">Economic firewall <ArrowRight size={18} /></Link>
+            <Link href="/policy-to-proof" className="inline-flex items-center justify-center gap-2 rounded-lg bg-white px-6 py-3 font-bold text-black transition hover:bg-gray-200">Policy-to-Proof <ArrowRight size={18} /></Link>
             <Link href="/ai-agent-cost-control" className="inline-flex items-center justify-center gap-2 rounded-lg border border-gray-700 px-6 py-3 font-bold text-white transition hover:border-cyan-500">AI agent cost control</Link>
           </div>
         </section>

--- a/satgate-landing/app/compare/helicone/page.tsx
+++ b/satgate-landing/app/compare/helicone/page.tsx
@@ -26,7 +26,7 @@ export const metadata = {
 };
 
 const rows: Array<[string, string, string]> = [
-  ['Primary job', 'Economic Firewall for AI agents', 'LLM observability / AI gateway / debugging and analytics'],
+  ['Primary job', 'Policy-to-Proof governance for enterprise agents', 'LLM observability / AI gateway / debugging and analytics'],
   ['Best fit', 'Agent/API spend governance, MCP tool budgets, scoped access, audit, paid-rail governance', 'Routing, debugging, request analytics, provider integrations, LLM app monitoring'],
   ['Request-path hard budget enforcement', 'Yes', 'Partial or adjacent, depending on gateway limits and usage policy'],
   ['MCP tool budget enforcement', 'Yes', 'Not the primary economic-control focus'],
@@ -42,7 +42,7 @@ const satgateWins = [
   { icon: ShieldCheck, title: 'Economic firewall in the request path', body: 'SatGate decides whether an agent should access, spend, route, delegate, or pay before upstream APIs, MCP tools, and model calls execute.' },
   { icon: Gauge, title: 'Hard budgets for autonomous workflows', body: 'Control spend by tenant, agent, workflow, delegated sub-agent, route, model, tool, session, day, and request.' },
   { icon: KeyRound, title: 'Scoped, revocable agent authority', body: 'Issue expiring capabilities constrained by route, tool, budget, call count, expiry, and delegation rules instead of broad static keys.' },
-  { icon: Zap, title: 'Charge paid agents', body: 'Use paid-rail context when external agents should pay for APIs, datasets, tools, or premium capabilities at request time.' },
+  { icon: Zap, title: 'Govern paid-rail access', body: 'Govern paid-rail context before external agents access APIs, datasets, tools, or premium capabilities at request time.' },
 ];
 
 const competitorWins: Array<{ title: string; body: string }> = [
@@ -190,7 +190,7 @@ export default function CompareHeliconePage() {
           <h2 className="mb-4 text-3xl font-bold text-white">Gateway features are useful. Economic governance is different.</h2>
           <p className="mb-8 max-w-3xl text-lg leading-relaxed text-gray-300">SatGate helps platform, finance, and security teams control what autonomous agents can spend, access, delegate, and monetize before the next request leaves the building.</p>
           <div className="flex flex-col gap-4 sm:flex-row">
-            <Link href="/economic-firewall" className="inline-flex items-center justify-center gap-2 rounded-lg bg-white px-6 py-3 font-bold text-black transition hover:bg-gray-200">Learn economic firewalls <ArrowRight size={18} /></Link>
+            <Link href="/policy-to-proof" className="inline-flex items-center justify-center gap-2 rounded-lg bg-white px-6 py-3 font-bold text-black transition hover:bg-gray-200">See Policy-to-Proof <ArrowRight size={18} /></Link>
             <Link href="/ai-agent-cost-control" className="inline-flex items-center justify-center gap-2 rounded-lg border border-gray-700 px-6 py-3 font-bold text-white transition hover:border-cyan-500">See agent cost control</Link>
           </div>
         </section>

--- a/satgate-landing/app/compare/kong-ai-gateway/page.tsx
+++ b/satgate-landing/app/compare/kong-ai-gateway/page.tsx
@@ -2,49 +2,49 @@ import Link from 'next/link';
 import { ArrowLeft, ArrowRight, Check, DollarSign, Gauge, KeyRound, Minus, ShieldCheck, Zap } from 'lucide-react';
 
 export const metadata = {
-  title: 'SatGate vs Kong AI Gateway - AI Gateway vs Economic Firewall',
+  title: 'SatGate vs Kong AI Gateway - AI Gateway vs Policy-to-Proof',
   description: 'Compare SatGate and Kong AI Gateway. Kong is API/AI gateway infrastructure; SatGate governs agent spend, MCP tools, scoped credentials, and paid-rail context.',
   alternates: { canonical: 'https://satgate.io/compare/kong-ai-gateway' },
   keywords: [
     'SatGate vs Kong AI Gateway',
     'Kong AI Gateway alternative',
-    'AI gateway vs economic firewall',
+    'AI gateway vs Policy-to-Proof governance',
     'Kong AI Gateway comparison',
     'agent API spend control',
     'SatGate comparison',
-    'economic firewall',
+    'Policy-to-Proof governance',
     'AI agent cost control',
     'MCP budget enforcement',
   ],
   openGraph: {
-    title: 'SatGate vs Kong AI Gateway - AI Gateway vs Economic Firewall',
+    title: 'SatGate vs Kong AI Gateway - AI Gateway vs Policy-to-Proof',
     description: 'Compare SatGate and Kong AI Gateway for gateway infrastructure, agent economics, MCP tool controls, scoped credentials, and paid-rail context.',
     url: 'https://satgate.io/compare/kong-ai-gateway',
     type: 'article',
   },
   twitter: {
     card: 'summary_large_image',
-    title: 'SatGate vs Kong AI Gateway - Gateway vs Economic Firewall',
+    title: 'SatGate vs Kong AI Gateway - Gateway vs Policy-to-Proof',
     description: 'Kong runs API gateway infrastructure. SatGate enforces agent budgets, MCP tool costs, scoped credentials, and paid-rail context.',
   },
 };
 
 const rows: Array<[string, string, string]> = [
-  ['Primary job', 'Economic Firewall for AI agents', 'API gateway, AI gateway, service connectivity, plugins, traffic policy, API platform operations'],
-  ['Best fit', 'Agent/API spend governance, MCP tool budgets, scoped credentials, revocation, audit, and paid-rail context', 'API gateway, AI gateway, service connectivity, plugins, traffic policy, API platform operations'],
+  ['Primary job', 'Policy-to-Proof governance for enterprise agents', 'API gateway, AI gateway, service connectivity, plugins, traffic policy, API platform operations'],
+  ['Best fit', 'Agent/API spend governance, MCP tool budgets, scoped credentials, revocation, Evidence Packs, and paid-rail context', 'API gateway, AI gateway, service connectivity, plugins, traffic policy, API platform operations'],
   ['Request-path hard budget enforcement', 'Yes: before upstream API, model, or MCP tool access', 'Partial / depends on gateway policy and traffic type'],
   ['MCP tool budget enforcement', 'Yes: per-tool budgets, cost attribution, and deny decisions', 'Not the primary category focus'],
   ['Scoped revocable agent capabilities', 'Yes: route, tool, call, budget, expiry, delegation, and revocation caveats', 'Typically API keys, policies, tokens, or platform auth primitives'],
   ['Runaway agent spend benchmark/data', 'Yes: benchmark page plus JSON/CSV dataset', 'No direct equivalent'],
-  ['L402 paid-agent API payments', 'Yes: Charge uses paid-rail context payment before access', 'No native SatGate-style paid-rail governance focus'],
+  ['L402 paid-agent API payments', 'Yes: governs paid-rail context before access and preserves Evidence Pack proof', 'No native SatGate-style paid-rail governance focus'],
   ['Broad API/AI platform management', 'Focused on economic governance layer', 'Yes / stronger fit'],
 ];
 
 const satgateWins = [
-  { icon: ShieldCheck, title: 'Economic firewall for agents', body: 'SatGate decides whether an autonomous agent can spend, access, delegate, route, revoke, or pay before the next request executes.' },
+  { icon: ShieldCheck, title: 'Policy-to-Proof for agents', body: 'SatGate decides whether an autonomous agent can spend, access, delegate, route, revoke, or pay before the next request executes.' },
   { icon: Gauge, title: 'Budgets beyond LLM tokens', body: 'Enforce cost controls across APIs, MCP tools, models, routes, workflows, tenants, agents, and delegated sub-agents.' },
   { icon: KeyRound, title: 'Scoped, revocable authority', body: 'Replace broad static keys with expiring capabilities constrained by route, tool, budget, calls, expiry, and delegation.' },
-  { icon: Zap, title: 'Charge paid agents', body: 'Use paid-rail context when external agents should pay for APIs, tools, datasets, or premium capabilities at request time.' },
+  { icon: Zap, title: 'Govern paid-rail access', body: 'Govern paid-rail context before external agents access APIs, tools, datasets, or premium capabilities at request time.' },
 ];
 
 const competitorWins = [
@@ -56,7 +56,7 @@ export default function ComparePage() {
   const articleJsonLd = {
     '@context': 'https://schema.org',
     '@type': 'TechArticle',
-    headline: 'SatGate vs Kong AI Gateway - AI Gateway vs Economic Firewall',
+    headline: 'SatGate vs Kong AI Gateway - AI Gateway vs Policy-to-Proof',
     description: metadata.description,
     author: { '@type': 'Organization', name: 'SatGate' },
     publisher: { '@type': 'Organization', name: 'SatGate', url: 'https://satgate.io' },
@@ -69,7 +69,7 @@ export default function ComparePage() {
     '@context': 'https://schema.org',
     '@type': 'FAQPage',
     mainEntity: [
-      { '@type': 'Question', name: 'Is SatGate a Kong AI Gateway replacement?', acceptedAnswer: { '@type': 'Answer', text: 'Not directly. Kong AI Gateway is the AI-facing extension of a mature API gateway platform. SatGate is an economic firewall for AI agents, API spend, MCP tools, scoped capabilities, revocation, audit, and paid-rail context.' } },
+      { '@type': 'Question', name: 'Is SatGate a Kong AI Gateway replacement?', acceptedAnswer: { '@type': 'Answer', text: 'Not directly. Kong AI Gateway is the AI-facing extension of a mature API gateway platform. SatGate is an Policy-to-Proof governance for AI agents, API spend, MCP tools, scoped capabilities, revocation, Evidence Packs, and paid-rail context.' } },
       { '@type': 'Question', name: 'Can SatGate and Kong AI Gateway work together?', acceptedAnswer: { '@type': 'Answer', text: 'Yes. SatGate can sit in front of or alongside gateway, API management, or observability infrastructure to enforce agent economics before upstream access.' } },
       { '@type': 'Question', name: 'When should I choose SatGate?', acceptedAnswer: { '@type': 'Answer', text: 'Choose SatGate when the core problem is autonomous agent economic governance: hard budgets, MCP tool spend, revocable credentials, delegated authority, Evidence Packs, and paid-agent payment.' } },
       { '@type': 'Question', name: 'When should I choose Kong AI Gateway?', acceptedAnswer: { '@type': 'Answer', text: 'Choose Kong when the primary need is a broad API gateway/API management platform with AI traffic support.' } },
@@ -86,7 +86,7 @@ export default function ComparePage() {
         <div className="mb-12 max-w-4xl">
           <div className="mb-6 inline-flex rounded-full border border-cyan-500/30 bg-cyan-950/25 px-4 py-2 text-sm text-cyan-200">Comparison</div>
           <h1 className="mb-5 text-5xl font-extrabold tracking-tight md:text-7xl">SatGate vs Kong AI Gateway</h1>
-          <p className="text-xl leading-relaxed text-gray-300 md:text-2xl">Kong AI Gateway is the AI-facing extension of a mature API gateway platform. SatGate is different: it is the request-path economic firewall for autonomous agents, API spend, MCP tools, scoped credentials, audit, and L402 paid-agent payments.</p>
+          <p className="text-xl leading-relaxed text-gray-300 md:text-2xl">Kong AI Gateway is the AI-facing extension of a mature API gateway platform. SatGate is different: it is the request-path Policy-to-Proof governance layer for autonomous agents, API spend, MCP tools, scoped credentials, Evidence Packs, and paid-rail context.</p>
         </div>
 
         <section className="mb-14 overflow-hidden rounded-2xl border border-gray-800">
@@ -105,7 +105,7 @@ export default function ComparePage() {
           <h2 className="mb-6 text-3xl font-bold text-white">SatGate vs Kong AI Gateway FAQ</h2>
           <div className="grid gap-5 md:grid-cols-2">
             {[
-              ['Is SatGate a Kong AI Gateway replacement?', 'Not directly. Kong AI Gateway is the AI-facing extension of a mature API gateway platform. SatGate is an economic firewall for AI agents, API spend, MCP tools, scoped capabilities, revocation, audit, and paid-rail context.'],
+              ['Is SatGate a Kong AI Gateway replacement?', 'Not directly. Kong AI Gateway is the AI-facing extension of a mature API gateway platform. SatGate is an Policy-to-Proof governance for AI agents, API spend, MCP tools, scoped capabilities, revocation, Evidence Packs, and paid-rail context.'],
               ['Can SatGate and Kong AI Gateway work together?', 'Yes. SatGate can sit in front of or alongside gateway, API management, or observability infrastructure to enforce agent economics before upstream access.'],
               ['When should I choose SatGate?', 'Choose SatGate when the core problem is autonomous agent economic governance: hard budgets, MCP tool spend, revocable credentials, delegated authority, Evidence Packs, and paid-agent payment.'],
               ['When should I choose Kong AI Gateway?', 'Choose Kong when the primary need is a broad API gateway/API management platform with AI traffic support.'],
@@ -122,7 +122,7 @@ export default function ComparePage() {
           <h2 className="mb-4 text-3xl font-bold text-white">Use the right layer.</h2>
           <p className="mb-8 max-w-3xl text-lg leading-relaxed text-gray-300">Gateways, API management, and observability tools are useful. They do not automatically solve agent economics. SatGate adds the pre-request decision layer: should this agent spend, access, delegate, revoke, route, or pay right now?</p>
           <div className="flex flex-col gap-4 sm:flex-row">
-            <Link href="/economic-firewall" className="inline-flex items-center justify-center gap-2 rounded-lg bg-white px-6 py-3 font-bold text-black transition hover:bg-gray-200">Economic firewall <ArrowRight size={18} /></Link>
+            <Link href="/policy-to-proof" className="inline-flex items-center justify-center gap-2 rounded-lg bg-white px-6 py-3 font-bold text-black transition hover:bg-gray-200">Policy-to-Proof <ArrowRight size={18} /></Link>
             <Link href="/ai-agent-cost-control" className="inline-flex items-center justify-center gap-2 rounded-lg border border-gray-700 px-6 py-3 font-bold text-white transition hover:border-cyan-500">AI agent cost control</Link>
           </div>
         </section>

--- a/satgate-landing/app/compare/langfuse/page.tsx
+++ b/satgate-landing/app/compare/langfuse/page.tsx
@@ -2,49 +2,49 @@ import Link from 'next/link';
 import { ArrowLeft, ArrowRight, Check, DollarSign, Gauge, KeyRound, Minus, ShieldCheck, Zap } from 'lucide-react';
 
 export const metadata = {
-  title: 'SatGate vs Langfuse - LLM Observability vs Economic Firewall',
+  title: 'SatGate vs Langfuse - LLM Observability vs Policy-to-Proof',
   description: 'Compare SatGate and Langfuse. Langfuse is strong for LLM observability and traces; SatGate enforces budgets and authority before agents spend.',
   alternates: { canonical: 'https://satgate.io/compare/langfuse' },
   keywords: [
     'SatGate vs Langfuse',
     'Langfuse alternative',
-    'LLM observability vs economic firewall',
+    'LLM observability vs Policy-to-Proof governance',
     'AI agent spend control',
     'Langfuse comparison',
     'SatGate comparison',
-    'economic firewall',
+    'Policy-to-Proof governance',
     'AI agent cost control',
     'MCP budget enforcement',
   ],
   openGraph: {
-    title: 'SatGate vs Langfuse - LLM Observability vs Economic Firewall',
+    title: 'SatGate vs Langfuse - LLM Observability vs Policy-to-Proof',
     description: 'Compare SatGate and Langfuse for LLM observability, traces, evaluations, and request-path agent budget enforcement.',
     url: 'https://satgate.io/compare/langfuse',
     type: 'article',
   },
   twitter: {
     card: 'summary_large_image',
-    title: 'SatGate vs Langfuse - Observability vs Economic Firewall',
+    title: 'SatGate vs Langfuse - Observability vs Policy-to-Proof',
     description: 'Langfuse traces AI apps. SatGate enforces agent budgets, MCP tool costs, scoped credentials, revocation, and paid-rail context.',
   },
 };
 
 const rows: Array<[string, string, string]> = [
-  ['Primary job', 'Economic Firewall for AI agents', 'LLM observability, traces, prompt management, evaluations, metrics, debugging, and product analytics for AI applications'],
-  ['Best fit', 'Agent/API spend governance, MCP tool budgets, scoped credentials, revocation, audit, and paid-rail context', 'LLM observability, traces, prompt management, evaluations, metrics, debugging, and product analytics for AI applications'],
+  ['Primary job', 'Policy-to-Proof governance for enterprise agents', 'LLM observability, traces, prompt management, evaluations, metrics, debugging, and product analytics for AI applications'],
+  ['Best fit', 'Agent/API spend governance, MCP tool budgets, scoped credentials, revocation, Evidence Packs, and paid-rail context', 'LLM observability, traces, prompt management, evaluations, metrics, debugging, and product analytics for AI applications'],
   ['Request-path hard budget enforcement', 'Yes: before upstream API, model, or MCP tool access', 'Partial / depends on gateway policy and traffic type'],
   ['MCP tool budget enforcement', 'Yes: per-tool budgets, cost attribution, and deny decisions', 'Not the primary category focus'],
   ['Scoped revocable agent capabilities', 'Yes: route, tool, call, budget, expiry, delegation, and revocation caveats', 'Typically API keys, policies, tokens, or platform auth primitives'],
   ['Runaway agent spend benchmark/data', 'Yes: benchmark page plus JSON/CSV dataset', 'No direct equivalent'],
-  ['L402 paid-agent API payments', 'Yes: Charge uses paid-rail context payment before access', 'No native SatGate-style paid-rail governance focus'],
+  ['L402 paid-agent API payments', 'Yes: governs paid-rail context before access and preserves Evidence Pack proof', 'No native SatGate-style paid-rail governance focus'],
   ['Broad API/AI platform management', 'Focused on economic governance layer', 'Yes / stronger fit'],
 ];
 
 const satgateWins = [
-  { icon: ShieldCheck, title: 'Economic firewall for agents', body: 'SatGate decides whether an autonomous agent can spend, access, delegate, route, revoke, or pay before the next request executes.' },
+  { icon: ShieldCheck, title: 'Policy-to-Proof for agents', body: 'SatGate decides whether an autonomous agent can spend, access, delegate, route, revoke, or pay before the next request executes.' },
   { icon: Gauge, title: 'Budgets beyond LLM tokens', body: 'Enforce cost controls across APIs, MCP tools, models, routes, workflows, tenants, agents, and delegated sub-agents.' },
   { icon: KeyRound, title: 'Scoped, revocable authority', body: 'Replace broad static keys with expiring capabilities constrained by route, tool, budget, calls, expiry, and delegation.' },
-  { icon: Zap, title: 'Charge paid agents', body: 'Use paid-rail context when external agents should pay for APIs, tools, datasets, or premium capabilities at request time.' },
+  { icon: Zap, title: 'Govern paid-rail access', body: 'Govern paid-rail context before external agents access APIs, tools, datasets, or premium capabilities at request time.' },
 ];
 
 const competitorWins = [
@@ -56,7 +56,7 @@ export default function ComparePage() {
   const articleJsonLd = {
     '@context': 'https://schema.org',
     '@type': 'TechArticle',
-    headline: 'SatGate vs Langfuse - LLM Observability vs Economic Firewall',
+    headline: 'SatGate vs Langfuse - LLM Observability vs Policy-to-Proof',
     description: metadata.description,
     author: { '@type': 'Organization', name: 'SatGate' },
     publisher: { '@type': 'Organization', name: 'SatGate', url: 'https://satgate.io' },
@@ -69,7 +69,7 @@ export default function ComparePage() {
     '@context': 'https://schema.org',
     '@type': 'FAQPage',
     mainEntity: [
-      { '@type': 'Question', name: 'Is SatGate a Langfuse replacement?', acceptedAnswer: { '@type': 'Answer', text: 'Not directly. Langfuse is an LLM observability and evaluation platform. SatGate is an economic firewall for AI agents, API spend, MCP tools, scoped capabilities, revocation, audit, and paid-rail context.' } },
+      { '@type': 'Question', name: 'Is SatGate a Langfuse replacement?', acceptedAnswer: { '@type': 'Answer', text: 'Not directly. Langfuse is an LLM observability and evaluation platform. SatGate is an Policy-to-Proof governance for AI agents, API spend, MCP tools, scoped capabilities, revocation, Evidence Packs, and paid-rail context.' } },
       { '@type': 'Question', name: 'Can SatGate and Langfuse work together?', acceptedAnswer: { '@type': 'Answer', text: 'Yes. SatGate can sit in front of or alongside gateway, API management, or observability infrastructure to enforce agent economics before upstream access.' } },
       { '@type': 'Question', name: 'When should I choose SatGate?', acceptedAnswer: { '@type': 'Answer', text: 'Choose SatGate when the core problem is autonomous agent economic governance: hard budgets, MCP tool spend, revocable credentials, delegated authority, Evidence Packs, and paid-agent payment.' } },
       { '@type': 'Question', name: 'When should I choose Langfuse?', acceptedAnswer: { '@type': 'Answer', text: 'Choose Langfuse when the primary need is tracing, prompt management, evaluations, metrics, and AI application observability.' } },
@@ -86,7 +86,7 @@ export default function ComparePage() {
         <div className="mb-12 max-w-4xl">
           <div className="mb-6 inline-flex rounded-full border border-cyan-500/30 bg-cyan-950/25 px-4 py-2 text-sm text-cyan-200">Comparison</div>
           <h1 className="mb-5 text-5xl font-extrabold tracking-tight md:text-7xl">SatGate vs Langfuse</h1>
-          <p className="text-xl leading-relaxed text-gray-300 md:text-2xl">Langfuse is an LLM observability and evaluation platform. SatGate is different: it is the request-path economic firewall for autonomous agents, API spend, MCP tools, scoped credentials, audit, and L402 paid-agent payments.</p>
+          <p className="text-xl leading-relaxed text-gray-300 md:text-2xl">Langfuse is an LLM observability and evaluation platform. SatGate is different: it is the request-path Policy-to-Proof governance layer for autonomous agents, API spend, MCP tools, scoped credentials, Evidence Packs, and paid-rail context.</p>
         </div>
 
         <section className="mb-14 overflow-hidden rounded-2xl border border-gray-800">
@@ -105,7 +105,7 @@ export default function ComparePage() {
           <h2 className="mb-6 text-3xl font-bold text-white">SatGate vs Langfuse FAQ</h2>
           <div className="grid gap-5 md:grid-cols-2">
             {[
-              ['Is SatGate a Langfuse replacement?', 'Not directly. Langfuse is an LLM observability and evaluation platform. SatGate is an economic firewall for AI agents, API spend, MCP tools, scoped capabilities, revocation, audit, and paid-rail context.'],
+              ['Is SatGate a Langfuse replacement?', 'Not directly. Langfuse is an LLM observability and evaluation platform. SatGate is an Policy-to-Proof governance for AI agents, API spend, MCP tools, scoped capabilities, revocation, Evidence Packs, and paid-rail context.'],
               ['Can SatGate and Langfuse work together?', 'Yes. SatGate can sit in front of or alongside gateway, API management, or observability infrastructure to enforce agent economics before upstream access.'],
               ['When should I choose SatGate?', 'Choose SatGate when the core problem is autonomous agent economic governance: hard budgets, MCP tool spend, revocable credentials, delegated authority, Evidence Packs, and paid-agent payment.'],
               ['When should I choose Langfuse?', 'Choose Langfuse when the primary need is tracing, prompt management, evaluations, metrics, and AI application observability.'],
@@ -122,7 +122,7 @@ export default function ComparePage() {
           <h2 className="mb-4 text-3xl font-bold text-white">Use the right layer.</h2>
           <p className="mb-8 max-w-3xl text-lg leading-relaxed text-gray-300">Gateways, API management, and observability tools are useful. They do not automatically solve agent economics. SatGate adds the pre-request decision layer: should this agent spend, access, delegate, revoke, route, or pay right now?</p>
           <div className="flex flex-col gap-4 sm:flex-row">
-            <Link href="/economic-firewall" className="inline-flex items-center justify-center gap-2 rounded-lg bg-white px-6 py-3 font-bold text-black transition hover:bg-gray-200">Economic firewall <ArrowRight size={18} /></Link>
+            <Link href="/policy-to-proof" className="inline-flex items-center justify-center gap-2 rounded-lg bg-white px-6 py-3 font-bold text-black transition hover:bg-gray-200">Policy-to-Proof <ArrowRight size={18} /></Link>
             <Link href="/ai-agent-cost-control" className="inline-flex items-center justify-center gap-2 rounded-lg border border-gray-700 px-6 py-3 font-bold text-white transition hover:border-cyan-500">AI agent cost control</Link>
           </div>
         </section>

--- a/satgate-landing/app/compare/litellm/page.tsx
+++ b/satgate-landing/app/compare/litellm/page.tsx
@@ -29,7 +29,7 @@ export const metadata = {
 };
 
 const rows: Array<[string, string, string]> = [
-  ['Primary job', 'Economic Firewall for AI agents', 'LLM gateway / OpenAI-compatible proxy'],
+  ['Primary job', 'Policy-to-Proof governance for enterprise agents', 'LLM gateway / OpenAI-compatible proxy'],
   ['Best fit', 'Agent/API spend governance, MCP tool budgets, scoped access, paid-rail governance', 'Model access, provider abstraction, fallbacks, routing, developer LLM access'],
   ['Request-path hard budget enforcement', 'Yes', 'Partial: budgets and rate limits for LLM gateway usage'],
   ['MCP tool budget enforcement', 'Yes', 'No native MCP economic firewall focus'],
@@ -59,8 +59,8 @@ const satgateWins: Array<{ icon: typeof ShieldCheck; title: string; body: string
   },
   {
     icon: Zap,
-    title: 'Charge paid agents',
-    body: 'Use paid-rail context when external agents should pay for APIs, tools, datasets, or premium capabilities at request time.',
+    title: 'Govern paid-rail access',
+    body: 'Govern paid-rail context before external agents access APIs, tools, datasets, or premium capabilities at request time.',
   },
 ];
 
@@ -251,8 +251,8 @@ export default function CompareLiteLLMPage() {
             LiteLLM helps developers reach models. SatGate helps platform, finance, and security teams control what autonomous agents can spend, access, delegate, and monetize before the next request leaves the building.
           </p>
           <div className="flex flex-col gap-4 sm:flex-row">
-            <Link href="/economic-firewall" className="inline-flex items-center justify-center gap-2 rounded-lg bg-white px-6 py-3 font-bold text-black transition hover:bg-gray-200">
-              Learn economic firewalls <ArrowRight size={18} />
+            <Link href="/policy-to-proof" className="inline-flex items-center justify-center gap-2 rounded-lg bg-white px-6 py-3 font-bold text-black transition hover:bg-gray-200">
+              See Policy-to-Proof <ArrowRight size={18} />
             </Link>
             <Link href="/ai-agent-cost-control" className="inline-flex items-center justify-center gap-2 rounded-lg border border-gray-700 px-6 py-3 font-bold text-white transition hover:border-cyan-500">
               See agent cost control

--- a/satgate-landing/app/compare/portkey/page.tsx
+++ b/satgate-landing/app/compare/portkey/page.tsx
@@ -26,7 +26,7 @@ export const metadata = {
 };
 
 const rows: Array<[string, string, string]> = [
-  ['Primary job', 'Economic Firewall for AI agents', 'Production GenAI stack / AI gateway / observability / guardrails'],
+  ['Primary job', 'Policy-to-Proof governance for enterprise agents', 'Production GenAI stack / AI gateway / observability / guardrails'],
   ['Best fit', 'Agent/API spend governance, MCP tool budgets, scoped access, audit, paid-rail governance', 'AI gateway, observability, guardrails, prompt management, governance, MCP access centralization'],
   ['Request-path hard budget enforcement', 'Yes', 'Partial or adjacent, depending on gateway limits and usage policy'],
   ['MCP tool budget enforcement', 'Yes', 'Not the primary economic-control focus'],
@@ -42,7 +42,7 @@ const satgateWins = [
   { icon: ShieldCheck, title: 'Economic firewall in the request path', body: 'SatGate decides whether an agent should access, spend, route, delegate, or pay before upstream APIs, MCP tools, and model calls execute.' },
   { icon: Gauge, title: 'Hard budgets for autonomous workflows', body: 'Control spend by tenant, agent, workflow, delegated sub-agent, route, model, tool, session, day, and request.' },
   { icon: KeyRound, title: 'Scoped, revocable agent authority', body: 'Issue expiring capabilities constrained by route, tool, budget, call count, expiry, and delegation rules instead of broad static keys.' },
-  { icon: Zap, title: 'Charge paid agents', body: 'Use paid-rail context when external agents should pay for APIs, datasets, tools, or premium capabilities at request time.' },
+  { icon: Zap, title: 'Govern paid-rail access', body: 'Govern paid-rail context before external agents access APIs, datasets, tools, or premium capabilities at request time.' },
 ];
 
 const competitorWins: Array<{ title: string; body: string }> = [
@@ -190,7 +190,7 @@ export default function ComparePortkeyPage() {
           <h2 className="mb-4 text-3xl font-bold text-white">Gateway features are useful. Economic governance is different.</h2>
           <p className="mb-8 max-w-3xl text-lg leading-relaxed text-gray-300">SatGate helps platform, finance, and security teams control what autonomous agents can spend, access, delegate, and monetize before the next request leaves the building.</p>
           <div className="flex flex-col gap-4 sm:flex-row">
-            <Link href="/economic-firewall" className="inline-flex items-center justify-center gap-2 rounded-lg bg-white px-6 py-3 font-bold text-black transition hover:bg-gray-200">Learn economic firewalls <ArrowRight size={18} /></Link>
+            <Link href="/policy-to-proof" className="inline-flex items-center justify-center gap-2 rounded-lg bg-white px-6 py-3 font-bold text-black transition hover:bg-gray-200">See Policy-to-Proof <ArrowRight size={18} /></Link>
             <Link href="/ai-agent-cost-control" className="inline-flex items-center justify-center gap-2 rounded-lg border border-gray-700 px-6 py-3 font-bold text-white transition hover:border-cyan-500">See agent cost control</Link>
           </div>
         </section>

--- a/satgate-landing/app/compare/tyk/page.tsx
+++ b/satgate-landing/app/compare/tyk/page.tsx
@@ -9,10 +9,10 @@ export const metadata = {
     'SatGate vs Tyk',
     'Tyk alternative',
     'Tyk AI governance',
-    'API gateway vs economic firewall',
+    'API gateway vs Policy-to-Proof governance',
     'AI native APIM comparison',
     'SatGate comparison',
-    'economic firewall',
+    'Policy-to-Proof governance',
     'AI agent cost control',
     'MCP budget enforcement',
   ],
@@ -24,27 +24,27 @@ export const metadata = {
   },
   twitter: {
     card: 'summary_large_image',
-    title: 'SatGate vs Tyk - API Management vs Economic Firewall',
+    title: 'SatGate vs Tyk: API Management vs Policy-to-Proof',
     description: 'Tyk manages API programs. SatGate enforces AI agent budgets, MCP tool costs, scoped authority, revocation, and paid-rail context.',
   },
 };
 
 const rows: Array<[string, string, string]> = [
-  ['Primary job', 'Economic Firewall for AI agents', 'API gateway, API management, policies, developer portal, analytics, self-managed/hybrid/cloud deployment, AI-native APIM'],
-  ['Best fit', 'Agent/API spend governance, MCP tool budgets, scoped credentials, revocation, audit, and paid-rail context', 'API gateway, API management, policies, developer portal, analytics, self-managed/hybrid/cloud deployment, AI-native APIM'],
+  ['Primary job', 'Policy-to-Proof governance for enterprise agents', 'API gateway, API management, policies, developer portal, analytics, self-managed/hybrid/cloud deployment, AI-native APIM'],
+  ['Best fit', 'Agent/API spend governance, MCP tool budgets, scoped credentials, revocation, Evidence Packs, and paid-rail context', 'API gateway, API management, policies, developer portal, analytics, self-managed/hybrid/cloud deployment, AI-native APIM'],
   ['Request-path hard budget enforcement', 'Yes: before upstream API, model, or MCP tool access', 'Partial / depends on gateway policy and traffic type'],
   ['MCP tool budget enforcement', 'Yes: per-tool budgets, cost attribution, and deny decisions', 'Not the primary category focus'],
   ['Scoped revocable agent capabilities', 'Yes: route, tool, call, budget, expiry, delegation, and revocation caveats', 'Typically API keys, policies, tokens, or platform auth primitives'],
   ['Runaway agent spend benchmark/data', 'Yes: benchmark page plus JSON/CSV dataset', 'No direct equivalent'],
-  ['L402 paid-agent API payments', 'Yes: Charge uses paid-rail context payment before access', 'No native SatGate-style paid-rail governance focus'],
+  ['L402 paid-agent API payments', 'Yes: governs paid-rail context before access and preserves Evidence Pack proof', 'No native SatGate-style paid-rail governance focus'],
   ['Broad API/AI platform management', 'Focused on economic governance layer', 'Yes / stronger fit'],
 ];
 
 const satgateWins = [
-  { icon: ShieldCheck, title: 'Economic firewall for agents', body: 'SatGate decides whether an autonomous agent can spend, access, delegate, route, revoke, or pay before the next request executes.' },
+  { icon: ShieldCheck, title: 'Policy-to-Proof for agents', body: 'SatGate decides whether an autonomous agent can spend, access, delegate, route, revoke, or pay before the next request executes.' },
   { icon: Gauge, title: 'Budgets beyond LLM tokens', body: 'Enforce cost controls across APIs, MCP tools, models, routes, workflows, tenants, agents, and delegated sub-agents.' },
   { icon: KeyRound, title: 'Scoped, revocable authority', body: 'Replace broad static keys with expiring capabilities constrained by route, tool, budget, calls, expiry, and delegation.' },
-  { icon: Zap, title: 'Charge paid agents', body: 'Use paid-rail context when external agents should pay for APIs, tools, datasets, or premium capabilities at request time.' },
+  { icon: Zap, title: 'Govern paid-rail access', body: 'Govern paid-rail context before external agents access APIs, tools, datasets, or premium capabilities at request time.' },
 ];
 
 const competitorWins = [
@@ -69,7 +69,7 @@ export default function ComparePage() {
     '@context': 'https://schema.org',
     '@type': 'FAQPage',
     mainEntity: [
-      { '@type': 'Question', name: 'Is SatGate a Tyk replacement?', acceptedAnswer: { '@type': 'Answer', text: 'Not directly. Tyk is an API management platform with gateway, governance, analytics, and portal capabilities. SatGate is an economic firewall for AI agents, API spend, MCP tools, scoped capabilities, revocation, audit, and paid-rail context.' } },
+      { '@type': 'Question', name: 'Is SatGate a Tyk replacement?', acceptedAnswer: { '@type': 'Answer', text: 'Not directly. Tyk is an API management platform with gateway, governance, analytics, and portal capabilities. SatGate is an Policy-to-Proof governance for AI agents, API spend, MCP tools, scoped capabilities, revocation, Evidence Packs, and paid-rail context.' } },
       { '@type': 'Question', name: 'Can SatGate and Tyk work together?', acceptedAnswer: { '@type': 'Answer', text: 'Yes. SatGate can sit in front of or alongside gateway, API management, or observability infrastructure to enforce agent economics before upstream access.' } },
       { '@type': 'Question', name: 'When should I choose SatGate?', acceptedAnswer: { '@type': 'Answer', text: 'Choose SatGate when the core problem is autonomous agent economic governance: hard budgets, MCP tool spend, revocable credentials, delegated authority, Evidence Packs, and paid-agent payment.' } },
       { '@type': 'Question', name: 'When should I choose Tyk?', acceptedAnswer: { '@type': 'Answer', text: 'Choose Tyk when the primary need is a flexible API management platform for publishing and operating APIs.' } },
@@ -86,7 +86,7 @@ export default function ComparePage() {
         <div className="mb-12 max-w-4xl">
           <div className="mb-6 inline-flex rounded-full border border-cyan-500/30 bg-cyan-950/25 px-4 py-2 text-sm text-cyan-200">Comparison</div>
           <h1 className="mb-5 text-5xl font-extrabold tracking-tight md:text-7xl">SatGate vs Tyk</h1>
-          <p className="text-xl leading-relaxed text-gray-300 md:text-2xl">Tyk is an API management platform with gateway, governance, analytics, and portal capabilities. SatGate is different: it is the request-path economic firewall for autonomous agents, API spend, MCP tools, scoped credentials, audit, and L402 paid-agent payments.</p>
+          <p className="text-xl leading-relaxed text-gray-300 md:text-2xl">Tyk is an API management platform with gateway, governance, analytics, and portal capabilities. SatGate is different: it is the request-path Policy-to-Proof governance layer for autonomous agents, API spend, MCP tools, scoped credentials, Evidence Packs, and paid-rail context.</p>
         </div>
 
         <section className="mb-14 overflow-hidden rounded-2xl border border-gray-800">
@@ -105,7 +105,7 @@ export default function ComparePage() {
           <h2 className="mb-6 text-3xl font-bold text-white">SatGate vs Tyk FAQ</h2>
           <div className="grid gap-5 md:grid-cols-2">
             {[
-              ['Is SatGate a Tyk replacement?', 'Not directly. Tyk is an API management platform with gateway, governance, analytics, and portal capabilities. SatGate is an economic firewall for AI agents, API spend, MCP tools, scoped capabilities, revocation, audit, and paid-rail context.'],
+              ['Is SatGate a Tyk replacement?', 'Not directly. Tyk is an API management platform with gateway, governance, analytics, and portal capabilities. SatGate is an Policy-to-Proof governance for AI agents, API spend, MCP tools, scoped capabilities, revocation, Evidence Packs, and paid-rail context.'],
               ['Can SatGate and Tyk work together?', 'Yes. SatGate can sit in front of or alongside gateway, API management, or observability infrastructure to enforce agent economics before upstream access.'],
               ['When should I choose SatGate?', 'Choose SatGate when the core problem is autonomous agent economic governance: hard budgets, MCP tool spend, revocable credentials, delegated authority, Evidence Packs, and paid-agent payment.'],
               ['When should I choose Tyk?', 'Choose Tyk when the primary need is a flexible API management platform for publishing and operating APIs.'],
@@ -122,7 +122,7 @@ export default function ComparePage() {
           <h2 className="mb-4 text-3xl font-bold text-white">Use the right layer.</h2>
           <p className="mb-8 max-w-3xl text-lg leading-relaxed text-gray-300">Gateways, API management, and observability tools are useful. They do not automatically solve agent economics. SatGate adds the pre-request decision layer: should this agent spend, access, delegate, revoke, route, or pay right now?</p>
           <div className="flex flex-col gap-4 sm:flex-row">
-            <Link href="/economic-firewall" className="inline-flex items-center justify-center gap-2 rounded-lg bg-white px-6 py-3 font-bold text-black transition hover:bg-gray-200">Economic firewall <ArrowRight size={18} /></Link>
+            <Link href="/policy-to-proof" className="inline-flex items-center justify-center gap-2 rounded-lg bg-white px-6 py-3 font-bold text-black transition hover:bg-gray-200">Policy-to-Proof <ArrowRight size={18} /></Link>
             <Link href="/ai-agent-cost-control" className="inline-flex items-center justify-center gap-2 rounded-lg border border-gray-700 px-6 py-3 font-bold text-white transition hover:border-cyan-500">AI agent cost control</Link>
           </div>
         </section>

--- a/satgate-landing/app/http-402-for-ai-agents/page.tsx
+++ b/satgate-landing/app/http-402-for-ai-agents/page.tsx
@@ -219,7 +219,7 @@ export default function Http402ForAiAgentsPage() {
             ['/govern', 'Govern AI agents', 'Govern paid agent actions before execution.'],
             ['/l402-agent-payments', 'L402 agent payments', 'Understand paid-rail context as one paid rail for governed agent/API access.'],
             ['/agent-payment-controls', 'Agent payment controls', 'Policy, budgets, approval, receipts, and payment rails for AI agents.'],
-            ['/economic-firewall', 'Economic firewall', 'Control agent access, spend, and paid-rail context before upstream API calls execute.'],
+            ['/policy-to-proof', 'Policy-to-Proof', 'Turn paid-rail context into governed authority decisions and Evidence Pack proof.'],
             ['/l402-api-pricing-calculator', 'L402 API pricing calculator', 'Estimate request-native pricing for agent/API paid-access scenarios.'],
           ].map(([href, title, body]) => (
             <Link key={href} href={href} className="rounded-xl border border-gray-800 bg-gray-950 p-5 transition hover:border-yellow-500/50 hover:bg-yellow-950/10">

--- a/satgate-landing/app/l402-agent-payments/page.tsx
+++ b/satgate-landing/app/l402-agent-payments/page.tsx
@@ -381,7 +381,7 @@ HTTP/1.1 200 OK
               ['/agent-capability-tokens', 'Agent capability tokens', 'Scope paid access with route, budget, expiry, delegation, and revocation caveats.'],
               ['/blog/l402-protocol-explained', 'L402 protocol explained', 'How HTTP 402, Lightning, and macaroons enable API payments.'],
               ['/l402-api-pricing-calculator', 'L402 API pricing calculator', 'Estimate per-request agent/API paid-access pricing.'],
-              ['/economic-firewall', 'Economic Firewall', 'Bound delegated agent authority in one request-path control plane.'],
+              ['/govern', 'AI agent governance', 'Bound delegated agent authority before paid-rail execution.'],
             ].map(([href, title, body]) => (
               <Link key={href} href={href} className="rounded-xl border border-gray-800 bg-gray-950 p-5 transition hover:border-yellow-500/50 hover:bg-yellow-950/10">
                 <h3 className="font-bold text-white mb-2">{title}</h3>

--- a/satgate-landing/app/llm-cost-dashboard/page.tsx
+++ b/satgate-landing/app/llm-cost-dashboard/page.tsx
@@ -269,8 +269,8 @@ export default function LlmCostDashboardPage() {
               <h3 className="mb-2 text-lg font-bold text-white">AI agent cost control →</h3>
               <p className="text-gray-400">Control model, API, and MCP spend before it happens.</p>
             </Link>
-            <Link href="/economic-firewall" className="rounded-2xl border border-gray-800 bg-black/70 p-6 transition hover:border-cyan-600">
-              <h3 className="mb-2 text-lg font-bold text-white">Economic firewall →</h3>
+            <Link href="/govern" className="rounded-2xl border border-gray-800 bg-black/70 p-6 transition hover:border-cyan-600">
+              <h3 className="mb-2 text-lg font-bold text-white">AI agent governance →</h3>
               <p className="text-gray-400">Move from observability to request-path economic governance.</p>
             </Link>
           </div>

--- a/satgate-landing/app/llm-cost-monitoring/page.tsx
+++ b/satgate-landing/app/llm-cost-monitoring/page.tsx
@@ -125,8 +125,8 @@ export default function LlmCostMonitoringPage() {
             <Link href="/llm-cost-dashboard" className="inline-flex items-center justify-center gap-2 rounded-lg bg-white px-6 py-3 font-bold text-black transition hover:bg-gray-200">
               See dashboard checklist <ArrowRight size={18} />
             </Link>
-            <Link href="/economic-firewall" className="inline-flex items-center justify-center gap-2 rounded-lg border border-gray-700 px-6 py-3 font-bold text-white transition hover:border-purple-500">
-              Learn economic firewalls
+            <Link href="/govern" className="inline-flex items-center justify-center gap-2 rounded-lg border border-gray-700 px-6 py-3 font-bold text-white transition hover:border-purple-500">
+              See AI agent governance
             </Link>
           </div>
         </div>

--- a/satgate-landing/app/paid-agent-payments/page.tsx
+++ b/satgate-landing/app/paid-agent-payments/page.tsx
@@ -332,7 +332,7 @@ export default function RobotCustomerPaymentsPage() {
               ['/l402-agent-payments', 'L402 paid-rail governance', 'Govern Lightning payment proof before protected API access.'],
               ['/agent-capability-tokens', 'Agent capability tokens', 'Give agents scoped, budgeted, expiring access after proof.'],
               ['/revocable-agent-credentials', 'Revocable agent credentials', 'Revoke delegated access when policy, budget, or risk changes.'],
-              ['/economic-firewall', 'Economic Firewall', 'Bound delegated agent authority in one request path.'],
+              ['/govern', 'AI agent governance', 'Bound delegated agent authority before paid-rail execution.'],
               ['/mcp-budget-enforcement', 'MCP budget enforcement', 'Apply the same budget logic to paid tools and MCP servers.'],
               ['/ai-agent-cost-control', 'AI agent cost control', 'Stop agent overspend before upstream requests execute.'],
             ].map(([href, title, body]) => (
@@ -355,8 +355,8 @@ export default function RobotCustomerPaymentsPage() {
             <Link href="/monetize" className="inline-flex items-center justify-center gap-2 rounded-lg bg-yellow-300 text-black px-6 py-3 font-bold hover:bg-yellow-200 transition">
               Monetize APIs with SatGate <ArrowRight size={18} />
             </Link>
-            <Link href="/economic-firewall" className="inline-flex items-center justify-center gap-2 rounded-lg border border-gray-700 px-6 py-3 font-bold text-white hover:border-cyan-500 transition">
-              Learn the economic firewall
+            <Link href="/govern" className="inline-flex items-center justify-center gap-2 rounded-lg border border-gray-700 px-6 py-3 font-bold text-white hover:border-cyan-500 transition">
+              See AI agent governance
             </Link>
           </div>
         </div>

--- a/satgate-landing/app/protect/page.tsx
+++ b/satgate-landing/app/protect/page.tsx
@@ -129,10 +129,10 @@ const faqJsonLd = {
     },
     {
       '@type': 'Question',
-      name: 'How does Control differ from Charge?',
+      name: 'How does Control differ from Prove?',
       acceptedAnswer: {
         '@type': 'Answer',
-        text: 'Control enforces access, budget, scope, and revocation policy for agent activity. Charge uses paid-rail context when external agents or paid agents should pay before API access is unlocked.',
+        text: 'Control enforces access, budget, scope, and revocation policy for agent activity. Prove preserves Evidence Pack receipts for paid-rail context and other agent decisions before API access is unlocked.',
       },
     },
   ],
@@ -1784,7 +1784,7 @@ export default function ProtectDemoPage() {
             {[
               ['What does SatGate Control protect?', 'SatGate Control protects agent API and MCP tool calls by enforcing scoped capability tokens, budgets, delegation limits, revocation, and audit policy before requests reach upstream services.'],
               ['Why use revocable capability tokens for agents?', 'Revocable capability tokens give agents narrow, expiring authority that can be delegated safely and killed instantly without rotating global API keys or service-account credentials.'],
-              ['How does Control differ from Charge?', 'Control enforces access, budget, scope, and revocation policy for agent activity. Charge uses paid-rail context when external agents or paid agents should pay before API access is unlocked.'],
+              ['How does Control differ from Prove?', 'Control enforces access, budget, scope, and revocation policy for agent activity. Prove preserves Evidence Pack receipts for paid-rail context and other agent decisions before API access is unlocked.'],
             ].map(([question, answer]) => (
               <div key={question} className="rounded-xl border border-gray-800 bg-gray-900 p-5">
                 <h3 className="mb-2 font-bold text-white">{question}</h3>

--- a/satgate-landing/app/satgate-for-claude-code/page.tsx
+++ b/satgate-landing/app/satgate-for-claude-code/page.tsx
@@ -114,7 +114,7 @@ export default function SatGateIntegrationPage() {
           <p className="mb-10 max-w-4xl text-xl leading-relaxed text-gray-300 md:text-2xl">Claude Code can delegate work across files, tools, model calls, MCP servers, package registries, and internal APIs. SatGate turns that activity into governed agent traffic with request-path spend caps, scoped credentials, revocation, and audit.</p>
 
           <div className="flex flex-col gap-4 sm:flex-row">
-            <Link href="/economic-firewall" className="inline-flex items-center justify-center gap-2 rounded-lg bg-white px-6 py-3 font-bold text-black transition hover:bg-gray-200">
+            <Link href="/policy-to-proof" className="inline-flex items-center justify-center gap-2 rounded-lg bg-white px-6 py-3 font-bold text-black transition hover:bg-gray-200">
               See Policy-to-Proof <ArrowRight size={18} />
             </Link>
             <Link href="/ai-agent-cost-control" className="inline-flex items-center justify-center gap-2 rounded-lg border border-gray-700 px-6 py-3 font-bold text-white transition hover:border-cyan-500">

--- a/satgate-landing/app/satgate-for-claude-desktop/page.tsx
+++ b/satgate-landing/app/satgate-for-claude-desktop/page.tsx
@@ -116,7 +116,7 @@ export default function SatGateIntegrationPage() {
           <p className="mb-10 max-w-4xl text-xl leading-relaxed text-gray-300 md:text-2xl">Claude Desktop plus MCP gives assistants access to real tools. That is exactly where static keys and best-effort prompts break down. SatGate enforces budget, scope, expiry, revocation, and audit at the request layer around MCP servers and paid APIs.</p>
 
           <div className="flex flex-col gap-4 sm:flex-row">
-            <Link href="/economic-firewall" className="inline-flex items-center justify-center gap-2 rounded-lg bg-white px-6 py-3 font-bold text-black transition hover:bg-gray-200">
+            <Link href="/policy-to-proof" className="inline-flex items-center justify-center gap-2 rounded-lg bg-white px-6 py-3 font-bold text-black transition hover:bg-gray-200">
               See Policy-to-Proof <ArrowRight size={18} />
             </Link>
             <Link href="/ai-agent-cost-control" className="inline-flex items-center justify-center gap-2 rounded-lg border border-gray-700 px-6 py-3 font-bold text-white transition hover:border-cyan-500">

--- a/satgate-landing/app/satgate-for-cursor/page.tsx
+++ b/satgate-landing/app/satgate-for-cursor/page.tsx
@@ -114,7 +114,7 @@ export default function SatGateIntegrationPage() {
           <p className="mb-10 max-w-4xl text-xl leading-relaxed text-gray-300 md:text-2xl">Cursor makes software agents fast enough to call tools, APIs, and model routes at machine speed. SatGate adds the missing authority-and-proof layer: per-agent budgets, scoped credentials, MCP tool limits, revocation, and audit before requests execute.</p>
 
           <div className="flex flex-col gap-4 sm:flex-row">
-            <Link href="/economic-firewall" className="inline-flex items-center justify-center gap-2 rounded-lg bg-white px-6 py-3 font-bold text-black transition hover:bg-gray-200">
+            <Link href="/policy-to-proof" className="inline-flex items-center justify-center gap-2 rounded-lg bg-white px-6 py-3 font-bold text-black transition hover:bg-gray-200">
               See Policy-to-Proof <ArrowRight size={18} />
             </Link>
             <Link href="/ai-agent-cost-control" className="inline-flex items-center justify-center gap-2 rounded-lg border border-gray-700 px-6 py-3 font-bold text-white transition hover:border-cyan-500">

--- a/satgate-landing/app/satgate-for-openclaw/page.tsx
+++ b/satgate-landing/app/satgate-for-openclaw/page.tsx
@@ -114,7 +114,7 @@ export default function SatGateIntegrationPage() {
           <p className="mb-10 max-w-4xl text-xl leading-relaxed text-gray-300 md:text-2xl">OpenClaw agents can run tools, spawn sub-agents, call MCP servers, route through models, and act across workflows. SatGate adds the Agent Authority & Accountability Layer underneath: Observe, Control, and Prove agent/API activity before upstream access.</p>
 
           <div className="flex flex-col gap-4 sm:flex-row">
-            <Link href="/economic-firewall" className="inline-flex items-center justify-center gap-2 rounded-lg bg-white px-6 py-3 font-bold text-black transition hover:bg-gray-200">
+            <Link href="/policy-to-proof" className="inline-flex items-center justify-center gap-2 rounded-lg bg-white px-6 py-3 font-bold text-black transition hover:bg-gray-200">
               See Policy-to-Proof <ArrowRight size={18} />
             </Link>
             <Link href="/ai-agent-cost-control" className="inline-flex items-center justify-center gap-2 rounded-lg border border-gray-700 px-6 py-3 font-bold text-white transition hover:border-cyan-500">

--- a/satgate-landing/app/sitemap.ts
+++ b/satgate-landing/app/sitemap.ts
@@ -110,7 +110,7 @@ const blogRoutes: SitemapEntry[] = [
   { path: '/blog/ai-agent-api-cost-control', lastModified: '2026-05-05', changeFrequency: 'monthly', priority: 0.8 },
   { path: '/blog/ai-governance-api-teams', lastModified: '2026-05-04', changeFrequency: 'monthly', priority: 0.7 },
   { path: '/blog/why-economic-firewalls-are-the-prerequisite-for-autonomous-ai-agents', lastModified: '2026-05-03', changeFrequency: 'monthly', priority: 0.8 },
-  { path: '/blog/the-enterprise-adoption-playbook-observe-control-charge', lastModified: '2026-05-02', changeFrequency: 'monthly', priority: 0.8 },
+  { path: '/blog/the-enterprise-adoption-playbook-observe-control-prove', lastModified: '2026-06-01', changeFrequency: 'monthly', priority: 0.8 },
   { path: '/blog/can-adversaries-game-your-economic-firewall', lastModified: '2026-05-02', changeFrequency: 'monthly', priority: 0.8 },
   { path: '/blog/mcp-gateway-guide', lastModified: '2026-05-04', changeFrequency: 'monthly', priority: 0.8 },
   { path: '/blog/api-monetization-ai', lastModified: '2026-05-04', changeFrequency: 'monthly', priority: 0.8 },

--- a/satgate-landing/app/stripe-link-agents-vs-satgate/page.tsx
+++ b/satgate-landing/app/stripe-link-agents-vs-satgate/page.tsx
@@ -112,8 +112,8 @@ export default function StripeLinkAgentsVsSatGatePage() {
             <Link href="/agent-payment-controls" className="inline-flex items-center justify-center gap-2 rounded-lg bg-white text-black px-6 py-3 font-bold hover:bg-gray-200 transition">
               Build agent payment controls <ArrowRight size={18} />
             </Link>
-            <Link href="/economic-firewall" className="inline-flex items-center justify-center gap-2 rounded-lg border border-gray-700 px-6 py-3 font-bold text-white hover:border-cyan-500 transition">
-              Learn the economic firewall
+            <Link href="/govern" className="inline-flex items-center justify-center gap-2 rounded-lg border border-gray-700 px-6 py-3 font-bold text-white hover:border-cyan-500 transition">
+              See AI agent governance
             </Link>
           </div>
         </div>

--- a/satgate-landing/app/tools/page.tsx
+++ b/satgate-landing/app/tools/page.tsx
@@ -228,8 +228,8 @@ export default function ToolsPage() {
             Quantify runaway agent spend, generate enforceable budget policy, govern MCP tools, and grade your economic firewall readiness before autonomous agents hit production scale.
           </p>
           <div className="flex flex-col gap-4 sm:flex-row">
-            <Link href="/economic-firewall" className="inline-flex items-center justify-center gap-2 rounded-lg bg-white px-6 py-3 font-bold text-black transition hover:bg-gray-200">
-              Learn economic firewalls <ArrowRight size={18} />
+            <Link href="/govern" className="inline-flex items-center justify-center gap-2 rounded-lg bg-white px-6 py-3 font-bold text-black transition hover:bg-gray-200">
+              See AI agent governance <ArrowRight size={18} />
             </Link>
             <Link href="/ai-agent-cost-control" className="inline-flex items-center justify-center gap-2 rounded-lg border border-gray-700 px-6 py-3 font-bold text-white transition hover:border-cyan-500">
               See agent cost control

--- a/satgate-landing/next.config.ts
+++ b/satgate-landing/next.config.ts
@@ -4,6 +4,7 @@ const nextConfig: NextConfig = {
   trailingSlash: false,
   async redirects() {
     return [
+      { source: '/blog/the-enterprise-adoption-playbook-observe-control-charge', destination: '/blog/the-enterprise-adoption-playbook-observe-control-prove', permanent: true },
       { source: '/blog/agent-to-agent-collaboration-security', destination: '/blog', permanent: true },
       { source: '/docs', destination: '/', permanent: true },
       { source: '/about', destination: '/', permanent: true },

--- a/satgate-landing/scripts/seo_machine.py
+++ b/satgate-landing/scripts/seo_machine.py
@@ -44,7 +44,7 @@ RECOMMENDED_META = {
    'description': 'Govern AI agents with SatGate: authority before execution, Observe/Control/Prove, MCP governance, paid-rail context, and Evidence Packs.'},
  '/blog/api-gateway-for-ai-agents': {
    'title': 'API Gateway for AI Agents: Control Tool and API Access',
-   'description': 'Learn how an API gateway for AI agents can enforce access, budgets, observability, and monetization across APIs and MCP tools.'},
+   'description': 'Learn how an API gateway for AI agents can enforce authority before execution, budgets, MCP governance, and Evidence Packs across APIs and paid rails.'},
  '/mcp-gateway': {
    'title': 'MCP Gateway for Agent Governance and Evidence Packs',
    'description': 'Use SatGate as an MCP gateway to check authority before tool execution, enforce policy, and export Evidence Packs.'},

--- a/satgate-landing/seo/reports/opportunities.json
+++ b/satgate-landing/seo/reports/opportunities.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-01T02:14:10.345024Z",
+  "generatedAt": "2026-06-01T13:45:29.180488Z",
   "items": [
     {
       "path": "/blog/how-to-add-budget-limits-to-openai-api-calls",
@@ -38,7 +38,7 @@
       "intent": "informational-commercial",
       "funnelStage": "problem-aware",
       "productAngle": "SatGate treats HTTP 402 and L402 as paid-rail context: budget authority before paid access and Evidence Pack proof after the request.",
-      "cta": "See paid-rail governance",
+      "cta": "Govern paid agent access",
       "status": "existing",
       "clicks": 1,
       "impressions": 831,

--- a/satgate-landing/seo/reports/opportunities.md
+++ b/satgate-landing/seo/reports/opportunities.md
@@ -1,6 +1,6 @@
 # SatGate SEO Machine Report
 
-Generated: 2026-06-01T02:14:10.345926Z
+Generated: 2026-06-01T13:45:29.181518Z
 
 ## Ranked opportunities
 
@@ -140,7 +140,7 @@ Generated: 2026-06-01T02:14:10.345926Z
 
 ### /blog/api-gateway-for-ai-agents
 - Title: API Gateway for AI Agents: Control Tool and API Access
-- Meta: Learn how an API gateway for AI agents can enforce access, budgets, observability, and monetization across APIs and MCP tools.
+- Meta: Learn how an API gateway for AI agents can enforce authority before execution, budgets, MCP governance, and Evidence Packs across APIs and paid rails.
 - Content changes:
   - Add or tighten the above-the-fold direct-answer block for the primary query.
   - Route the first CTA into a tool, signup, or commercial product page instead of letting the article dead-end.

--- a/satgate-landing/seo/reports/page-audit.json
+++ b/satgate-landing/seo/reports/page-audit.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-01T02:14:10.345481Z",
+  "generatedAt": "2026-06-01T13:45:29.180936Z",
   "items": [
     {
       "path": "/blog/ai-spend-governance",
@@ -29,9 +29,8 @@
         "/blog",
         "/blog/ai-agent-spending-limits",
         "/blog/llm-cost-management",
-        "/blog/the-enterprise-adoption-playbook-observe-control-charge",
+        "/blog/the-enterprise-adoption-playbook-observe-control-prove",
         "/compare/langsmith-helicone-datadog",
-        "/economic-firewall",
         "/policy-to-proof",
         "/runaway-agent-cost-calculator"
       ],
@@ -43,7 +42,7 @@
         "TechArticle",
         "Thing"
       ],
-      "wordCount": 1316,
+      "wordCount": 1315,
       "hasObserveControlProve": true,
       "hasEvidencePack": true,
       "hasFAQ": true,
@@ -161,10 +160,10 @@
     {
       "path": "/blog/http-402-payment-required-use-cases",
       "exists": true,
-      "title": "HTTP 402 Payment Required: Meaning, Use Cases, and AI Agents",
-      "titleLength": 60,
-      "metaDescription": "HTTP 402 Payment Required explained: why it was reserved, how L402 works for paid APIs, and how agents need budget authority before paid access.",
-      "metaDescriptionLength": 144,
+      "title": "HTTP 402 Payment Required: API and Agent Use Cases",
+      "titleLength": 50,
+      "metaDescription": "HTTP 402 and L402 are paid-rail context. SatGate governs authority before execution and preserves Evidence Packs.",
+      "metaDescriptionLength": 113,
       "canonical": "/blog/http-402-payment-required-use-cases",
       "h1": [
         "HTTP 402 Payment Required: Meaning, Reserved Use, and AI Agent Payments"
@@ -205,7 +204,7 @@
         "TechArticle",
         "Thing"
       ],
-      "wordCount": 2655,
+      "wordCount": 2647,
       "hasObserveControlProve": true,
       "hasEvidencePack": true,
       "hasFAQ": true,
@@ -331,8 +330,8 @@
       "exists": true,
       "title": "API Gateway for AI Agents: Control Tool and API Access",
       "titleLength": 54,
-      "metaDescription": "Learn how AI agent gateways enforce authority before execution with Observe/Control/Prove, budgets, MCP governance, and Evidence Packs.",
-      "metaDescriptionLength": 135,
+      "metaDescription": "Learn how AI agent gateways enforce authority before execution with Observe/Control/Prove, budgets, MCP governance, Evidence Packs, and paid rails.",
+      "metaDescriptionLength": 147,
       "canonical": "/blog/api-gateway-for-ai-agents",
       "h1": [
         "API Gateway for AI Agents: Budgets, MCP Tools, and Economic Control"
@@ -365,7 +364,7 @@
         "TechArticle",
         "Thing"
       ],
-      "wordCount": 1376,
+      "wordCount": 1378,
       "hasObserveControlProve": true,
       "hasEvidencePack": true,
       "hasFAQ": true,
@@ -480,6 +479,7 @@
         "Where SatGate evaluates agent authority",
         "What to compare for agent governance",
         "Why this matters in production",
+        "The hard question is not routing. It is who had authority before execution.",
         "FAQ",
         "Dashboards explain what happened. SatGate controls what agents are allowed to do."
       ],
@@ -499,7 +499,7 @@
         "TechArticle",
         "Thing"
       ],
-      "wordCount": 440,
+      "wordCount": 627,
       "hasObserveControlProve": true,
       "hasEvidencePack": true,
       "hasFAQ": true,
@@ -524,6 +524,7 @@
         "Where SatGate evaluates agent authority",
         "What to compare for agent governance",
         "Why this matters in production",
+        "The hard question is not routing. It is who had authority before execution.",
         "FAQ",
         "Dashboards explain what happened. SatGate controls what agents are allowed to do."
       ],
@@ -543,7 +544,7 @@
         "TechArticle",
         "Thing"
       ],
-      "wordCount": 438,
+      "wordCount": 625,
       "hasObserveControlProve": true,
       "hasEvidencePack": true,
       "hasFAQ": true,
@@ -568,6 +569,7 @@
         "Where SatGate evaluates agent authority",
         "What to compare for agent governance",
         "Why this matters in production",
+        "The hard question is not routing. It is who had authority before execution.",
         "FAQ",
         "Dashboards explain what happened. SatGate controls what agents are allowed to do."
       ],
@@ -587,7 +589,7 @@
         "TechArticle",
         "Thing"
       ],
-      "wordCount": 436,
+      "wordCount": 623,
       "hasObserveControlProve": true,
       "hasEvidencePack": true,
       "hasFAQ": true,
@@ -612,6 +614,7 @@
         "Where SatGate evaluates agent authority",
         "What to compare for agent governance",
         "Why this matters in production",
+        "The hard question is not routing. It is who had authority before execution.",
         "FAQ",
         "Dashboards explain what happened. SatGate controls what agents are allowed to do."
       ],
@@ -631,7 +634,7 @@
         "TechArticle",
         "Thing"
       ],
-      "wordCount": 440,
+      "wordCount": 627,
       "hasObserveControlProve": true,
       "hasEvidencePack": true,
       "hasFAQ": true,
@@ -656,6 +659,7 @@
         "Where SatGate evaluates agent authority",
         "What to compare for agent governance",
         "Why this matters in production",
+        "The hard question is not routing. It is who had authority before execution.",
         "FAQ",
         "Dashboards explain what happened. SatGate controls what agents are allowed to do."
       ],
@@ -675,7 +679,7 @@
         "TechArticle",
         "Thing"
       ],
-      "wordCount": 437,
+      "wordCount": 624,
       "hasObserveControlProve": true,
       "hasEvidencePack": true,
       "hasFAQ": true,

--- a/satgate-landing/seo/reports/recommendations.json
+++ b/satgate-landing/seo/reports/recommendations.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-01T02:14:10.345779Z",
+  "generatedAt": "2026-06-01T13:45:29.181305Z",
   "items": [
     {
       "path": "/blog/how-to-add-budget-limits-to-openai-api-calls",
@@ -122,7 +122,7 @@
       "score": 75,
       "primaryKeyword": "api gateway for ai agents",
       "recommendedTitle": "API Gateway for AI Agents: Control Tool and API Access",
-      "recommendedMetaDescription": "Learn how an API gateway for AI agents can enforce access, budgets, observability, and monetization across APIs and MCP tools.",
+      "recommendedMetaDescription": "Learn how an API gateway for AI agents can enforce authority before execution, budgets, MCP governance, and Evidence Packs across APIs and paid rails.",
       "contentChanges": [
         "Add or tighten the above-the-fold direct-answer block for the primary query.",
         "Route the first CTA into a tool, signup, or commercial product page instead of letting the article dead-end."

--- a/satgate-landing/seo/reports/recommendations.md
+++ b/satgate-landing/seo/reports/recommendations.md
@@ -1,6 +1,6 @@
 # SatGate SEO Machine Report
 
-Generated: 2026-06-01T02:14:10.345926Z
+Generated: 2026-06-01T13:45:29.181518Z
 
 ## Ranked opportunities
 
@@ -140,7 +140,7 @@ Generated: 2026-06-01T02:14:10.345926Z
 
 ### /blog/api-gateway-for-ai-agents
 - Title: API Gateway for AI Agents: Control Tool and API Access
-- Meta: Learn how an API gateway for AI agents can enforce access, budgets, observability, and monetization across APIs and MCP tools.
+- Meta: Learn how an API gateway for AI agents can enforce authority before execution, budgets, MCP governance, and Evidence Packs across APIs and paid rails.
 - Content changes:
   - Add or tighten the above-the-fold direct-answer block for the primary query.
   - Route the first CTA into a tool, signup, or commercial product page instead of letting the article dead-end.

--- a/satgate-landing/seo/targets.json
+++ b/satgate-landing/seo/targets.json
@@ -62,7 +62,7 @@
     "intent": "informational-commercial",
     "funnelStage": "problem-aware",
     "productAngle": "SatGate treats HTTP 402 and L402 as paid-rail context: budget authority before paid access and Evidence Pack proof after the request.",
-    "cta": "See paid-rail governance",
+    "cta": "Govern paid agent access",
     "status": "existing"
   },
   {


### PR DESCRIPTION
## Summary
- Completes the weekly SEO telemetry cleanup by moving the stale Observe/Control/Charge blog slug to Observe/Control/Prove with a permanent redirect.
- Reframes high-intent HTTP 402/API gateway/protect/build/comparison surfaces around Policy-to-Proof, Evidence Packs, and paid rails as context.
- Demotes primary internal `/economic-firewall` CTAs toward `/govern` and `/policy-to-proof` while preserving the legacy/category capture page.
- Expands shared comparison pages with a Policy-to-Proof / Evidence Pack section and regenerates checked-in SEO reports.

## Verification
- `python3 scripts/seo_machine.py --check` ✅
- `npm run build` ✅
- Local rendered probes ✅ for renamed blog route, redirect, HTTP 402, API gateway, protect, build, `.well-known/satgate`, priority comparison pages, and sitemap.
- Stale-term rendered probe ✅ no `Observe, Control, Charge`, `Audit Trail`, `Charge paid agents`, `Charge uses paid-rail`, or `Economic Firewall for AI agents` on probed routes.

## Known pre-existing hygiene
- `npm run lint` still fails on site-wide pre-existing lint debt unrelated to this diff.
- `npm run seo:links` still reports pre-existing metadata length/freshness/canonical issues outside this scoped remediation.
