### PR TITLE
docs: clean landing claim hygiene

### DIFF
--- a/satgate-landing/app/agent-control-plane/page.tsx
+++ b/satgate-landing/app/agent-control-plane/page.tsx
@@ -137,7 +137,7 @@ const faqs = [
   ],
   [
     "How is an agent control plane different from an API gateway?",
-    "An API gateway protects services. An agent control plane governs the agents using those services: their budget, customer boundary, delegation rights, Evidence Pack, and ability to be revoked instantly.",
+    "An API gateway protects services. An agent control plane governs the agents using those services: their budget, customer boundary, delegation rights, Evidence Pack, and ability to have governed requests denied after revocation.",
   ],
   [
     "Why do enterprise AI agents need no standing authority?",

--- a/satgate-landing/app/agents/page.tsx
+++ b/satgate-landing/app/agents/page.tsx
@@ -268,7 +268,7 @@ export default function AgentsLandingPage() {
             </h2>
             <p className="text-gray-400 max-w-2xl mx-auto">
               Your agents present an identity credential, SatGate mints a budgeted macaroon, 
-              and they&apos;re through the gate. When the budget runs out or you revoke access — they stop. Instantly.
+              and they&apos;re through the gate. When the budget runs out or you revoke access, the next governed request stops before upstream.
             </p>
           </div>
 
@@ -300,7 +300,7 @@ export default function AgentsLandingPage() {
                 <Ban className="text-red-400" size={16} />
                 <h4 className="text-red-300 font-semibold text-sm">Admin Kill Switch</h4>
               </div>
-              <p className="text-gray-500 text-xs">Revoke any agent&apos;s token instantly. Next request gets 401. Cascade revocation kills the entire delegation tree.</p>
+              <p className="text-gray-500 text-xs">Revoke any agent&apos;s token. The next governed request gets 401, including cascade to delegated child tokens.</p>
             </div>
             <div className="bg-amber-950/20 border border-amber-900/30 rounded-xl p-5">
               <div className="flex items-center gap-2 mb-2">

--- a/satgate-landing/app/blog/agent-swarms-cost-governance/page.tsx
+++ b/satgate-landing/app/blog/agent-swarms-cost-governance/page.tsx
@@ -208,7 +208,7 @@ export default function AgentSwarmsCostGovernancePage() {
               <CheckCircle className="text-green-400 mt-1 shrink-0" size={18} />
               <div>
                 <p className="text-white font-semibold">Cascade revocation</p>
-                <p className="text-gray-400">If a coordinator goes rogue, revoke its token. Every agent in the delegation tree is instantly invalidated — no need to track down individual agents.</p>
+                <p className="text-gray-400">If a coordinator goes rogue, revoke its token. Governed requests from agents in the delegation tree are denied at policy check — no need to track down individual agents.</p>
               </div>
             </div>
             <div className="flex items-start gap-3">

--- a/satgate-landing/app/blog/deepmind-intelligent-delegation-satgate/page.tsx
+++ b/satgate-landing/app/blog/deepmind-intelligent-delegation-satgate/page.tsx
@@ -233,7 +233,7 @@ export default function DeepMindDelegationPage() {
                   <p className="text-gray-300 text-sm">
                     <span className="text-cyan-400 font-mono text-xs">SatGate →</span> Every request is logged with full token
                     lineage — which parent minted it, what caveats it carries, what it spent. Token revocation
-                    cascades: revoking a parent instantly invalidates all children. The Evidence Pack is the
+                    cascades: revoking a parent invalidates governed child requests at the next policy check. The Evidence Pack is the
                     accountability mechanism.
                   </p>
                 </div>
@@ -327,7 +327,7 @@ export default function DeepMindDelegationPage() {
                   <p className="text-gray-500 text-sm mb-2">Paper: Algorithmic circuit breakers that invalidate tokens across delegation chains (pp. 18–19)</p>
                   <p className="text-gray-300 text-sm">
                     <span className="text-cyan-400 font-mono text-xs">SatGate →</span> Governance service with cascade revocation.
-                    Banning a parent token instantly invalidates every child and grandchild in the delegation tree.
+                    Banning a parent token causes governed child and grandchild requests to be denied at their next policy check.
                     Rate limiting acts as an additional circuit breaker — runaway agents hit throttling before they can
                     cause economic damage.
                   </p>

--- a/satgate-landing/app/blog/l402-protocol-explained/page.tsx
+++ b/satgate-landing/app/blog/l402-protocol-explained/page.tsx
@@ -421,7 +421,7 @@ routes:
           <div className="mt-16 bg-gradient-to-r from-yellow-900/20 to-green-900/20 border border-yellow-800/30 rounded-xl p-8">
             <h3 className="text-xl font-bold text-white mb-3">Ready to Add L402 Payments to Your API?</h3>
             <p className="text-gray-300 mb-4">
-              SatGate implements L402 as a gateway policy — deploy in front of any API to enable machine-native micropayments with zero changes to your backend. Open source. Production ready.
+              SatGate implements L402 as a gateway policy — deploy in front of any API to enable machine-native micropayments with zero changes to your backend. Open source. Use the OSS gateway with your own operational gates, policies, and receipts.
             </p>
             <div className="flex flex-wrap gap-3">
               <a href="https://github.com/SatGate-io/satgate" className="inline-flex items-center gap-2 bg-white text-black px-6 py-3 rounded-lg font-bold hover:bg-gray-200 transition text-sm">

--- a/satgate-landing/app/blog/mcp-budget-enforcement-guide/page.tsx
+++ b/satgate-landing/app/blog/mcp-budget-enforcement-guide/page.tsx
@@ -279,7 +279,7 @@ satgate delegate \\
 
           <p className="text-gray-300 leading-relaxed">
             The parent&apos;s budget is the ceiling. Sub-agents can never collectively exceed what 
-            was delegated. If you revoke the parent token, the entire tree is instantly invalidated.
+            was delegated. If you revoke the parent token, governed child requests are denied at policy check.
           </p>
 
           <h2 className="text-2xl font-bold mt-12 mb-4 text-white">Step 6: Monitor and Attribute</h2>

--- a/satgate-landing/app/blog/zero-trust-for-ai-agents/page.tsx
+++ b/satgate-landing/app/blog/zero-trust-for-ai-agents/page.tsx
@@ -316,7 +316,7 @@ Token: search-worker-12
           </p>
 
           <p className="text-gray-300 leading-relaxed">
-            <strong className="text-white">Enforce budgets at the gateway.</strong> Every API call has a cost. The gateway tracks cumulative spend against the token&apos;s budget caveat. When the budget is exhausted, access stops — instantly, automatically, with no human intervention.
+            <strong className="text-white">Enforce budgets at the gateway.</strong> Every API call has a cost. The gateway tracks cumulative spend against the token&apos;s budget caveat. When the budget is exhausted, the gateway denies the request automatically, with no human intervention.
           </p>
 
           <p className="text-gray-300 leading-relaxed">

--- a/satgate-landing/app/crawl/page.tsx
+++ b/satgate-landing/app/crawl/page.tsx
@@ -966,7 +966,7 @@ export default function ProtectDemoPage() {
                     </div>
                   </div>
                   <p className="text-gray-300 leading-relaxed">
-                    "The token is compromised. Ban it <strong className="text-orange-400">globally and instantly</strong>. 
+                    "The token is compromised. Ban it <strong className="text-orange-400">globally</strong>.
                     We're stateless for validation (fast), but stateful for revocation (secure). 
                     This is the <strong className="text-orange-400">Panic Button</strong>."
                   </p>
@@ -1363,7 +1363,7 @@ export default function ProtectDemoPage() {
                           <XCircle size={18} /> Token Rejected!
                         </div>
                         <p className="text-gray-400 text-sm mb-3">
-                          The banned token was instantly rejected. The attacker is locked out.
+                          The banned token is rejected on the next governed request. The attacker is locked out.
                         </p>
                         <pre className="text-xs bg-black rounded-lg p-3 text-red-400 overflow-x-auto">
 {`{
@@ -1430,7 +1430,7 @@ export default function ProtectDemoPage() {
                       </li>
                       <li className="flex items-start gap-2">
                         <CheckCircle size={16} className="text-green-400 mt-0.5 flex-shrink-0" />
-                        <span>Instant Kill Switch revocation — no propagation delay</span>
+                        <span>Kill Switch revocation checked before the next governed request</span>
                       </li>
                       <li className="flex items-start gap-2">
                         <CheckCircle size={16} className="text-green-400 mt-0.5 flex-shrink-0" />

--- a/satgate-landing/app/protect/page.tsx
+++ b/satgate-landing/app/protect/page.tsx
@@ -124,7 +124,7 @@ const faqJsonLd = {
       name: 'Why use revocable capability tokens for agents?',
       acceptedAnswer: {
         '@type': 'Answer',
-        text: 'Revocable capability tokens give agents narrow, expiring authority that can be delegated safely and killed instantly without rotating global API keys or service-account credentials.',
+        text: 'Revocable capability tokens give agents narrow, expiring authority that can be delegated safely and denied at policy check without rotating global API keys or service-account credentials.',
       },
     },
     {
@@ -1006,7 +1006,7 @@ export default function ProtectDemoPage() {
                     </div>
                   </div>
                   <p className="text-gray-300 leading-relaxed">
-                    "The token is compromised. Ban it <strong className="text-orange-400">globally and instantly</strong>. 
+                    "The token is compromised. Ban it <strong className="text-orange-400">globally</strong>.
                     We're stateless for validation (fast), but stateful for revocation (secure). 
                     This is the <strong className="text-orange-400">Panic Button</strong>."
                   </p>
@@ -1044,7 +1044,7 @@ export default function ProtectDemoPage() {
                         <User size={18} /> CISO Role
                       </div>
                       <p className="text-gray-400 text-sm">
-                        Issues root credentials. Retains authority. Can revoke instantly.
+                        Issues root credentials. Retains authority. Can revoke governed access.
                       </p>
                     </div>
                     <div className="p-4 bg-black rounded-xl border border-gray-800">
@@ -1412,7 +1412,7 @@ export default function ProtectDemoPage() {
                           <XCircle size={18} /> Token Rejected!
                         </div>
                         <p className="text-gray-400 text-sm mb-3">
-                          The banned token was instantly rejected. The attacker is locked out.
+                          The banned token is rejected on the next governed request. The attacker is locked out.
                         </p>
                         <pre className="text-xs bg-black rounded-lg p-3 text-red-400 overflow-x-auto">
 {`{
@@ -1475,7 +1475,7 @@ export default function ProtectDemoPage() {
                       </li>
                       <li className="flex items-start gap-2">
                         <CheckCircle size={16} className="text-green-400 mt-0.5 flex-shrink-0" />
-                        <span>CISO retains authority (instant Kill Switch revocation)</span>
+                        <span>CISO retains authority (Kill Switch checked before governed requests)</span>
                       </li>
                       <li className="flex items-start gap-2">
                         <CheckCircle size={16} className="text-green-400 mt-0.5 flex-shrink-0" />
@@ -1783,7 +1783,7 @@ export default function ProtectDemoPage() {
           <div className="grid gap-4 md:grid-cols-3">
             {[
               ['What does SatGate Control protect?', 'SatGate Control protects agent API and MCP tool calls by enforcing scoped capability tokens, budgets, delegation limits, revocation, and audit policy before requests reach upstream services.'],
-              ['Why use revocable capability tokens for agents?', 'Revocable capability tokens give agents narrow, expiring authority that can be delegated safely and killed instantly without rotating global API keys or service-account credentials.'],
+              ['Why use revocable capability tokens for agents?', 'Revocable capability tokens give agents narrow, expiring authority that can be delegated safely and denied at policy check without rotating global API keys or service-account credentials.'],
               ['How does Control differ from Prove?', 'Control enforces access, budget, scope, and revocation policy for agent activity. Prove preserves Evidence Pack receipts for paid-rail context and other agent decisions before API access is unlocked.'],
             ].map(([question, answer]) => (
               <div key={question} className="rounded-xl border border-gray-800 bg-gray-900 p-5">

--- a/satgate-landing/app/sandbox/page.tsx
+++ b/satgate-landing/app/sandbox/page.tsx
@@ -142,7 +142,7 @@ export default function SandboxPage() {
 
     addEvent({ id: 'alpha-header', agent: 'alpha', type: 'summary', status: 'running',
       label: '🔴 Agent Alpha — Admin Kill Switch',
-      detail: 'Can an admin instantly cut off a rogue agent? Watch.' });
+      detail: 'Can an admin deny a rogue agent at the next governed request? Watch.' });
 
     // Step 1: Auth
     const authId = 'alpha-auth';
@@ -191,7 +191,7 @@ export default function SandboxPage() {
     await sleep(jitter(300));
     if (abortRef.current) return;
     updateEvent(revokeId, { status: 'revoked', latencyMs: jitter(12),
-      detail: '✓ Token revoked instantly — agent has no idea yet.' });
+      detail: '✓ Token revoked — next governed request should be denied.' });
 
     await sleep(600);
     if (abortRef.current) return;
@@ -203,10 +203,10 @@ export default function SandboxPage() {
     await sleep(jitter(400));
     if (abortRef.current) return;
     updateEvent(verifyId, { status: 'blocked', latencyMs: jitter(8),
-      detail: 'HTTP 401 — Blocked. Agent is permanently locked out. Zero human latency.' });
+      detail: 'HTTP 401 — Blocked on the next governed request after revocation.' });
 
     addEvent({ id: 'alpha-done', agent: 'alpha', type: 'summary', status: 'success',
-      label: '✓ Kill switch works: Authenticate → Call API → Admin Revoke → Instant Block' });
+      label: '✓ Kill switch works: Authenticate → Call API → Admin Revoke → Next request blocked' });
 
     return true;
   }, []);
@@ -469,7 +469,7 @@ export default function SandboxPage() {
             </span>
           </h2>
           <p className="text-gray-400 text-lg leading-relaxed max-w-2xl mx-auto">
-            Two scenarios CFOs care about: a rogue agent gets cut off instantly, and an agent
+            Two scenarios CFOs care about: a rogue agent gets denied at the next governed request, and an agent
             hits its budget ceiling and stops — before the bill arrives.
           </p>
         </div>

--- a/satgate-landing/app/security/page.tsx
+++ b/satgate-landing/app/security/page.tsx
@@ -184,8 +184,8 @@ export default function SecurityPage() {
             <div className="bg-gray-900/50 border border-gray-800 rounded-lg p-4">
               <h4 className="text-white text-sm font-bold mb-2">Cascade Revocation</h4>
               <p className="text-gray-500 text-xs mb-0">
-                Revoking a parent token instantly invalidates all of its children. No propagation delay — 
-                the gateway checks revocation status on every request. Admin kill switch: immediate.
+                Revoking a parent token invalidates governed child requests at the next policy check.
+                The gateway checks revocation status before each governed request.
               </p>
             </div>
           </section>


### PR DESCRIPTION
## Summary
- cleans landing copy that could overstate proof/readiness semantics
- removes the residual “Production ready” phrasing from the L402 explainer CTA
- keeps generated SEO reports from current main to avoid reverting newer report data

## Verification
- git diff --check HEAD~1..HEAD
- exact claim scan: no unsafe current/public/demo overclaims remain; accepted residuals only
- broader revocation scan: accepted instant auth/payment/mint residuals only

No deploys, staging mutations, prod mutations, or merges performed.