### PR TITLE
Narrow public claim hygiene wording

### DIFF
--- a/docs/ARCHITECTURE.html
+++ b/docs/ARCHITECTURE.html
@@ -404,7 +404,7 @@ compliance</li>
 │  ├─────────────────────────────────────────────────────────────────────┤   │
 │  │                                                                     │   │
 │  │  Responsibilities:                                                  │   │
-│  │  • Maintain token ban list (instant revocation)                     │   │
+│  │  • Maintain token ban list (next-request revocation checks)                     │   │
 │  │  • Track token lineage (parent → child relationships)               │   │
 │  │  • Record all minted tokens                                         │   │
 │  │  • Audit logging (immutable)                                        │   │
@@ -925,7 +925,7 @@ Gateway</h3>
 │  │                                                                       │  │
 │  │  • HMAC-SHA256 token signatures (256-bit key)                         │  │
 │  │  • Time-based expiration (caveats)                                    │  │
-│  │  • Instant revocation (governance ban list)                           │  │
+│  │  • Next-request revocation checks (governance ban list)                           │  │
 │  │  • Scope-based authorization                                          │  │
 │  │  • No token storage (stateless validation)                            │  │
 │  │                                                                       │  │

--- a/docs/guides/langchain-integration.md
+++ b/docs/guides/langchain-integration.md
@@ -217,7 +217,7 @@ Delegation uses macaroon attenuation — the child token is cryptographically de
 
 - **No extra network calls**: Delegation happens locally (the gateway verifies the chain)
 - **Least privilege**: Each worker gets only what it needs
-- **Revocation**: Ban the parent to revoke all children instantly
+- **Revocation**: Ban the parent so child tokens fail the next governed gateway check
 - **Auditability**: The governance graph tracks the full delegation tree
 
 ## 5. Optional paid-route settlement context

--- a/docs/guides/lnget-integration.md
+++ b/docs/guides/lnget-integration.md
@@ -128,7 +128,7 @@ That's it. The agent gets data, the API gets paid.
 | **Per-agent spend tracking** | ❌ | ✅ |
 | **Per-tool cost attribution (MCP)** | ❌ | ✅ |
 | **Token delegation hierarchy** | ❌ | ✅ |
-| **Instant token revocation** | ❌ | ✅ |
+| **Next-request token revocation checks** | ❌ | ✅ |
 | **Cost center rollups** | ❌ | ✅ |
 | **Multi-tenant isolation** | ❌ | ✅ |
 | **Observe → Control → Charge modes** | ❌ | ✅ |

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,7 +7,7 @@ SatGate docs are organized around three voices. Use the voice that matches the r
 For buyers, operators, and security leaders. The story is not a payment rail. It is Policy-to-Proof governance for agents.
 
 - **Govern**: define scoped authority before an agent can act.
-- **Enforce**: apply policy, budget, route/tool scope, expiry, and delegation limits before upstream access.
+- **Enforce**: apply policy, budget, route/tool scope, expiry, and delegation limits at the gateway before forwarding.
 - **Prove**: return signed receipts and Evidence Packs for allowed, denied, delegated, revoked, and settlement-aware decisions.
 
 Start here:

--- a/satgate-landing/app/agent-api-key-risk-assessment/page.tsx
+++ b/satgate-landing/app/agent-api-key-risk-assessment/page.tsx
@@ -137,7 +137,7 @@ export default function AgentApiKeyRiskAssessmentPage() {
         name: 'How does SatGate reduce API key risk?',
         acceptedAnswer: {
           '@type': 'Answer',
-          text: 'SatGate sits in the request path and checks identity, budget, route, scope, expiry, revocation, and policy before upstream API or MCP tool access.',
+          text: 'SatGate sits in the request path and checks identity, budget, route, scope, expiry, revocation, and policy at the gateway before forwarding to an upstream API or MCP tool.',
         },
       },
     ],
@@ -247,7 +247,7 @@ export default function AgentApiKeyRiskAssessmentPage() {
             </div>
             <div className="rounded-xl border border-gray-800 bg-gray-950 p-6">
               <h3 className="mb-2 text-xl font-bold text-white">How does SatGate reduce API key risk?</h3>
-              <p className="leading-relaxed text-gray-400">SatGate sits in the request path and checks identity, budget, route, scope, expiry, revocation, and policy before upstream API or MCP tool access.</p>
+              <p className="leading-relaxed text-gray-400">SatGate sits in the request path and checks identity, budget, route, scope, expiry, revocation, and policy at the gateway before forwarding to an upstream API or MCP tool.</p>
             </div>
           </div>
         </div>
@@ -257,7 +257,7 @@ export default function AgentApiKeyRiskAssessmentPage() {
         <div className="rounded-3xl border border-cyan-900/60 bg-gradient-to-br from-cyan-950/30 to-orange-950/20 p-8 md:p-12">
           <h2 className="mb-4 text-3xl font-bold text-white">Move from API keys to economic capabilities.</h2>
           <p className="mb-8 max-w-3xl text-lg leading-relaxed text-gray-300">
-            SatGate turns agent access into request-path policy: scoped authority, spend limits, revocation, audit, and payment controls before upstream access.
+            SatGate turns agent access into request-path policy: scoped authority, spend limits, revocation, audit, and payment controls at the gateway before forwarding.
           </p>
           <div className="flex flex-col gap-4 sm:flex-row">
             <Link href="/revocable-capability-token-policy-template" className="inline-flex items-center justify-center gap-2 rounded-lg bg-white px-6 py-3 font-bold text-black transition hover:bg-gray-200">

--- a/satgate-landing/app/agent-capability-tokens/page.tsx
+++ b/satgate-landing/app/agent-capability-tokens/page.tsx
@@ -62,7 +62,7 @@ export default function Page() {
     mainEntity: [
       { '@type': 'Question', name: 'What is an agent capability token?', acceptedAnswer: { '@type': 'Answer', text: 'An agent capability token is a credential that carries constrained authority for an autonomous agent, such as allowed routes, tools, budget, expiry, delegation, and revocation behavior. Macaroons are one implementation pattern for capability-based tokens.' } },
       { '@type': 'Question', name: 'Why are static API keys risky for AI agents?', acceptedAnswer: { '@type': 'Answer', text: 'Static API keys are broad, long-lived, and hard to delegate safely. Autonomous agents need credentials with scoped authority, budget limits, expiry, revocation, and audit context.' } },
-      { '@type': 'Question', name: 'How does SatGate enforce agent credentials?', acceptedAnswer: { '@type': 'Answer', text: 'SatGate sits in the request path and checks identity, token scope, route, tool, budget, expiry, delegation rules, and revocation state before forwarding upstream access.' } },
+      { '@type': 'Question', name: 'How does SatGate enforce agent credentials?', acceptedAnswer: { '@type': 'Answer', text: 'SatGate sits in the request path and checks identity, token scope, route, tool, budget, expiry, delegation rules, and revocation state before forwarding upstream.' } },
     ],
   };
 
@@ -101,7 +101,7 @@ export default function Page() {
           <div className="space-y-5 text-lg leading-relaxed text-gray-300">
             <p>Human access systems assume stable users, managed devices, predictable sessions, and human-scale request rates. Agent systems are different: credentials can be copied into tools, delegated to sub-agents, retried in loops, and used faster than a billing alert can fire.</p>
             <p>The safe model is not a single permanent secret. It is a request-path capability that answers: what can this agent do, on which route, for how long, with what budget, and can it still be revoked right now?</p>
-            <p>SatGate turns those answers into enforceable policy before upstream API, model, or MCP tool access happens.</p>
+            <p>SatGate turns those answers into enforceable policy at the gateway before forwarding to an upstream API, model, or MCP tool happens.</p>
           </div>
         </div>
         <div className="rounded-2xl border border-yellow-900/50 bg-yellow-950/10 p-6">
@@ -130,7 +130,7 @@ export default function Page() {
             ['Issue', 'Parent gets scoped authority for one tenant, task, budget, and tool set.'],
             ['Delegate', 'A child worker receives linked authority from the parent.'],
             ['Attenuate', 'Child authority shrinks: lower spend cap, fewer tools, shorter TTL, visible depth.'],
-            ['Revoke', 'SatGate blocks the next request before upstream execution.'],
+            ['Revoke', 'SatGate rejects the next governed request at the gateway policy check.'],
             ['Prove', 'Evidence Pack shows lineage, caveats, decision, spend, and receipt IDs.'],
           ].map(([title, body]) => (
             <Link key={title} href="/capability-lifecycle-demo" className="rounded-2xl border border-gray-800 bg-gray-950 p-5 transition hover:border-cyan-500/60 hover:bg-cyan-950/10">
@@ -202,7 +202,7 @@ audit:
             <div className="rounded-xl border border-gray-800 bg-gray-950 p-6">
               <h3 className="mb-2 text-xl font-bold text-white">How does SatGate enforce agent credentials?</h3>
               <p className="leading-relaxed text-gray-400">
-                SatGate sits in the request path and checks identity, token scope, route, tool, budget, expiry, delegation rules, and revocation state before forwarding upstream access.
+                SatGate sits in the request path and checks identity, token scope, route, tool, budget, expiry, delegation rules, and revocation state before forwarding upstream.
               </p>
             </div>
           </div>

--- a/satgate-landing/app/agent-control-plane/page.tsx
+++ b/satgate-landing/app/agent-control-plane/page.tsx
@@ -54,7 +54,7 @@ export const metadata: Metadata = {
     card: "summary_large_image",
     title: "SatGate Agent Control Plane",
     description:
-      "Control the agent. Control delegation. Prove the lineage. Meter spend. Shut it down instantly.",
+      "Control the agent. Control delegation. Prove the lineage. Meter spend. Stop the next governed request.",
     images: ["/acp-demo/satgate-acp-thumbnail.jpg"],
   },
 };

--- a/satgate-landing/app/agent-spending-limits/page.tsx
+++ b/satgate-landing/app/agent-spending-limits/page.tsx
@@ -76,7 +76,7 @@ export default function Page() {
     '@type': 'FAQPage',
     mainEntity: [
       { '@type': 'Question', name: 'What are agent spending limits?', acceptedAnswer: { '@type': 'Answer', text: 'Agent spending limits are request-path budgets and caps that constrain what autonomous AI agents can spend by task, route, tool, model, workflow, tenant, session, or day before requests execute.' } },
-      { '@type': 'Question', name: 'Why are dashboards not enough?', acceptedAnswer: { '@type': 'Answer', text: 'Dashboards and billing alerts report spend after requests complete. Autonomous agents can loop, retry, and delegate fast enough that budget policy must be enforced before upstream access.' } },
+      { '@type': 'Question', name: 'Why are dashboards not enough?', acceptedAnswer: { '@type': 'Answer', text: 'Dashboards and billing alerts report spend after requests complete. Autonomous agents can loop, retry, and delegate fast enough that budget policy must be enforced at the gateway before forwarding.' } },
       { '@type': 'Question', name: 'How does SatGate help?', acceptedAnswer: { '@type': 'Answer', text: 'SatGate sits in the request path and checks identity, budget, route, tool scope, credential caveats, expiry, revocation, and audit policy before forwarding the request.' } },
       { '@type': 'Question', name: 'What spending limits should AI agents have?', acceptedAnswer: { '@type': 'Answer', text: 'AI agents should have spending limits by tenant, agent, task, workflow, session, model, tool, route, delegated sub-agent, and time window, with per-request ceilings and emergency revocation.' } },
       { '@type': 'Question', name: 'Are spending limits better than rate limits for AI agents?', acceptedAnswer: { '@type': 'Answer', text: 'They solve different problems. Rate limits control frequency, while spending limits control economic exposure by checking request price, remaining budget, scope, and policy before cost is created.' } },
@@ -119,7 +119,7 @@ export default function Page() {
           <h2 className="mb-6 text-3xl font-bold text-white">The control point is before the call</h2>
           <div className="space-y-5 text-lg leading-relaxed text-gray-300">
             <p>Autonomous agents can generate real costs through model calls, API requests, MCP tools, delegated sub-agents, retries, and background workflows. If the policy check happens after the request, the money is already spent.</p>
-            <p>SatGate enforces economic policy at the gateway boundary. Every important request can be evaluated against budget, scope, identity, revocation, route, tool, receipt, and audit rules before upstream access.</p>
+            <p>SatGate enforces economic policy at the gateway boundary. Every important request can be evaluated against budget, scope, identity, revocation, route, tool, receipt, and audit rules at the gateway before forwarding.</p>
             <p>That is the difference between cost reporting and economic control.</p>
           </div>
         </div>
@@ -164,7 +164,7 @@ export default function Page() {
             <div className="rounded-xl border border-gray-800 bg-gray-950 p-6">
               <h3 className="mb-2 text-xl font-bold text-white">Why are dashboards not enough?</h3>
               <p className="text-gray-400 leading-relaxed">
-                Dashboards and billing alerts report spend after requests complete. Autonomous agents can loop, retry, and delegate fast enough that budget policy must be enforced before upstream access.
+                Dashboards and billing alerts report spend after requests complete. Autonomous agents can loop, retry, and delegate fast enough that budget policy must be enforced at the gateway before forwarding.
               </p>
             </div>
             <div className="rounded-xl border border-gray-800 bg-gray-950 p-6">

--- a/satgate-landing/app/agents/page.tsx
+++ b/satgate-landing/app/agents/page.tsx
@@ -268,7 +268,7 @@ export default function AgentsLandingPage() {
             </h2>
             <p className="text-gray-400 max-w-2xl mx-auto">
               Your agents present an identity credential, SatGate mints a budgeted macaroon, 
-              and they&apos;re through the gate. When the budget runs out or you revoke access, the next governed request stops before upstream.
+              and they&apos;re through the gate. When the budget runs out or you revoke access, the next governed request is denied at the gateway policy check.
             </p>
           </div>
 

--- a/satgate-landing/app/ai-agent-cost-control/page.tsx
+++ b/satgate-landing/app/ai-agent-cost-control/page.tsx
@@ -118,7 +118,7 @@ export default function AiAgentCostControlPage() {
         name: 'Why are provider dashboards not enough for AI agent spend control?',
         acceptedAnswer: {
           '@type': 'Answer',
-          text: 'Dashboards report spend after the fact. Autonomous agents can retry, loop, and delegate fast enough that budget enforcement must happen inline before upstream API calls complete.',
+          text: 'Dashboards report spend after the fact. Autonomous agents can retry, loop, and delegate fast enough that budget enforcement must happen inline at the gateway at the gateway before forwarding to upstream APIs.',
         },
       },
       {
@@ -476,7 +476,7 @@ export default function AiAgentCostControlPage() {
             <div className="rounded-xl border border-gray-800 bg-gray-950 p-6">
               <h3 className="mb-2 text-xl font-bold text-white">Why are provider dashboards not enough for AI agent spend control?</h3>
               <p className="text-gray-400 leading-relaxed">
-                Dashboards report spend after the fact. Autonomous agents can retry, loop, and delegate fast enough that budget enforcement must happen inline before upstream API calls complete.
+                Dashboards report spend after the fact. Autonomous agents can retry, loop, and delegate fast enough that budget enforcement must happen inline at the gateway at the gateway before forwarding to upstream APIs.
               </p>
             </div>
             <div className="rounded-xl border border-gray-800 bg-gray-950 p-6">

--- a/satgate-landing/app/ai-agent-runaway-spend-benchmark/page.tsx
+++ b/satgate-landing/app/ai-agent-runaway-spend-benchmark/page.tsx
@@ -103,7 +103,7 @@ export default function AiAgentRunawaySpendBenchmarkPage() {
       {
         '@type': 'Question',
         name: 'How does SatGate reduce runaway spend?',
-        acceptedAnswer: { '@type': 'Answer', text: 'SatGate checks identity, budget, route, tool scope, request cost, expiry, and revocation before upstream access, blocking the next expensive request when policy says stop and recording the decision in an Evidence Pack.' },
+        acceptedAnswer: { '@type': 'Answer', text: 'SatGate checks identity, budget, route, tool scope, request cost, expiry, and revocation at the gateway before forwarding, blocking the next expensive request when policy says stop and recording the decision in an Evidence Pack.' },
       },
       {
         '@type': 'Question',
@@ -232,7 +232,7 @@ export default function AiAgentRunawaySpendBenchmarkPage() {
       <section className="border-y border-gray-900 bg-black">
         <div className="mx-auto grid max-w-6xl gap-8 px-6 py-20 lg:grid-cols-3">
           <div className="rounded-2xl border border-gray-800 bg-gray-950 p-6"><Zap className="mb-4 text-yellow-300" size={28} /><h2 className="mb-3 text-2xl font-bold text-white">Observe</h2><p className="leading-relaxed text-gray-400">Route agent traffic through SatGate to attribute cost by agent, workflow, route, tool, tenant, and MCP server before enforcing hard limits.</p></div>
-          <div className="rounded-2xl border border-gray-800 bg-gray-950 p-6"><Gauge className="mb-4 text-cyan-300" size={28} /><h2 className="mb-3 text-2xl font-bold text-white">Control</h2><p className="leading-relaxed text-gray-400">Enforce per-agent budgets, per-tool caps, route policy, revocation, expiry, and kill switches before upstream API calls execute.</p></div>
+          <div className="rounded-2xl border border-gray-800 bg-gray-950 p-6"><Gauge className="mb-4 text-cyan-300" size={28} /><h2 className="mb-3 text-2xl font-bold text-white">Control</h2><p className="leading-relaxed text-gray-400">Enforce per-agent budgets, per-tool caps, route policy, revocation, expiry, and kill switches at the gateway before forwarding to upstream APIs.</p></div>
           <div className="rounded-2xl border border-gray-800 bg-gray-950 p-6"><Bot className="mb-4 text-purple-300" size={28} /><h2 className="mb-3 text-2xl font-bold text-white">Prove</h2><p className="leading-relaxed text-gray-400">Record the policy decision, budget state, paid-rail context, and upstream outcome in an Evidence Pack before anyone argues about the bill.</p></div>
         </div>
       </section>
@@ -245,7 +245,7 @@ export default function AiAgentRunawaySpendBenchmarkPage() {
             {[
               ['What is AI agent runaway spend?', 'AI agent runaway spend is cost created when autonomous agents loop, retry, delegate, or continue calling paid APIs and MCP tools after the work is no longer economically justified.'],
               ['Why do dashboards fail to control runaway agent cost?', 'Dashboards report spend after requests complete. Autonomous agents can generate hundreds or thousands of paid calls before a human sees an alert, so enforcement has to happen before forwarding each request.'],
-              ['How does SatGate reduce runaway spend?', 'SatGate checks identity, budget, route, tool scope, request cost, expiry, and revocation before upstream access, blocking the next expensive request when policy says stop and recording the decision in an Evidence Pack.'],
+              ['How does SatGate reduce runaway spend?', 'SatGate checks identity, budget, route, tool scope, request cost, expiry, and revocation at the gateway before forwarding, blocking the next expensive request when policy says stop and recording the decision in an Evidence Pack.'],
               ['Which benchmark variable is most dangerous for AI agent cost?', 'Detection delay is usually the most dangerous variable because agents can create paid calls at machine speed while dashboards, billing alerts, and humans react after spend has already happened.'],
               ['Why include MCP tools in runaway spend benchmarks?', 'MCP tools can trigger paid APIs, browser automation, cloud jobs, data exports, or code agents. A low model cost can still become expensive when tool calls fan out without per-tool budgets.'],
             ].map(([question, answer]) => (

--- a/satgate-landing/app/ai-agent-runaway-spend-index/page.tsx
+++ b/satgate-landing/app/ai-agent-runaway-spend-index/page.tsx
@@ -101,7 +101,7 @@ const faqJsonLd = {
       name: 'How does SatGate reduce runaway agent spend?',
       acceptedAnswer: {
         '@type': 'Answer',
-        text: 'SatGate reduces runaway agent spend by enforcing per-request budgets, MCP tool cost policy, revocable capabilities, delegation caps, audit requirements, and kill switches before upstream calls execute.',
+        text: 'SatGate reduces runaway agent spend by enforcing per-request budgets, MCP tool cost policy, revocable capabilities, delegation caps, audit requirements, and kill switches at the gateway before forwarding to upstream services.',
       },
     },
     {
@@ -200,7 +200,7 @@ export default function AiAgentRunawaySpendIndexPage() {
           {[
             ['What is the AI Agent Runaway Spend Index?', 'The AI Agent Runaway Spend Index is a recurring benchmark of modeled autonomous agent cost failures, including retry loops, MCP tool storms, delegated fanout, paid API polling, and avoided spend from request-path controls.'],
             ['Why do runaway AI agents create cost risk?', 'Agents can loop, retry, delegate, and call paid tools or APIs much faster than humans. Without request-path budgets and kill switches, small mistakes can become expensive incidents before dashboards report the damage.'],
-            ['How does SatGate reduce runaway agent spend?', 'SatGate reduces runaway agent spend by enforcing per-request budgets, MCP tool cost policy, revocable capabilities, delegation caps, audit requirements, and kill switches before upstream calls execute.'],
+            ['How does SatGate reduce runaway agent spend?', 'SatGate reduces runaway agent spend by enforcing per-request budgets, MCP tool cost policy, revocable capabilities, delegation caps, audit requirements, and kill switches at the gateway before forwarding to upstream services.'],
             ['Which failure modes does the index track?', 'The index tracks OpenAI retry loops, MCP browser automation loops, sub-agent research fanout, paid data API polling loops, and multi-tenant agent swarms.'],
             ['How should teams use the index?', 'Teams should use the index as a control-plan checklist: price expensive tools, set per-request and session budgets, cap delegation, require revocable capabilities, and block loops in the request path.'],
           ].map(([question, answer]) => (
@@ -216,7 +216,7 @@ export default function AiAgentRunawaySpendIndexPage() {
         <div className="rounded-3xl border border-orange-900/60 bg-gradient-to-br from-orange-950/40 to-cyan-950/20 p-8 md:p-12">
           <h2 className="mb-4 text-3xl font-bold text-white">Use the index as a control-plan checklist</h2>
           <p className="mb-8 max-w-3xl text-lg leading-relaxed text-gray-300">
-            The pattern is consistent: agent spend incidents are not solved by better dashboards. They are solved by request-path budget enforcement, MCP tool cost policy, revocable capabilities, delegation caps, and kill switches before upstream calls execute.
+            The pattern is consistent: agent spend incidents are not solved by better dashboards. They are solved by request-path budget enforcement, MCP tool cost policy, revocable capabilities, delegation caps, and kill switches at the gateway before forwarding to upstream services.
           </p>
           <div className="flex flex-col gap-4 sm:flex-row">
             <Link href="/agent-spend-policy-template" className="inline-flex items-center justify-center gap-2 rounded-lg bg-white px-6 py-3 font-bold text-black transition hover:bg-gray-200">Generate spend policy <ArrowRight size={18} /></Link>

--- a/satgate-landing/app/ai-api-budget-enforcement/page.tsx
+++ b/satgate-landing/app/ai-api-budget-enforcement/page.tsx
@@ -76,7 +76,7 @@ export default function Page() {
     '@type': 'FAQPage',
     mainEntity: [
       { '@type': 'Question', name: 'What is AI API budget enforcement?', acceptedAnswer: { '@type': 'Answer', text: 'AI API budget enforcement is the request-path control that checks budgets, per-request cost, route policy, tool scope, expiry, and revocation before an autonomous agent can spend against an API or model provider.' } },
-      { '@type': 'Question', name: 'Why are dashboards not enough?', acceptedAnswer: { '@type': 'Answer', text: 'Dashboards and billing alerts report spend after requests complete. Autonomous agents can loop, retry, and delegate fast enough that budget policy must be enforced before upstream access.' } },
+      { '@type': 'Question', name: 'Why are dashboards not enough?', acceptedAnswer: { '@type': 'Answer', text: 'Dashboards and billing alerts report spend after requests complete. Autonomous agents can loop, retry, and delegate fast enough that budget policy must be enforced at the gateway before forwarding.' } },
       { '@type': 'Question', name: 'How does SatGate help?', acceptedAnswer: { '@type': 'Answer', text: 'SatGate sits in the request path and checks identity, budget, route, tool scope, credential caveats, expiry, revocation, and audit policy before forwarding the request.' } },
       { '@type': 'Question', name: 'How is AI API budget enforcement different from provider spend alerts?', acceptedAnswer: { '@type': 'Answer', text: 'Provider spend alerts notify teams after usage crosses a threshold. AI API budget enforcement checks request cost, remaining budget, identity, route, and policy before the API call executes.' } },
       { '@type': 'Question', name: 'What should happen when an AI agent exceeds its API budget?', acceptedAnswer: { '@type': 'Answer', text: 'The request should be blocked, downgraded, routed to a cheaper provider, sent for approval, or challenged for payment depending on policy, with an audit record explaining the decision.' } },
@@ -105,7 +105,7 @@ export default function Page() {
         <div className="relative mx-auto max-w-6xl px-6 py-24">
           <div className="mb-8 inline-flex items-center gap-2 rounded-full border border-cyan-500/30 bg-cyan-950/30 px-4 py-2 text-sm text-cyan-200"><Gauge size={16} /> Hard caps before API spend happens</div>
           <h1 className="mb-8 max-w-5xl text-5xl font-extrabold tracking-tight md:text-7xl">AI API budget enforcement belongs in the request path</h1>
-          <p className="mb-10 max-w-4xl text-xl leading-relaxed text-gray-300 md:text-2xl">AI agents can call APIs faster than finance, dashboards, or alerts can react. SatGate puts authority before execution by enforcing budget, route, scope, revocation, and audit policy before upstream API, model, or MCP tool calls execute.</p>
+          <p className="mb-10 max-w-4xl text-xl leading-relaxed text-gray-300 md:text-2xl">AI agents can call APIs faster than finance, dashboards, or alerts can react. SatGate puts authority before execution by enforcing budget, route, scope, revocation, and audit policy at the gateway before forwarding to upstream APIs, models, or MCP tools.</p>
           <div className="flex flex-col gap-4 sm:flex-row">
             <Link href="/govern" className="inline-flex items-center justify-center gap-2 rounded-lg bg-white px-6 py-3 font-bold text-black transition hover:bg-gray-200">Govern AI API budgets <ArrowRight size={18} /></Link>
             <Link href="/policy-to-proof" className="inline-flex items-center justify-center gap-2 rounded-lg border border-gray-700 px-6 py-3 font-bold text-white transition hover:border-cyan-500">See Policy-to-Proof</Link>
@@ -118,7 +118,7 @@ export default function Page() {
           <h2 className="mb-6 text-3xl font-bold text-white">The control point is before the call</h2>
           <div className="space-y-5 text-lg leading-relaxed text-gray-300">
             <p>Autonomous agents can generate real costs through model calls, API requests, MCP tools, delegated sub-agents, retries, and background workflows. If the policy check happens after the request, the money is already spent.</p>
-            <p>SatGate enforces economic policy at the gateway boundary. Every important request can be evaluated against budget, scope, identity, revocation, route, tool, receipt, and audit rules before upstream access.</p>
+            <p>SatGate enforces economic policy at the gateway boundary. Every important request can be evaluated against budget, scope, identity, revocation, route, tool, receipt, and audit rules at the gateway before forwarding.</p>
             <p>That is the difference between cost reporting and economic control.</p>
           </div>
         </div>
@@ -163,7 +163,7 @@ export default function Page() {
             <div className="rounded-xl border border-gray-800 bg-gray-950 p-6">
               <h3 className="mb-2 text-xl font-bold text-white">Why are dashboards not enough?</h3>
               <p className="text-gray-400 leading-relaxed">
-                Dashboards and billing alerts report spend after requests complete. Autonomous agents can loop, retry, and delegate fast enough that budget policy must be enforced before upstream access.
+                Dashboards and billing alerts report spend after requests complete. Autonomous agents can loop, retry, and delegate fast enough that budget policy must be enforced at the gateway before forwarding.
               </p>
             </div>
             <div className="rounded-xl border border-gray-800 bg-gray-950 p-6">

--- a/satgate-landing/app/blog/ai-agent-api-cost-control/page.tsx
+++ b/satgate-landing/app/blog/ai-agent-api-cost-control/page.tsx
@@ -56,7 +56,7 @@ export default function AiAgentApiCostControlPage() {
         name: 'How do you control AI agent API costs?',
         acceptedAnswer: {
           '@type': 'Answer',
-          text: 'Control AI agent API costs by putting an enforcement layer in the request path. The layer should identify the agent, price the API or tool call, check remaining budget, apply route/model policy, and block or downgrade requests before upstream spend occurs.',
+          text: 'Control AI agent API costs by putting an enforcement layer in the request path. The layer should identify the agent, price the API or tool call, check remaining budget, apply route/model policy, and deny or downgrade requests at the gateway before forwarding.',
         },
       },
       {
@@ -80,7 +80,7 @@ export default function AiAgentApiCostControlPage() {
         name: 'When should AI agent API cost controls block a request?',
         acceptedAnswer: {
           '@type': 'Answer',
-          text: 'AI agent API cost controls should block a request before execution when the estimated cost exceeds the remaining budget, the tool or route is outside scope, the credential is revoked or expired, or a delegated sub-agent would exceed its parent allowance.',
+          text: 'AI agent API cost controls should deny a request at the gateway policy check when the estimated cost exceeds the remaining budget, the tool or route is outside scope, the credential is revoked or expired, or a delegated sub-agent would exceed its parent allowance.',
         },
       },
     ],
@@ -229,7 +229,7 @@ audit:
               <div>
                 <h3 className="text-xl font-bold text-white mb-2">How do you control AI agent API costs?</h3>
                 <p className="text-gray-300 leading-relaxed mb-0">
-                  Put an enforcement layer in the request path. It should identify the agent, price the API or tool call, check remaining budget, apply route/model policy, and block or downgrade requests before upstream spend occurs.
+                  Put an enforcement layer in the request path. It should identify the agent, price the API or tool call, check remaining budget, apply route/model policy, and deny or downgrade requests at the gateway before forwarding.
                 </p>
               </div>
               <div>
@@ -247,7 +247,7 @@ audit:
               <div>
                 <h3 className="text-xl font-bold text-white mb-2">When should AI agent API cost controls block a request?</h3>
                 <p className="text-gray-300 leading-relaxed mb-0">
-                  They should block before execution when the estimated cost exceeds remaining budget, the tool or route is outside scope, the credential is revoked or expired, or a delegated sub-agent would exceed its parent allowance.
+                  They should deny at the gateway policy check when the estimated cost exceeds remaining budget, the tool or route is outside scope, the credential is revoked or expired, or a delegated sub-agent would exceed its parent allowance.
                 </p>
               </div>
             </div>

--- a/satgate-landing/app/blog/ai-agent-spending-limits/page.tsx
+++ b/satgate-landing/app/blog/ai-agent-spending-limits/page.tsx
@@ -49,7 +49,7 @@ export default function AiAgentSpendingLimitsBlogPage() {
         name: 'What are AI agent spending limits?',
         acceptedAnswer: {
           '@type': 'Answer',
-          text: 'AI agent spending limits are request-path policies that cap how much an autonomous agent can spend by agent, tool, model, route, workflow, or time window before upstream API or MCP tool calls execute.',
+          text: 'AI agent spending limits are request-path policies that cap how much an autonomous agent can spend by agent, tool, model, route, workflow, or time window at the gateway before forwarding to upstream APIs or MCP tools.',
         },
       },
       {
@@ -205,7 +205,7 @@ export default function AiAgentSpendingLimitsBlogPage() {
             <h2 className="mb-6 text-2xl font-bold text-white">AI agent spending limit questions</h2>
             <div className="space-y-5">
               {[
-                ['What are AI agent spending limits?', 'AI agent spending limits are request-path policies that cap how much an autonomous agent can spend by agent, tool, model, route, workflow, or time window before upstream API or MCP tool calls execute.'],
+                ['What are AI agent spending limits?', 'AI agent spending limits are request-path policies that cap how much an autonomous agent can spend by agent, tool, model, route, workflow, or time window at the gateway before forwarding to upstream APIs or MCP tools.'],
                 ['Why are rate limits not enough for AI agent cost control?', 'Rate limits control request volume, not money. AI agents can still choose expensive tools, retry costly calls, or fan out across subtasks while staying under a request-per-minute limit.'],
                 ['Where should teams enforce AI agent spend limits?', 'Enforce spending limits in the request path at an economic firewall or MCP proxy so budget, revocation, routing, and audit policy are checked before a costly call executes.'],
                 ['Can AI agent spending limits be set per workflow or time window?', 'Yes. AI agent spending limits can be scoped by workflow, task, agent, sub-agent, model, MCP tool, route, customer, environment, day, week, or token expiry window so each workload receives a precise hard budget.'],

--- a/satgate-landing/app/blog/ai-governance-api-teams/page.tsx
+++ b/satgate-landing/app/blog/ai-governance-api-teams/page.tsx
@@ -64,7 +64,7 @@ export default function AiGovernanceApiTeamsBlogPage() {
         name: 'Where should API teams enforce AI agent policy?',
         acceptedAnswer: {
           '@type': 'Answer',
-          text: 'API teams should enforce AI agent policy in the request path at an economic firewall, gateway, or MCP proxy so budget, permission, revocation, and audit checks happen before upstream work executes.',
+          text: 'API teams should enforce AI agent policy in the request path at an economic firewall, gateway, or MCP proxy so budget, permission, revocation, and audit checks happen at the gateway policy check before forwarding.',
         },
       },
     ],
@@ -412,7 +412,7 @@ export API_BASE_URL=https://gateway.satgate.io/v1
               {[
                 ['What does AI governance mean for API teams?', 'For API teams, AI governance means enforcing who can call an API, what each agent can spend, which tools or routes are allowed, when access should be revoked, and how every autonomous request is audited.'],
                 ['Why is routing not enough for AI API governance?', 'Routing moves traffic to the right upstream service, but it does not decide whether an autonomous agent is allowed to spend money, use a high-risk tool, exceed a workflow budget, or delegate access to a sub-agent.'],
-                ['Where should API teams enforce AI agent policy?', 'Enforce AI agent policy in the request path at an economic firewall, gateway, or MCP proxy so budget, permission, revocation, and audit checks happen before upstream work executes.'],
+                ['Where should API teams enforce AI agent policy?', 'Enforce AI agent policy in the request path at an economic firewall, gateway, or MCP proxy so budget, permission, revocation, and audit checks happen at the gateway policy check before forwarding.'],
               ].map(([question, answer]) => (
                 <div key={question} className="border-t border-gray-800 pt-5 first:border-t-0 first:pt-0">
                   <h3 className="mb-2 text-lg font-bold text-white">{question}</h3>

--- a/satgate-landing/app/blog/can-adversaries-game-your-economic-firewall/page.tsx
+++ b/satgate-landing/app/blog/can-adversaries-game-your-economic-firewall/page.tsx
@@ -56,7 +56,7 @@ export default function AdversarialBlogPage() {
         name: 'What makes an economic firewall resistant to adversarial AI?',
         acceptedAnswer: {
           '@type': 'Answer',
-          text: 'Adversarial resistance comes from per-tool cost attribution, cryptographic capability tokens, non-escalatable caveats, revocation, Evidence Packs, and fail-closed enforcement before upstream calls execute.',
+          text: 'Adversarial resistance comes from per-tool cost attribution, cryptographic capability tokens, non-escalatable caveats, revocation, Evidence Packs, and fail-closed enforcement at the gateway before forwarding to upstream services.',
         },
       },
       {
@@ -367,7 +367,7 @@ export default function AdversarialBlogPage() {
             <div className="space-y-5">
               {[
                 ['Can attackers game an economic firewall?', 'Attackers can try to game weak economic controls through prompt injection, tool confusion, budget spreading, or token misuse. A well-designed economic firewall resists this by enforcing policy below the agent layer in the request path.'],
-                ['What makes an economic firewall resistant to adversarial AI?', 'Adversarial resistance comes from per-tool cost attribution, cryptographic capability tokens, non-escalatable caveats, revocation, Evidence Packs, and fail-closed enforcement before upstream calls execute.'],
+                ['What makes an economic firewall resistant to adversarial AI?', 'Adversarial resistance comes from per-tool cost attribution, cryptographic capability tokens, non-escalatable caveats, revocation, Evidence Packs, and fail-closed enforcement at the gateway before forwarding to upstream services.'],
                 ['Why are macaroons useful for economic firewall security?', 'Macaroons let teams encode scope, expiry, budget, delegation, and revocation constraints directly into credentials. Child tokens can only add stricter caveats, never expand authority.'],
               ].map(([question, answer]) => (
                 <div key={question} className="border-t border-gray-800 pt-5 first:border-t-0 first:pt-0">

--- a/satgate-landing/app/blog/deepmind-intelligent-delegation-satgate/page.tsx
+++ b/satgate-landing/app/blog/deepmind-intelligent-delegation-satgate/page.tsx
@@ -65,7 +65,7 @@ export default function DeepMindDelegationPage() {
         name: 'How does SatGate implement intelligent agent delegation?',
         acceptedAnswer: {
           '@type': 'Answer',
-          text: 'SatGate uses macaroon-based capability tokens with caveats for route scope, MCP tool scope, budgets, expiry, and delegation chains, then enforces those constraints in the request path before upstream APIs execute.',
+          text: 'SatGate uses macaroon-based capability tokens with caveats for route scope, MCP tool scope, budgets, expiry, and delegation chains, then enforces those constraints in the request path before forwarding to upstream APIs.',
         },
       },
       {
@@ -485,7 +485,7 @@ export default function DeepMindDelegationPage() {
               {[
                 ['What are Delegation Capability Tokens for AI agents?', 'Delegation Capability Tokens are scoped credentials that let an agent pass limited authority to another agent. The useful form is attenuated: each delegation can only narrow permissions, budgets, routes, tools, or time windows.'],
                 ['Why are macaroons a strong primitive for AI agent delegation?', 'Macaroons support cryptographic caveats, local verification, and privilege attenuation. A parent token can mint child tokens with stricter constraints, but a child token cannot expand authority beyond its parent.'],
-                ['How does SatGate implement intelligent agent delegation?', 'SatGate uses macaroon-based capability tokens with caveats for route scope, MCP tool scope, budgets, expiry, and delegation chains, then enforces those constraints in the request path before upstream APIs execute.'],
+                ['How does SatGate implement intelligent agent delegation?', 'SatGate uses macaroon-based capability tokens with caveats for route scope, MCP tool scope, budgets, expiry, and delegation chains, then enforces those constraints in the request path before forwarding to upstream APIs.'],
                 ['What does Intelligent AI Delegation require beyond task routing?', 'Intelligent AI delegation needs explicit authority transfer, attenuated permissions, resource budgets, accountability across delegation chains, revocation, and enforcement before delegated agents can call APIs, MCP tools, or paid services.'],
               ].map(([question, answer]) => (
                 <div key={question} className="border-t border-gray-800 pt-5 first:border-t-0 first:pt-0">

--- a/satgate-landing/app/blog/l402-protocol-explained/page.tsx
+++ b/satgate-landing/app/blog/l402-protocol-explained/page.tsx
@@ -64,7 +64,7 @@ export default function L402ProtocolExplainedBlogPage() {
         name: 'Is L402 the same as enterprise budget enforcement?',
         acceptedAnswer: {
           '@type': 'Answer',
-          text: 'No. L402 is per-request Lightning payment for external API monetization. Enterprise budget enforcement controls internal agent spend with policies, caps, revocation, and audit before upstream requests execute.',
+          text: 'No. L402 is per-request Lightning payment for external API monetization. Enterprise budget enforcement controls internal agent spend with policies, caps, revocation, and audit at the gateway policy check before forwarding.',
         },
       },
     ],
@@ -407,7 +407,7 @@ routes:
               {[
                 ['What is the L402 protocol?', 'L402 is a machine-native API payment protocol that combines HTTP 402 Payment Required, Lightning invoices, and macaroon tokens so delegated software can present payment proof for API access without a per-request human checkout flow.'],
                 ['How does a delegated agent use L402 for paid API access?', 'The delegated client requests a protected API, receives a 402 response with a Lightning invoice and macaroon, presents proof, then retries with Authorization: L402 <macaroon>:<preimage> as proof of payment.'],
-                ['Is L402 the same as enterprise budget enforcement?', 'No. L402 is per-request Lightning payment for external API monetization. Enterprise budget enforcement controls internal agent spend with policies, caps, revocation, and audit before upstream requests execute.'],
+                ['Is L402 the same as enterprise budget enforcement?', 'No. L402 is per-request Lightning payment for external API monetization. Enterprise budget enforcement controls internal agent spend with policies, caps, revocation, and audit at the gateway policy check before forwarding.'],
               ].map(([question, answer]) => (
                 <div key={question} className="border-t border-gray-800 pt-5 first:border-t-0 first:pt-0">
                   <h3 className="mb-2 text-lg font-bold text-white">{question}</h3>

--- a/satgate-landing/app/blog/macaroon-tokens-vs-api-keys/page.tsx
+++ b/satgate-landing/app/blog/macaroon-tokens-vs-api-keys/page.tsx
@@ -250,7 +250,7 @@ agent_c_macaroon = attenuate(agent_b_macaroon, [
           </pre>
 
           <p className="text-gray-300 leading-relaxed">
-            This solves the delegation problem elegantly. Any agent can safely create more restrictive tokens for sub-agents without involving the original API provider. The math is guaranteed by cryptography: attenuated tokens can only have fewer permissions, never more.
+            This solves the delegation problem elegantly. Any agent can safely create more restrictive tokens for sub-agents without involving the original API provider. The cryptography constrains delegation: attenuated tokens can only have fewer permissions, never more.
           </p>
 
           <div className="my-8 rounded-2xl border border-purple-900/60 bg-purple-950/20 p-6">

--- a/satgate-landing/app/blog/page.tsx
+++ b/satgate-landing/app/blog/page.tsx
@@ -353,7 +353,7 @@ export default function BlogPage() {
         name: 'How is SatGate different from an LLM dashboard or API gateway?',
         acceptedAnswer: {
           '@type': 'Answer',
-          text: 'LLM dashboards report spend after it happens and traditional API gateways mainly route traffic. SatGate sits in the request path to observe, control, and prove agent/API activity before upstream access.',
+          text: 'LLM dashboards report spend after it happens and traditional API gateways mainly route traffic. SatGate sits in the request path to observe, control, and prove agent/API activity at the gateway before forwarding.',
         },
       },
     ],
@@ -456,7 +456,7 @@ export default function BlogPage() {
             {[
               ['What does the SatGate blog cover?', 'The SatGate blog covers AI agent governance, Policy-to-Proof governance, AI agent cost control, MCP budget enforcement, revocable capability tokens, paid-rail context, and API economics for autonomous agents.'],
               ['Where should I start if I need to control AI agent spend?', 'Start with the AI agent cost control guide, the economic firewall definition, the ROI calculator, and the MCP budget enforcement guide to understand the request-path controls needed before agents spend.'],
-              ['How is SatGate different from an LLM dashboard or API gateway?', 'LLM dashboards report spend after it happens and traditional API gateways mainly route traffic. SatGate sits in the request path to observe, control, and prove agent/API activity before upstream access.'],
+              ['How is SatGate different from an LLM dashboard or API gateway?', 'LLM dashboards report spend after it happens and traditional API gateways mainly route traffic. SatGate sits in the request path to observe, control, and prove agent/API activity at the gateway before forwarding.'],
             ].map(([question, answer]) => (
               <div key={question} className="border-t border-gray-800 pt-5 first:border-t-0 first:pt-0">
                 <h3 className="mb-2 text-lg font-bold text-white">{question}</h3>

--- a/satgate-landing/app/blog/why-economic-firewalls-are-the-prerequisite-for-autonomous-ai-agents/page.tsx
+++ b/satgate-landing/app/blog/why-economic-firewalls-are-the-prerequisite-for-autonomous-ai-agents/page.tsx
@@ -66,7 +66,7 @@ export default function WhyEconomicFirewallsPrerequisitePage() {
         name: 'Are economic firewalls only cost-control tools?',
         acceptedAnswer: {
           '@type': 'Answer',
-          text: 'No. Cost control is one function, but the larger purpose is economic governance: deciding which agents may access, spend, route, delegate, or pay before upstream work executes.',
+          text: 'No. Cost control is one function, but the larger purpose is economic governance: deciding which agents may access, spend, route, delegate, or pay at the gateway policy check before forwarding.',
         },
       },
       {
@@ -274,7 +274,7 @@ export default function WhyEconomicFirewallsPrerequisitePage() {
               {[
                 ['Why do autonomous AI agents need economic firewalls?', 'Autonomous AI agents need economic firewalls because they can spend money, call paid APIs, delegate work, and purchase resources faster than humans can approve or monitor. Economic firewalls bound that authority before spend occurs.'],
                 ['How do economic firewalls enable agent autonomy?', 'They let teams grant agents real autonomy inside hard budget, scope, expiry, revocation, and audit boundaries, so risk committees can approve independent action without accepting unbounded liability.'],
-                ['Are economic firewalls only cost-control tools?', 'No. Cost control is one function, but the larger purpose is economic governance: deciding which agents may access, spend, route, delegate, or pay before upstream work executes.'],
+                ['Are economic firewalls only cost-control tools?', 'No. Cost control is one function, but the larger purpose is economic governance: deciding which agents may access, spend, route, delegate, or pay at the gateway policy check before forwarding.'],
                 ['What controls should an economic firewall apply to autonomous agents?', 'An economic firewall should apply hard spend ceilings, route and tool scope, expiry windows, delegated budget limits, revocation, Evidence Packs, and request-path deny decisions before autonomous agents can spend or call paid services.'],
               ].map(([question, answer]) => (
                 <div key={question} className="border-t border-gray-800 pt-5 first:border-t-0 first:pt-0">

--- a/satgate-landing/app/blog/why-process-wont-scale-for-ai-agent-costs/page.tsx
+++ b/satgate-landing/app/blog/why-process-wont-scale-for-ai-agent-costs/page.tsx
@@ -65,7 +65,7 @@ export default function WhyProcessWontScaleBlogPage() {
         name: 'What is the alternative to manual AI cost governance?',
         acceptedAnswer: {
           '@type': 'Answer',
-          text: 'The alternative is request-path economic governance: every agent request is checked against budget, routing, revocation, and audit policy before upstream APIs, models, or MCP tools execute.',
+          text: 'The alternative is request-path economic governance: every agent request is checked against budget, routing, revocation, and audit policy at the gateway before forwarding to upstream APIs, models, or MCP tools.',
         },
       },
     ],
@@ -275,7 +275,7 @@ export default function WhyProcessWontScaleBlogPage() {
               {[
                 ['Why does process-based AI agent cost control fail at scale?', 'Process-based cost control fails because autonomous agents make API and tool calls faster than humans can review dashboards, spreadsheets, or invoices. Controls need to execute before each costly request.'],
                 ['Which AI agent cost controls should be automated?', 'Budget checks, model routing, per-tool cost attribution, workflow spend tracking, policy templates, token quotas, and real-time denials should be automated at the gateway or economic firewall layer.'],
-                ['What is the alternative to manual AI cost governance?', 'The alternative is request-path economic governance: every agent request is checked against budget, routing, revocation, and audit policy before upstream APIs, models, or MCP tools execute.'],
+                ['What is the alternative to manual AI cost governance?', 'The alternative is request-path economic governance: every agent request is checked against budget, routing, revocation, and audit policy at the gateway before forwarding to upstream APIs, models, or MCP tools.'],
               ].map(([question, answer]) => (
                 <div key={question} className="border-t border-gray-800 pt-5 first:border-t-0 first:pt-0">
                   <h3 className="mb-2 text-lg font-bold text-white">{question}</h3>

--- a/satgate-landing/app/blog/zero-trust-for-ai-agents/page.tsx
+++ b/satgate-landing/app/blog/zero-trust-for-ai-agents/page.tsx
@@ -65,7 +65,7 @@ export default function ZeroTrustForAIAgentsBlogPage() {
         name: 'How does an economic firewall extend Zero Trust for AI agents?',
         acceptedAnswer: {
           '@type': 'Answer',
-          text: 'An economic firewall enforces cost, scope, and delegation in the request path before upstream APIs execute, giving teams budget-aware authorization that identity systems alone cannot provide.',
+          text: 'An economic firewall enforces cost, scope, and delegation in the request path before forwarding to upstream APIs, giving teams budget-aware authorization that identity systems alone cannot provide.',
         },
       },
       {
@@ -396,7 +396,7 @@ Token: search-worker-12
               {[
                 ['Why does traditional Zero Trust break down for AI agents?', 'Traditional Zero Trust assumes stable human identities, managed devices, and predictable access patterns. AI agents are ephemeral, delegate to sub-agents, and can generate thousands of API calls from one task.'],
                 ['What replaces identity-based security for autonomous agents?', 'Autonomous agents need capability-based security: scoped, revocable tokens that encode what the agent can do, how much it can spend, where it can call, and when authority expires.'],
-                ['How does an economic firewall extend Zero Trust for AI agents?', 'An economic firewall enforces cost, scope, and delegation in the request path before upstream APIs execute, giving teams budget-aware authorization that identity systems alone cannot provide.'],
+                ['How does an economic firewall extend Zero Trust for AI agents?', 'An economic firewall enforces cost, scope, and delegation in the request path before forwarding to upstream APIs, giving teams budget-aware authorization that identity systems alone cannot provide.'],
                 ['Can Zero Trust policies express agent budgets and delegated authority?', 'Most Zero Trust policies can express identity, device posture, location, and application access, but they usually cannot express per-agent spend limits, delegated budget attenuation, MCP tool costs, or proof-of-payment requirements before each request.'],
               ].map(([question, answer]) => (
                 <div key={question} className="border-t border-gray-800 pt-5 first:border-t-0 first:pt-0">

--- a/satgate-landing/app/build/page.tsx
+++ b/satgate-landing/app/build/page.tsx
@@ -18,7 +18,7 @@ import {
 export const metadata: Metadata = {
   title: "Build Agents With Bounded Economic Authority",
   description:
-    "Issue scoped capabilities, enforce max budgets before upstream access, and verify receipts with SatGate's developer surface for agent authority and Evidence Pack proof.",
+    "Issue scoped capabilities, enforce max budgets at the gateway before forwarding, and verify receipts with SatGate's developer surface for agent authority and Evidence Pack proof.",
   keywords: [
     "SatGate build",
     "AI agent capabilities",
@@ -34,7 +34,7 @@ export const metadata: Metadata = {
   openGraph: {
     title: "Build agents with bounded economic authority",
     description:
-      "Capabilities in. Receipts out. Rails abstracted. Build agents with scoped authority, max budgets before upstream access, and verifiable receipts.",
+      "Capabilities in. Receipts out. Rails abstracted. Build agents with scoped authority, max budgets at the gateway before forwarding, and verifiable receipts.",
     url: "https://satgate.io/build",
     type: "website",
   },
@@ -42,7 +42,7 @@ export const metadata: Metadata = {
     card: "summary_large_image",
     title: "Build agents with bounded economic authority",
     description:
-      "Issue scoped capabilities, enforce max budgets before upstream access, and verify receipts with SatGate's rail-neutral developer primitive.",
+      "Issue scoped capabilities, enforce max budgets at the gateway before forwarding, and verify receipts with SatGate's rail-neutral developer primitive.",
   },
 };
 
@@ -138,7 +138,7 @@ const primitives = [
 const docsBase = "https://github.com/SatGate-io/satgate/blob/main/docs";
 
 const voiceCards = [
-  { title: "Marketing voice", label: "govern / enforce / prove", body: "Explain the buyer outcome: scoped authority before action, policy enforcement before upstream access, and Evidence Pack proof after every decision." },
+  { title: "Marketing voice", label: "govern / enforce / prove", body: "Explain the buyer outcome: scoped authority before action, policy enforcement at the gateway before forwarding, and Evidence Pack proof after every decision." },
   { title: "Developer voice", label: "issue / pay / verify", body: "Give builders one primitive across SDKs, MCP, raw HTTP, OpenAI tools, Anthropic tools, LangChain, and CrewAI." },
   { title: "Machine voice", label: "schemas / signatures / receipts", body: "Anchor verifiers on canonical capability fields, receipt schema, JWKS discovery, RFC 8785 canonicalization, and Ed25519 signatures." },
 ];
@@ -247,7 +247,7 @@ export default function BuildPage() {
               Build agents with bounded economic authority
             </h1>
             <p className="mt-6 max-w-3xl text-xl leading-8 text-gray-300">
-              Issue scoped capabilities, enforce max budgets before upstream access, and return verifiable receipts your principal can trust.
+              Issue scoped capabilities, enforce max budgets at the gateway before forwarding, and return verifiable receipts your principal can trust.
             </p>
             <p className="mt-5 max-w-3xl text-lg leading-8 text-gray-400">
               SatGate is the <strong className="font-semibold text-white">Agent Authority &amp; Accountability Layer</strong>. This is the developer surface: <strong className="font-semibold text-white">Capabilities in. Receipts out. Rails abstracted.</strong>

--- a/satgate-landing/app/capability-lifecycle-demo/CapabilityLifecycleDemo.tsx
+++ b/satgate-landing/app/capability-lifecycle-demo/CapabilityLifecycleDemo.tsx
@@ -37,7 +37,7 @@ const lifecycle = [
     label: '4. Revoke',
     title: 'Revoke authority before the next request',
     buyer: 'When the job is complete, behavior falls outside policy, or the parent is revoked, the child is denied on its next gateway-enforced request.',
-    technical: 'Set revocation_state=revoked for the child capability; SatGate rejects the next request at the gateway before upstream execution.',
+    technical: 'Set revocation_state=revoked for the child capability; SatGate rejects the next governed request at the gateway policy check.',
     status: 'Denied',
     evidence: 'revocation decision recorded',
   },

--- a/satgate-landing/app/compare/apigee/page.tsx
+++ b/satgate-landing/app/compare/apigee/page.tsx
@@ -32,7 +32,7 @@ export const metadata = {
 const rows: Array<[string, string, string]> = [
   ['Primary job', 'Policy-to-Proof governance for enterprise agents', 'Enterprise API management, API products, developer portals, analytics, policy, monetization, and Google Cloud integration'],
   ['Best fit', 'Agent/API spend governance, MCP tool budgets, scoped credentials, revocation, Evidence Packs, and paid-rail context', 'Enterprise API management, API products, developer portals, analytics, policy, monetization, and Google Cloud integration'],
-  ['Request-path hard budget enforcement', 'Yes: before upstream API, model, or MCP tool access', 'Partial / depends on gateway policy and traffic type'],
+  ['Request-path hard budget enforcement', 'Yes: at the gateway before forwarding to an upstream API, model, or MCP tool', 'Partial / depends on gateway policy and traffic type'],
   ['MCP tool budget enforcement', 'Yes: per-tool budgets, cost attribution, and deny decisions', 'Not the primary category focus'],
   ['Scoped revocable agent capabilities', 'Yes: route, tool, call, budget, expiry, delegation, and revocation caveats', 'Typically API keys, policies, tokens, or platform auth primitives'],
   ['Runaway agent spend benchmark/data', 'Yes: benchmark page plus JSON/CSV dataset', 'No direct equivalent'],
@@ -70,7 +70,7 @@ export default function ComparePage() {
     '@type': 'FAQPage',
     mainEntity: [
       { '@type': 'Question', name: 'Is SatGate a Google Apigee replacement?', acceptedAnswer: { '@type': 'Answer', text: 'Not directly. Apigee is a full enterprise API management platform. SatGate is an Policy-to-Proof governance for AI agents, API spend, MCP tools, scoped capabilities, revocation, Evidence Packs, and paid-rail context.' } },
-      { '@type': 'Question', name: 'Can SatGate and Google Apigee work together?', acceptedAnswer: { '@type': 'Answer', text: 'Yes. SatGate can sit in front of or alongside gateway, API management, or observability infrastructure to enforce agent economics before upstream access.' } },
+      { '@type': 'Question', name: 'Can SatGate and Google Apigee work together?', acceptedAnswer: { '@type': 'Answer', text: 'Yes. SatGate can sit in front of or alongside gateway, API management, or observability infrastructure to enforce agent economics at the gateway before forwarding.' } },
       { '@type': 'Question', name: 'When should I choose SatGate?', acceptedAnswer: { '@type': 'Answer', text: 'Choose SatGate when the core problem is autonomous agent economic governance: hard budgets, MCP tool spend, revocable credentials, delegated authority, Evidence Packs, and paid-agent payment.' } },
       { '@type': 'Question', name: 'When should I choose Google Apigee?', acceptedAnswer: { '@type': 'Answer', text: 'Choose Apigee when the primary need is broad enterprise API management across human and application consumers.' } },
     ],
@@ -106,7 +106,7 @@ export default function ComparePage() {
           <div className="grid gap-5 md:grid-cols-2">
             {[
               ['Is SatGate a Google Apigee replacement?', 'Not directly. Apigee is a full enterprise API management platform. SatGate is an Policy-to-Proof governance for AI agents, API spend, MCP tools, scoped capabilities, revocation, Evidence Packs, and paid-rail context.'],
-              ['Can SatGate and Google Apigee work together?', 'Yes. SatGate can sit in front of or alongside gateway, API management, or observability infrastructure to enforce agent economics before upstream access.'],
+              ['Can SatGate and Google Apigee work together?', 'Yes. SatGate can sit in front of or alongside gateway, API management, or observability infrastructure to enforce agent economics at the gateway before forwarding.'],
               ['When should I choose SatGate?', 'Choose SatGate when the core problem is autonomous agent economic governance: hard budgets, MCP tool spend, revocable credentials, delegated authority, Evidence Packs, and paid-agent payment.'],
               ['When should I choose Google Apigee?', 'Choose Apigee when the primary need is broad enterprise API management across human and application consumers.'],
             ].map(([question, answer]) => (

--- a/satgate-landing/app/compare/cloud-native/page.tsx
+++ b/satgate-landing/app/compare/cloud-native/page.tsx
@@ -93,7 +93,7 @@ const CloudNativeComparisonPage = () => {
         name: 'How is SatGate different from AWS, Azure, or GCP AI governance?',
         acceptedAnswer: {
           '@type': 'Answer',
-          text: 'SatGate is provider-neutral and enforces economic policy before upstream calls execute. It can cap per-agent, per-tool, and per-task spend across clouds instead of relying on one cloud billing system.',
+          text: 'SatGate is provider-neutral and enforces economic policy at the gateway before forwarding to upstream services. It can cap per-agent, per-tool, and per-task spend across clouds instead of relying on one cloud billing system.',
         },
       },
       {
@@ -301,7 +301,7 @@ const CloudNativeComparisonPage = () => {
           <div className="space-y-5">
             {[
               ['Why are cloud-native AI governance tools not enough for autonomous agents?', 'Cloud-native tools are usually siloed to one provider and built around IAM, logs, and after-the-fact billing. Autonomous agents need request-path controls that follow tool calls across clouds, APIs, and MCP servers.'],
-              ['How is SatGate different from AWS, Azure, or GCP AI governance?', 'SatGate is provider-neutral and enforces economic policy before upstream calls execute. It can cap per-agent, per-tool, and per-task spend across clouds instead of relying on one cloud billing system.'],
+              ['How is SatGate different from AWS, Azure, or GCP AI governance?', 'SatGate is provider-neutral and enforces economic policy at the gateway before forwarding to upstream services. It can cap per-agent, per-tool, and per-task spend across clouds instead of relying on one cloud billing system.'],
               ['Can SatGate work alongside cloud-native AI platforms?', 'Yes. SatGate can sit between agents and cloud-hosted models or tools, adding budget enforcement, cost attribution, and policy controls while the cloud platform continues to provide compute and model hosting.'],
             ].map(([question, answer]) => (
               <div key={question} className="border-t border-gray-800 pt-5 first:border-t-0 first:pt-0">

--- a/satgate-landing/app/compare/helicone/page.tsx
+++ b/satgate-landing/app/compare/helicone/page.tsx
@@ -39,7 +39,7 @@ const rows: Array<[string, string, string]> = [
 ];
 
 const satgateWins = [
-  { icon: ShieldCheck, title: 'Economic firewall in the request path', body: 'SatGate decides whether an agent should access, spend, route, delegate, or pay before upstream APIs, MCP tools, and model calls execute.' },
+  { icon: ShieldCheck, title: 'Economic firewall in the request path', body: 'SatGate decides whether an agent should access, spend, route, delegate, or pay at the gateway before forwarding to upstream APIs, MCP tools, and model calls.' },
   { icon: Gauge, title: 'Hard budgets for autonomous workflows', body: 'Control spend by tenant, agent, workflow, delegated sub-agent, route, model, tool, session, day, and request.' },
   { icon: KeyRound, title: 'Scoped, revocable agent authority', body: 'Issue expiring capabilities constrained by route, tool, budget, call count, expiry, and delegation rules instead of broad static keys.' },
   { icon: Zap, title: 'Govern paid-rail access', body: 'Govern paid-rail context before external agents access APIs, datasets, tools, or premium capabilities at request time.' },

--- a/satgate-landing/app/compare/kong-ai-gateway/page.tsx
+++ b/satgate-landing/app/compare/kong-ai-gateway/page.tsx
@@ -32,7 +32,7 @@ export const metadata = {
 const rows: Array<[string, string, string]> = [
   ['Primary job', 'Policy-to-Proof governance for enterprise agents', 'API gateway, AI gateway, service connectivity, plugins, traffic policy, API platform operations'],
   ['Best fit', 'Agent/API spend governance, MCP tool budgets, scoped credentials, revocation, Evidence Packs, and paid-rail context', 'API gateway, AI gateway, service connectivity, plugins, traffic policy, API platform operations'],
-  ['Request-path hard budget enforcement', 'Yes: before upstream API, model, or MCP tool access', 'Partial / depends on gateway policy and traffic type'],
+  ['Request-path hard budget enforcement', 'Yes: at the gateway before forwarding to an upstream API, model, or MCP tool', 'Partial / depends on gateway policy and traffic type'],
   ['MCP tool budget enforcement', 'Yes: per-tool budgets, cost attribution, and deny decisions', 'Not the primary category focus'],
   ['Scoped revocable agent capabilities', 'Yes: route, tool, call, budget, expiry, delegation, and revocation caveats', 'Typically API keys, policies, tokens, or platform auth primitives'],
   ['Runaway agent spend benchmark/data', 'Yes: benchmark page plus JSON/CSV dataset', 'No direct equivalent'],
@@ -70,7 +70,7 @@ export default function ComparePage() {
     '@type': 'FAQPage',
     mainEntity: [
       { '@type': 'Question', name: 'Is SatGate a Kong AI Gateway replacement?', acceptedAnswer: { '@type': 'Answer', text: 'Not directly. Kong AI Gateway is the AI-facing extension of a mature API gateway platform. SatGate is an Policy-to-Proof governance for AI agents, API spend, MCP tools, scoped capabilities, revocation, Evidence Packs, and paid-rail context.' } },
-      { '@type': 'Question', name: 'Can SatGate and Kong AI Gateway work together?', acceptedAnswer: { '@type': 'Answer', text: 'Yes. SatGate can sit in front of or alongside gateway, API management, or observability infrastructure to enforce agent economics before upstream access.' } },
+      { '@type': 'Question', name: 'Can SatGate and Kong AI Gateway work together?', acceptedAnswer: { '@type': 'Answer', text: 'Yes. SatGate can sit in front of or alongside gateway, API management, or observability infrastructure to enforce agent economics at the gateway before forwarding.' } },
       { '@type': 'Question', name: 'When should I choose SatGate?', acceptedAnswer: { '@type': 'Answer', text: 'Choose SatGate when the core problem is autonomous agent economic governance: hard budgets, MCP tool spend, revocable credentials, delegated authority, Evidence Packs, and paid-agent payment.' } },
       { '@type': 'Question', name: 'When should I choose Kong AI Gateway?', acceptedAnswer: { '@type': 'Answer', text: 'Choose Kong when the primary need is a broad API gateway/API management platform with AI traffic support.' } },
     ],
@@ -106,7 +106,7 @@ export default function ComparePage() {
           <div className="grid gap-5 md:grid-cols-2">
             {[
               ['Is SatGate a Kong AI Gateway replacement?', 'Not directly. Kong AI Gateway is the AI-facing extension of a mature API gateway platform. SatGate is an Policy-to-Proof governance for AI agents, API spend, MCP tools, scoped capabilities, revocation, Evidence Packs, and paid-rail context.'],
-              ['Can SatGate and Kong AI Gateway work together?', 'Yes. SatGate can sit in front of or alongside gateway, API management, or observability infrastructure to enforce agent economics before upstream access.'],
+              ['Can SatGate and Kong AI Gateway work together?', 'Yes. SatGate can sit in front of or alongside gateway, API management, or observability infrastructure to enforce agent economics at the gateway before forwarding.'],
               ['When should I choose SatGate?', 'Choose SatGate when the core problem is autonomous agent economic governance: hard budgets, MCP tool spend, revocable credentials, delegated authority, Evidence Packs, and paid-agent payment.'],
               ['When should I choose Kong AI Gateway?', 'Choose Kong when the primary need is a broad API gateway/API management platform with AI traffic support.'],
             ].map(([question, answer]) => (

--- a/satgate-landing/app/compare/langfuse/page.tsx
+++ b/satgate-landing/app/compare/langfuse/page.tsx
@@ -32,7 +32,7 @@ export const metadata = {
 const rows: Array<[string, string, string]> = [
   ['Primary job', 'Policy-to-Proof governance for enterprise agents', 'LLM observability, traces, prompt management, evaluations, metrics, debugging, and product analytics for AI applications'],
   ['Best fit', 'Agent/API spend governance, MCP tool budgets, scoped credentials, revocation, Evidence Packs, and paid-rail context', 'LLM observability, traces, prompt management, evaluations, metrics, debugging, and product analytics for AI applications'],
-  ['Request-path hard budget enforcement', 'Yes: before upstream API, model, or MCP tool access', 'Partial / depends on gateway policy and traffic type'],
+  ['Request-path hard budget enforcement', 'Yes: at the gateway before forwarding to an upstream API, model, or MCP tool', 'Partial / depends on gateway policy and traffic type'],
   ['MCP tool budget enforcement', 'Yes: per-tool budgets, cost attribution, and deny decisions', 'Not the primary category focus'],
   ['Scoped revocable agent capabilities', 'Yes: route, tool, call, budget, expiry, delegation, and revocation caveats', 'Typically API keys, policies, tokens, or platform auth primitives'],
   ['Runaway agent spend benchmark/data', 'Yes: benchmark page plus JSON/CSV dataset', 'No direct equivalent'],
@@ -70,7 +70,7 @@ export default function ComparePage() {
     '@type': 'FAQPage',
     mainEntity: [
       { '@type': 'Question', name: 'Is SatGate a Langfuse replacement?', acceptedAnswer: { '@type': 'Answer', text: 'Not directly. Langfuse is an LLM observability and evaluation platform. SatGate is an Policy-to-Proof governance for AI agents, API spend, MCP tools, scoped capabilities, revocation, Evidence Packs, and paid-rail context.' } },
-      { '@type': 'Question', name: 'Can SatGate and Langfuse work together?', acceptedAnswer: { '@type': 'Answer', text: 'Yes. SatGate can sit in front of or alongside gateway, API management, or observability infrastructure to enforce agent economics before upstream access.' } },
+      { '@type': 'Question', name: 'Can SatGate and Langfuse work together?', acceptedAnswer: { '@type': 'Answer', text: 'Yes. SatGate can sit in front of or alongside gateway, API management, or observability infrastructure to enforce agent economics at the gateway before forwarding.' } },
       { '@type': 'Question', name: 'When should I choose SatGate?', acceptedAnswer: { '@type': 'Answer', text: 'Choose SatGate when the core problem is autonomous agent economic governance: hard budgets, MCP tool spend, revocable credentials, delegated authority, Evidence Packs, and paid-agent payment.' } },
       { '@type': 'Question', name: 'When should I choose Langfuse?', acceptedAnswer: { '@type': 'Answer', text: 'Choose Langfuse when the primary need is tracing, prompt management, evaluations, metrics, and AI application observability.' } },
     ],
@@ -106,7 +106,7 @@ export default function ComparePage() {
           <div className="grid gap-5 md:grid-cols-2">
             {[
               ['Is SatGate a Langfuse replacement?', 'Not directly. Langfuse is an LLM observability and evaluation platform. SatGate is an Policy-to-Proof governance for AI agents, API spend, MCP tools, scoped capabilities, revocation, Evidence Packs, and paid-rail context.'],
-              ['Can SatGate and Langfuse work together?', 'Yes. SatGate can sit in front of or alongside gateway, API management, or observability infrastructure to enforce agent economics before upstream access.'],
+              ['Can SatGate and Langfuse work together?', 'Yes. SatGate can sit in front of or alongside gateway, API management, or observability infrastructure to enforce agent economics at the gateway before forwarding.'],
               ['When should I choose SatGate?', 'Choose SatGate when the core problem is autonomous agent economic governance: hard budgets, MCP tool spend, revocable credentials, delegated authority, Evidence Packs, and paid-agent payment.'],
               ['When should I choose Langfuse?', 'Choose Langfuse when the primary need is tracing, prompt management, evaluations, metrics, and AI application observability.'],
             ].map(([question, answer]) => (

--- a/satgate-landing/app/compare/litellm/page.tsx
+++ b/satgate-landing/app/compare/litellm/page.tsx
@@ -45,7 +45,7 @@ const satgateWins: Array<{ icon: typeof ShieldCheck; title: string; body: string
   {
     icon: ShieldCheck,
     title: 'Economic firewall, not just LLM gateway',
-    body: 'SatGate governs whether an agent should access, spend, route, delegate, or pay before upstream APIs and tools execute.',
+    body: 'SatGate governs whether an agent should access, spend, route, delegate, or pay at the gateway before forwarding to upstream APIs and tools.',
   },
   {
     icon: Gauge,

--- a/satgate-landing/app/compare/page.tsx
+++ b/satgate-landing/app/compare/page.tsx
@@ -201,7 +201,7 @@ export default function ComparePage() {
         name: 'How is SatGate different from AI gateways?',
         acceptedAnswer: {
           '@type': 'Answer',
-          text: 'Most AI gateways focus on routing, provider abstraction, caching, rate limits, observability, or prompt operations. SatGate focuses on request-path economic governance: hard budgets, scoped agent authority, MCP tool cost policy, audit evidence, revocation, and paid-rail context before upstream access.',
+          text: 'Most AI gateways focus on routing, provider abstraction, caching, rate limits, observability, or prompt operations. SatGate focuses on request-path economic governance: hard budgets, scoped agent authority, MCP tool cost policy, audit evidence, revocation, and paid-rail context at the gateway before forwarding.',
         },
       },
       {
@@ -249,7 +249,7 @@ export default function ComparePage() {
           </div>
           <h1 className="mb-5 text-5xl font-extrabold tracking-tight md:text-7xl">Compare SatGate</h1>
           <p className="text-xl leading-relaxed text-gray-300 md:text-2xl">
-            Most AI gateways help route, observe, or expose model/API traffic. SatGate focuses on economic governance: hard budgets, MCP tool cost attribution, scoped agent authority, Evidence Packs, and paid-rail context before upstream access.
+            Most AI gateways help route, observe, or expose model/API traffic. SatGate focuses on economic governance: hard budgets, MCP tool cost attribution, scoped agent authority, Evidence Packs, and paid-rail context at the gateway before forwarding.
           </p>
         </div>
 
@@ -288,7 +288,7 @@ export default function ComparePage() {
             {[
               [
                 'How is SatGate different from AI gateways?',
-                'Most AI gateways focus on routing, provider abstraction, caching, rate limits, observability, or prompt operations. SatGate focuses on request-path economic governance: hard budgets, scoped agent authority, MCP tool cost policy, audit evidence, revocation, and paid-rail context before upstream access.',
+                'Most AI gateways focus on routing, provider abstraction, caching, rate limits, observability, or prompt operations. SatGate focuses on request-path economic governance: hard budgets, scoped agent authority, MCP tool cost policy, audit evidence, revocation, and paid-rail context at the gateway before forwarding.',
               ],
               [
                 'Does SatGate replace LiteLLM, Portkey, Helicone, or Cloudflare AI Gateway?',

--- a/satgate-landing/app/compare/portkey/page.tsx
+++ b/satgate-landing/app/compare/portkey/page.tsx
@@ -39,7 +39,7 @@ const rows: Array<[string, string, string]> = [
 ];
 
 const satgateWins = [
-  { icon: ShieldCheck, title: 'Economic firewall in the request path', body: 'SatGate decides whether an agent should access, spend, route, delegate, or pay before upstream APIs, MCP tools, and model calls execute.' },
+  { icon: ShieldCheck, title: 'Economic firewall in the request path', body: 'SatGate decides whether an agent should access, spend, route, delegate, or pay at the gateway before forwarding to upstream APIs, MCP tools, and model calls.' },
   { icon: Gauge, title: 'Hard budgets for autonomous workflows', body: 'Control spend by tenant, agent, workflow, delegated sub-agent, route, model, tool, session, day, and request.' },
   { icon: KeyRound, title: 'Scoped, revocable agent authority', body: 'Issue expiring capabilities constrained by route, tool, budget, call count, expiry, and delegation rules instead of broad static keys.' },
   { icon: Zap, title: 'Govern paid-rail access', body: 'Govern paid-rail context before external agents access APIs, datasets, tools, or premium capabilities at request time.' },

--- a/satgate-landing/app/compare/tyk/page.tsx
+++ b/satgate-landing/app/compare/tyk/page.tsx
@@ -32,7 +32,7 @@ export const metadata = {
 const rows: Array<[string, string, string]> = [
   ['Primary job', 'Policy-to-Proof governance for enterprise agents', 'API gateway, API management, policies, developer portal, analytics, self-managed/hybrid/cloud deployment, AI-native APIM'],
   ['Best fit', 'Agent/API spend governance, MCP tool budgets, scoped credentials, revocation, Evidence Packs, and paid-rail context', 'API gateway, API management, policies, developer portal, analytics, self-managed/hybrid/cloud deployment, AI-native APIM'],
-  ['Request-path hard budget enforcement', 'Yes: before upstream API, model, or MCP tool access', 'Partial / depends on gateway policy and traffic type'],
+  ['Request-path hard budget enforcement', 'Yes: at the gateway before forwarding to an upstream API, model, or MCP tool', 'Partial / depends on gateway policy and traffic type'],
   ['MCP tool budget enforcement', 'Yes: per-tool budgets, cost attribution, and deny decisions', 'Not the primary category focus'],
   ['Scoped revocable agent capabilities', 'Yes: route, tool, call, budget, expiry, delegation, and revocation caveats', 'Typically API keys, policies, tokens, or platform auth primitives'],
   ['Runaway agent spend benchmark/data', 'Yes: benchmark page plus JSON/CSV dataset', 'No direct equivalent'],
@@ -70,7 +70,7 @@ export default function ComparePage() {
     '@type': 'FAQPage',
     mainEntity: [
       { '@type': 'Question', name: 'Is SatGate a Tyk replacement?', acceptedAnswer: { '@type': 'Answer', text: 'Not directly. Tyk is an API management platform with gateway, governance, analytics, and portal capabilities. SatGate is an Policy-to-Proof governance for AI agents, API spend, MCP tools, scoped capabilities, revocation, Evidence Packs, and paid-rail context.' } },
-      { '@type': 'Question', name: 'Can SatGate and Tyk work together?', acceptedAnswer: { '@type': 'Answer', text: 'Yes. SatGate can sit in front of or alongside gateway, API management, or observability infrastructure to enforce agent economics before upstream access.' } },
+      { '@type': 'Question', name: 'Can SatGate and Tyk work together?', acceptedAnswer: { '@type': 'Answer', text: 'Yes. SatGate can sit in front of or alongside gateway, API management, or observability infrastructure to enforce agent economics at the gateway before forwarding.' } },
       { '@type': 'Question', name: 'When should I choose SatGate?', acceptedAnswer: { '@type': 'Answer', text: 'Choose SatGate when the core problem is autonomous agent economic governance: hard budgets, MCP tool spend, revocable credentials, delegated authority, Evidence Packs, and paid-agent payment.' } },
       { '@type': 'Question', name: 'When should I choose Tyk?', acceptedAnswer: { '@type': 'Answer', text: 'Choose Tyk when the primary need is a flexible API management platform for publishing and operating APIs.' } },
     ],
@@ -106,7 +106,7 @@ export default function ComparePage() {
           <div className="grid gap-5 md:grid-cols-2">
             {[
               ['Is SatGate a Tyk replacement?', 'Not directly. Tyk is an API management platform with gateway, governance, analytics, and portal capabilities. SatGate is an Policy-to-Proof governance for AI agents, API spend, MCP tools, scoped capabilities, revocation, Evidence Packs, and paid-rail context.'],
-              ['Can SatGate and Tyk work together?', 'Yes. SatGate can sit in front of or alongside gateway, API management, or observability infrastructure to enforce agent economics before upstream access.'],
+              ['Can SatGate and Tyk work together?', 'Yes. SatGate can sit in front of or alongside gateway, API management, or observability infrastructure to enforce agent economics at the gateway before forwarding.'],
               ['When should I choose SatGate?', 'Choose SatGate when the core problem is autonomous agent economic governance: hard budgets, MCP tool spend, revocable credentials, delegated authority, Evidence Packs, and paid-agent payment.'],
               ['When should I choose Tyk?', 'Choose Tyk when the primary need is a flexible API management platform for publishing and operating APIs.'],
             ].map(([question, answer]) => (

--- a/satgate-landing/app/components/HomeClient.tsx
+++ b/satgate-landing/app/components/HomeClient.tsx
@@ -415,7 +415,7 @@ const LandingPage = () => {
               <ul className="text-xs text-gray-500 space-y-1">
                 <li>✓ Let approved agents consume APIs without long-lived shared secrets</li>
                 <li>✓ Preserve authority evidence above x402, L402, API-key, or enterprise billing rails</li>
-                <li>✓ Per-request pricing and policy before upstream execution</li>
+                <li>✓ Per-request pricing and policy at the gateway before forwarding</li>
                 <li>✓ Approved agents consume scoped access and leave an Evidence Pack</li>
               </ul>
             </div>
@@ -536,14 +536,14 @@ const LandingPage = () => {
               <DollarSign className="text-green-400 mb-2" size={20} />
               <h3 className="font-bold text-sm mb-1">Budget Ceilings</h3>
               <p className="text-gray-400 text-xs">
-                Per-agent and per-route economic policy, enforced before upstream execution.
+                Per-agent and per-route economic policy, checked at the gateway before forwarding.
               </p>
             </div>
             <div className="p-4 rounded-lg bg-gray-800/50 border border-gray-700">
               <Zap className="text-yellow-400 mb-2" size={20} />
               <h3 className="font-bold text-sm mb-1">Immediate Enforcement</h3>
               <p className="text-gray-400 text-xs">
-                When limits hit, requests stop. Not after billing. Now.
+                When limits hit, the gateway denies the next governed request before forwarding.
               </p>
             </div>
           </div>

--- a/satgate-landing/app/crawl/page.tsx
+++ b/satgate-landing/app/crawl/page.tsx
@@ -538,7 +538,7 @@ export default function ProtectDemoPage() {
         
         addLog('', 'info');
         addLog('✅ Token BANNED successfully!', 'success');
-        addLog('⚡ Propagation: INSTANT (no sync delay)', 'success');
+        addLog('✅ Revocation state recorded for the next governed check', 'success');
         addLog('📝 Ban reason: "Demo revocation - compromised token"', 'info');
         addLog('🔗 All child tokens derived from this: ALSO BANNED', 'warn');
         
@@ -574,7 +574,7 @@ export default function ProtectDemoPage() {
       const data = await response.json();
       addLog('', 'info');
       addLog('✅ Token BANNED successfully!', 'success');
-      addLog('⚡ Propagation: INSTANT', 'success');
+      addLog('✅ Revocation state recorded', 'success');
       
       setBannedToken(childToken.raw);
       setRevocationResult({ banned: true, tested: false });
@@ -614,7 +614,7 @@ export default function ProtectDemoPage() {
         addLog('   reason: "This token has been banned by an administrator"', 'error');
         addLog('   code: "TOKEN_BANNED"', 'error');
         addLog('', 'info');
-        addLog('💡 The Panic Button worked. Token is dead globally.', 'success');
+        addLog('💡 The Panic Button worked. The next governed request was denied.', 'success');
         
         setRevocationResult({ banned: true, tested: true });
         return;
@@ -631,7 +631,7 @@ export default function ProtectDemoPage() {
         addLog('🚫 403 Forbidden - TOKEN REVOKED!', 'error');
         addLog(`📝 Response: ${JSON.stringify(data)}`, 'info');
         addLog('', 'info');
-        addLog('💡 The Panic Button worked. Token is dead globally.', 'success');
+        addLog('💡 The Panic Button worked. The next governed request was denied.', 'success');
         setRevocationResult({ banned: true, tested: true });
       } else {
         addLog(`⚠️ Unexpected response: ${response.status}`, 'warn');
@@ -1328,11 +1328,11 @@ export default function ProtectDemoPage() {
 
                       <div className="bg-gradient-to-r from-orange-950/30 to-red-950/30 rounded-xl p-4 border border-orange-800/30">
                         <h4 className="font-semibold text-white mb-2 flex items-center gap-2">
-                          <Zap size={16} className="text-yellow-400" /> Instant Propagation
+                          <Zap size={16} className="text-yellow-400" /> Next-request check
                         </h4>
                         <p className="text-gray-400 text-sm">
                           Unlike traditional IAM where revocation can take minutes/hours to propagate, 
-                          SatGate's ban list is checked on every request. The token is dead <strong>now</strong>.
+                          SatGate's ban list is checked on every governed request. The next request is denied at the gateway policy check.
                         </p>
                       </div>
 
@@ -1363,7 +1363,7 @@ export default function ProtectDemoPage() {
                           <XCircle size={18} /> Token Rejected!
                         </div>
                         <p className="text-gray-400 text-sm mb-3">
-                          The banned token is rejected on the next governed request. The attacker is locked out.
+                          The banned token is rejected on the next governed request at the gateway policy check.
                         </p>
                         <pre className="text-xs bg-black rounded-lg p-3 text-red-400 overflow-x-auto">
 {`{
@@ -1376,8 +1376,8 @@ export default function ProtectDemoPage() {
 
                       <div className="grid grid-cols-2 gap-4">
                         <div className="p-4 bg-black rounded-xl border border-orange-800/50 text-center">
-                          <div className="text-2xl font-bold text-orange-400 mb-1">Instant</div>
-                          <div className="text-gray-400 text-xs">Revocation Time</div>
+                          <div className="text-2xl font-bold text-orange-400 mb-1">Next request</div>
+                          <div className="text-gray-400 text-xs">Revocation Check</div>
                         </div>
                         <div className="p-4 bg-black rounded-xl border border-red-800/50 text-center">
                           <div className="text-2xl font-bold text-red-400 mb-1">Global</div>
@@ -1408,8 +1408,8 @@ export default function ProtectDemoPage() {
                       <div className="text-gray-400 text-sm">Admin tickets required</div>
                     </div>
                     <div className="p-4 bg-black rounded-xl border border-orange-800/50">
-                      <div className="text-3xl font-bold text-orange-400 mb-1">Instant</div>
-                      <div className="text-gray-400 text-sm">Kill Switch revocation</div>
+                      <div className="text-3xl font-bold text-orange-400 mb-1">Next request</div>
+                      <div className="text-gray-400 text-sm">Kill Switch check</div>
                     </div>
                   </div>
 

--- a/satgate-landing/app/dashboard/page.tsx
+++ b/satgate-landing/app/dashboard/page.tsx
@@ -64,7 +64,7 @@ const faqJsonLd = {
       name: 'How does dashboard evidence connect to request-path control?',
       acceptedAnswer: {
         '@type': 'Answer',
-        text: 'Dashboard evidence surfaces receipts after SatGate enforces decisions in the request path. The dashboard surfaces receipt-backed decisions; Evidence Packs are the exportable proof artifact; the gateway is where budgets, revocation, scopes, and policy are applied before upstream access.',
+        text: 'Dashboard evidence surfaces receipts after SatGate enforces decisions in the request path. The dashboard surfaces receipt-backed decisions; Evidence Packs are the exportable proof artifact; the gateway is where budgets, revocation, scopes, and policy are applied at the gateway before forwarding.',
       },
     },
   ],
@@ -545,7 +545,7 @@ export default function DashboardPage() {
               {[
                 ['What does the SatGate governance dashboard show?', 'The SatGate governance dashboard shows active agent tokens, delegation depth, caveats, blocked requests, banned tokens, revocation hits, and receipt-backed governance evidence for agent activity.'],
                 ['Why do AI agent teams need receipt-backed governance evidence?', 'Receipt-backed governance evidence shows which agents hold authority, what scopes and budgets apply, whether tokens are delegated, and which allowed, denied, revoked, or paid decisions feed Evidence Packs.'],
-                ['How does dashboard evidence connect to request-path control?', 'Dashboard evidence surfaces receipts after SatGate enforces decisions in the request path. The dashboard surfaces receipt-backed decisions; Evidence Packs are the exportable proof artifact; the gateway is where budgets, revocation, scopes, and policy are applied before upstream access.'],
+                ['How does dashboard evidence connect to request-path control?', 'Dashboard evidence surfaces receipts after SatGate enforces decisions in the request path. The dashboard surfaces receipt-backed decisions; Evidence Packs are the exportable proof artifact; the gateway is where budgets, revocation, scopes, and policy are applied at the gateway before forwarding.'],
               ].map(([question, answer]) => (
                 <div key={question} className="rounded-xl border border-gray-800 bg-gray-900 p-5">
                   <h3 className="mb-2 font-bold text-white">{question}</h3>

--- a/satgate-landing/app/economic-firewall/page.tsx
+++ b/satgate-landing/app/economic-firewall/page.tsx
@@ -128,7 +128,7 @@ export default function EconomicFirewallPage() {
     '@context': 'https://schema.org',
     '@type': 'DefinedTerm',
     name: 'Economic firewall',
-    description: 'A request-path control layer that governs AI agent authority, spend, budgets, revocation, audit evidence, and payment context before upstream API calls execute.',
+    description: 'A request-path control layer that governs AI agent authority, spend, budgets, revocation, audit evidence, and payment context at the gateway before forwarding to upstream APIs.',
     inDefinedTermSet: 'https://satgate.io/economic-firewall',
     url: 'https://satgate.io/economic-firewall',
   };
@@ -287,7 +287,7 @@ export default function EconomicFirewallPage() {
                 Paid rails such as x402, L402, AgentCore Payments, Pay.sh, API-key billing, and wallet flows can help value move between agents and services. That is useful, but payment approval is not the same as governing agent behavior.
               </p>
               <p>
-                An economic firewall sits earlier in the path. It decides whether an agent may access an API, consume budget, call an MCP tool, delegate authority, or unlock a paid resource before upstream work happens.
+                An economic firewall sits at the gateway boundary. It decides whether an agent may access an API, consume budget, call an MCP tool, delegate authority, or unlock a paid resource before forwarding.
               </p>
               <p className="font-semibold text-white">
                 Payment rails authorize value movement. Economic firewalls authorize behavior — and preserve the proof.

--- a/satgate-landing/app/http-402-for-ai-agents/page.tsx
+++ b/satgate-landing/app/http-402-for-ai-agents/page.tsx
@@ -114,7 +114,7 @@ export default function Http402ForAiAgentsPage() {
             That challenge may point to different rails: card-based credentials, shared payment tokens, paid-rail context invoices, or future protocols. But the payment challenge is not the governance layer.
           </p>
           <p>
-            SatGate sits before upstream access and applies policy: identify the agent, confirm authority, estimate cost, enforce budgets, decide whether the rail is allowed, record the challenge, and unlock only scoped access after proof.
+            SatGate sits at the gateway before forwarding and applies policy: identify the agent, confirm authority, estimate cost, enforce budgets, decide whether the rail is allowed, record the challenge, and unlock only scoped access after proof.
           </p>
         </div>
         <div className="rounded-2xl border border-yellow-900/50 bg-yellow-950/10 p-6">

--- a/satgate-landing/app/l402-agent-payments/page.tsx
+++ b/satgate-landing/app/l402-agent-payments/page.tsx
@@ -26,7 +26,7 @@ export const metadata = {
   twitter: {
     card: 'summary_large_image',
     title: 'L402 Paid-Rail Governance for APIs',
-    description: 'L402 can carry Lightning payment proof for agent/API access. SatGate governs the action, budget, rail, and receipt before upstream execution.',
+    description: 'L402 can carry Lightning payment proof for agent/API access. SatGate checks the action, budget, rail, and receipt at the gateway before forwarding.',
   },
 };
 
@@ -303,7 +303,7 @@ HTTP/1.1 200 OK
 { "answer": "paid premium result" }`}</code></pre>
         </div>
         <p className="text-gray-400 mt-5 leading-relaxed">
-          In this pattern, the merchant runs SatGate. The delegated client or wallet presents payment proof. Payment, authorization, receipt capture, and audit happen before upstream access.
+          In this pattern, the merchant runs SatGate. The delegated client or wallet presents payment proof. Payment, authorization, receipt capture, and audit happen at the gateway before forwarding.
         </p>
       </section>
 

--- a/satgate-landing/app/l402-api-pricing-calculator/page.tsx
+++ b/satgate-landing/app/l402-api-pricing-calculator/page.tsx
@@ -122,7 +122,7 @@ export default function L402ApiPricingCalculatorPage() {
         name: 'How should APIs price paid agent access?',
         acceptedAnswer: {
           '@type': 'Answer',
-          text: 'Start from marginal cost per request, add target gross margin, account for free allowances or trial traffic, and enforce payment or budget policy before upstream access. L402 is one paid rail; SatGate preserves the authority and receipt context around access.',
+          text: 'Start from marginal cost per request, add target gross margin, account for free allowances or trial traffic, and enforce payment or budget policy at the gateway before forwarding. L402 is one paid rail; SatGate preserves the authority and receipt context around access.',
         },
       },
       {
@@ -251,7 +251,7 @@ export default function L402ApiPricingCalculatorPage() {
             <div className="rounded-xl border border-gray-800 bg-gray-950 p-6">
               <h3 className="mb-2 text-xl font-bold text-white">How should APIs price paid agent access?</h3>
               <p className="text-gray-400 leading-relaxed">
-                Start from marginal cost per request, add target gross margin, account for free allowances or trial traffic, and enforce payment or budget policy before upstream access. L402 is one paid rail; SatGate preserves the authority and receipt context around access.
+                Start from marginal cost per request, add target gross margin, account for free allowances or trial traffic, and enforce payment or budget policy at the gateway before forwarding. L402 is one paid rail; SatGate preserves the authority and receipt context around access.
               </p>
             </div>
             <div className="rounded-xl border border-gray-800 bg-gray-950 p-6">

--- a/satgate-landing/app/llm-cost-dashboard/page.tsx
+++ b/satgate-landing/app/llm-cost-dashboard/page.tsx
@@ -93,7 +93,7 @@ export default function LlmCostDashboardPage() {
         name: 'How does SatGate turn LLM cost dashboards into enforcement?',
         acceptedAnswer: {
           '@type': 'Answer',
-          text: 'SatGate observes agent/API spend, attributes it by agent and route, then enforces budgets, revocation, routing, and MCP tool policy in the request path before upstream calls execute.',
+          text: 'SatGate observes agent/API spend, attributes it by agent and route, then enforces budgets, revocation, routing, and MCP tool policy in the request path before forwarding to upstream services.',
         },
       },
       {
@@ -248,7 +248,7 @@ export default function LlmCostDashboardPage() {
             </div>
             <div className="rounded-xl border border-gray-800 bg-gray-950 p-6">
               <h3 className="mb-2 text-xl font-bold text-white">How does SatGate turn LLM cost dashboards into enforcement?</h3>
-              <p className="leading-relaxed text-gray-400">SatGate observes agent/API spend, attributes it by agent and route, then enforces budgets, revocation, routing, and MCP tool policy in the request path before upstream calls execute.</p>
+              <p className="leading-relaxed text-gray-400">SatGate observes agent/API spend, attributes it by agent and route, then enforces budgets, revocation, routing, and MCP tool policy in the request path before forwarding to upstream services.</p>
             </div>
             <div className="rounded-xl border border-gray-800 bg-gray-950 p-6">
               <h3 className="mb-2 text-xl font-bold text-white">What should teams do after finding LLM spend risk?</h3>

--- a/satgate-landing/app/llm-cost-monitoring/page.tsx
+++ b/satgate-landing/app/llm-cost-monitoring/page.tsx
@@ -88,7 +88,7 @@ export default function LlmCostMonitoringPage() {
         name: 'How do you turn LLM cost monitoring signals into controls?',
         acceptedAnswer: {
           '@type': 'Answer',
-          text: 'Convert monitoring signals into policy objects: per-agent and per-route budgets, MCP tool caps, model-routing rules, scoped capability tokens, revocation triggers, and Evidence Pack requirements enforced before upstream calls execute.',
+          text: 'Convert monitoring signals into policy objects: per-agent and per-route budgets, MCP tool caps, model-routing rules, scoped capability tokens, revocation triggers, and Evidence Pack requirements enforced at the gateway before forwarding to upstream services.',
         },
       },
     ],
@@ -241,7 +241,7 @@ export default function LlmCostMonitoringPage() {
             </div>
             <div className="rounded-xl border border-gray-800 bg-gray-950 p-6">
               <h3 className="mb-2 text-xl font-bold text-white">How do you turn LLM cost monitoring signals into controls?</h3>
-              <p className="leading-relaxed text-gray-400">Convert monitoring signals into policy objects: per-agent and per-route budgets, MCP tool caps, model-routing rules, scoped capability tokens, revocation triggers, and Evidence Pack requirements enforced before upstream calls execute.</p>
+              <p className="leading-relaxed text-gray-400">Convert monitoring signals into policy objects: per-agent and per-route budgets, MCP tool caps, model-routing rules, scoped capability tokens, revocation triggers, and Evidence Pack requirements enforced at the gateway before forwarding to upstream services.</p>
             </div>
           </div>
         </div>

--- a/satgate-landing/app/mcp-budget-enforcement/page.tsx
+++ b/satgate-landing/app/mcp-budget-enforcement/page.tsx
@@ -116,7 +116,7 @@ export default function McpBudgetEnforcementPage() {
         name: 'Can dashboards enforce MCP spend?',
         acceptedAnswer: {
           '@type': 'Answer',
-          text: 'Dashboards can report spend after the fact. MCP budget enforcement needs to sit in the request path so policy can allow, deny, route, approve, require paid-rail context, or revoke before the tool executes.',
+          text: 'Dashboards can report spend after the fact. MCP budget enforcement needs to sit in the request path so policy can allow, deny, route, approve, require paid-rail context, or revoke at the gateway policy check.',
         },
       },
       {
@@ -268,7 +268,7 @@ export default function McpBudgetEnforcementPage() {
             <div className="rounded-xl border border-gray-800 bg-gray-950 p-6">
               <h3 className="mb-2 text-xl font-bold text-white">Can dashboards enforce MCP spend?</h3>
               <p className="text-gray-400 leading-relaxed">
-                Dashboards can report spend after the fact. MCP budget enforcement needs to sit in the request path so policy can allow, deny, route, approve, require paid-rail context, or revoke before the tool executes.
+                Dashboards can report spend after the fact. MCP budget enforcement needs to sit in the request path so policy can allow, deny, route, approve, require paid-rail context, or revoke at the gateway policy check.
               </p>
             </div>
             <div className="rounded-xl border border-gray-800 bg-gray-950 p-6">

--- a/satgate-landing/app/mcp-cost-control/page.tsx
+++ b/satgate-landing/app/mcp-cost-control/page.tsx
@@ -76,7 +76,7 @@ export default function Page() {
     '@type': 'FAQPage',
     mainEntity: [
       { '@type': 'Question', name: 'What is MCP cost control?', acceptedAnswer: { '@type': 'Answer', text: 'MCP cost control is the practice of pricing, limiting, attributing, and auditing Model Context Protocol tool calls before they execute so agents cannot create hidden API, SaaS, cloud, search, or data spend.' } },
-      { '@type': 'Question', name: 'Why are dashboards not enough?', acceptedAnswer: { '@type': 'Answer', text: 'Dashboards and billing alerts report spend after requests complete. Autonomous agents can loop, retry, and delegate fast enough that budget policy must be enforced before upstream access.' } },
+      { '@type': 'Question', name: 'Why are dashboards not enough?', acceptedAnswer: { '@type': 'Answer', text: 'Dashboards and billing alerts report spend after requests complete. Autonomous agents can loop, retry, and delegate fast enough that budget policy must be enforced at the gateway before forwarding.' } },
       { '@type': 'Question', name: 'How does SatGate help?', acceptedAnswer: { '@type': 'Answer', text: 'SatGate sits in the request path and checks identity, budget, route, tool scope, credential caveats, expiry, revocation, and audit policy before forwarding the request.' } },
       { '@type': 'Question', name: 'How is MCP cost control different from LLM cost control?', acceptedAnswer: { '@type': 'Answer', text: 'LLM cost control focuses on model and token usage. MCP cost control covers tool calls that can trigger paid search, browser automation, cloud actions, SaaS APIs, data lookups, code execution, or delegated workflows outside the LLM bill.' } },
       { '@type': 'Question', name: 'Where should MCP tool cost policy be enforced?', acceptedAnswer: { '@type': 'Answer', text: 'MCP tool cost policy should be enforced in the request path before the MCP server executes the tool, so expensive calls can be blocked, downgraded, routed, approved, revoked, paid, or recorded before cost is created.' } },
@@ -119,7 +119,7 @@ export default function Page() {
           <h2 className="mb-6 text-3xl font-bold text-white">The control point is before the call</h2>
           <div className="space-y-5 text-lg leading-relaxed text-gray-300">
             <p>Autonomous agents can generate real costs through model calls, API requests, MCP tools, delegated sub-agents, retries, and background workflows. If the policy check happens after the request, the money is already spent.</p>
-            <p>SatGate enforces economic policy at the gateway boundary. Every important request can be evaluated against budget, scope, identity, revocation, route, tool, receipt, and audit rules before upstream access.</p>
+            <p>SatGate enforces economic policy at the gateway boundary. Every important request can be evaluated against budget, scope, identity, revocation, route, tool, receipt, and audit rules at the gateway before forwarding.</p>
             <p>That is the difference between cost reporting and economic control.</p>
           </div>
         </div>
@@ -164,7 +164,7 @@ export default function Page() {
             <div className="rounded-xl border border-gray-800 bg-gray-950 p-6">
               <h3 className="mb-2 text-xl font-bold text-white">Why are dashboards not enough?</h3>
               <p className="text-gray-400 leading-relaxed">
-                Dashboards and billing alerts report spend after requests complete. Autonomous agents can loop, retry, and delegate fast enough that budget policy must be enforced before upstream access.
+                Dashboards and billing alerts report spend after requests complete. Autonomous agents can loop, retry, and delegate fast enough that budget policy must be enforced at the gateway before forwarding.
               </p>
             </div>
             <div className="rounded-xl border border-gray-800 bg-gray-950 p-6">

--- a/satgate-landing/app/mcp-gateway/page.tsx
+++ b/satgate-landing/app/mcp-gateway/page.tsx
@@ -42,7 +42,7 @@ const controls = [
 
 const proofRows = [
   ['Claude Desktop / Claude Code', 'MCP stdio config points the client at satgate-mcp before the upstream server.', 'Verified MCP-compatible path: allowed web_search call, budget-exhausted code_execute denial, Evidence Pack-style decision transcript.'],
-  ['Ollama agent wrapper', 'Local Ollama agents use an MCP-capable wrapper that speaks stdio or SSE to SatGate.', 'Same protocol path: list tools, call allowed tool, burn budget, receive denial before upstream execution.'],
+  ['Ollama agent wrapper', 'Local Ollama agents use an MCP-capable wrapper that speaks stdio or SSE to SatGate.', 'Same protocol path: list tools, call allowed tool, burn budget, receive denial at the gateway policy check.'],
   ['Hermes agent runtime', 'Hermes agents running through an MCP client receive no standing tool authority; SatGate grants scoped calls per policy.', 'The sample Evidence Pack shows the receipt fields that bind tenant, agent, tool, policy digest, budget ID, decision reason, and remaining credits.'],
 ];
 

--- a/satgate-landing/app/paid-agent-payments/page.tsx
+++ b/satgate-landing/app/paid-agent-payments/page.tsx
@@ -334,7 +334,7 @@ export default function RobotCustomerPaymentsPage() {
               ['/revocable-agent-credentials', 'Revocable agent credentials', 'Revoke delegated access when policy, budget, or risk changes.'],
               ['/govern', 'AI agent governance', 'Bound delegated agent authority before paid-rail execution.'],
               ['/mcp-budget-enforcement', 'MCP budget enforcement', 'Apply the same budget logic to paid tools and MCP servers.'],
-              ['/ai-agent-cost-control', 'AI agent cost control', 'Stop agent overspend before upstream requests execute.'],
+              ['/ai-agent-cost-control', 'AI agent cost control', 'Stop agent overspend at the gateway policy check.'],
             ].map(([href, title, body]) => (
               <Link key={href} href={href} className="rounded-xl border border-gray-800 bg-gray-950 p-5 transition hover:border-yellow-500/50 hover:bg-yellow-950/10">
                 <h3 className="font-bold text-white mb-2">{title}</h3>

--- a/satgate-landing/app/pay/layout.tsx
+++ b/satgate-landing/app/pay/layout.tsx
@@ -4,7 +4,7 @@ export const metadata: Metadata = {
   title: "L402 Paid-Rail Governance Demo | SatGate",
   alternates: { canonical: "https://satgate.io/pay" },
   description:
-    "See SatGate govern delegated paid API access with paid-rail context, payment proof, scoped authority, receipts, and Evidence Packs before upstream access.",
+    "See SatGate govern delegated paid API access with paid-rail context, payment proof, scoped authority, receipts, and Evidence Packs at the gateway before forwarding.",
   keywords: [
     "L402 paid-rail governance demo",
     "SatGate paid-rail governance",

--- a/satgate-landing/app/protect/layout.tsx
+++ b/satgate-landing/app/protect/layout.tsx
@@ -17,7 +17,7 @@ export const metadata: Metadata = {
   openGraph: {
     title: "AI Agent Budget Enforcement Demo | SatGate Control",
     description:
-      "Watch SatGate enforce per-agent budgets, MCP tool limits, delegation controls, policy decisions, and revocation before upstream spend happens.",
+      "Watch SatGate enforce per-agent budgets, MCP tool limits, delegation controls, policy decisions, and revocation at the gateway policy check.",
     url: "https://satgate.io/protect",
     type: "website",
   },

--- a/satgate-landing/app/protect/page.tsx
+++ b/satgate-landing/app/protect/page.tsx
@@ -565,7 +565,7 @@ export default function ProtectDemoPage() {
         
         addLog('', 'info');
         addLog('✅ Token BANNED successfully!', 'success');
-        addLog('⚡ Propagation: INSTANT (no sync delay)', 'success');
+        addLog('✅ Revocation state recorded for the next governed check', 'success');
         addLog('📝 Ban reason: "Demo revocation - compromised token"', 'info');
         addLog('🔗 All child tokens derived from this: ALSO BANNED', 'warn');
         
@@ -601,7 +601,7 @@ export default function ProtectDemoPage() {
       const data = await response.json();
       addLog('', 'info');
       addLog('✅ Token BANNED successfully!', 'success');
-      addLog('⚡ Propagation: INSTANT', 'success');
+      addLog('✅ Revocation state recorded', 'success');
       
       setBannedToken(childToken.raw);
       setRevocationResult({ banned: true, tested: false });
@@ -641,7 +641,7 @@ export default function ProtectDemoPage() {
         addLog('   reason: "This token has been banned by an administrator"', 'error');
         addLog('   code: "TOKEN_BANNED"', 'error');
         addLog('', 'info');
-        addLog('💡 The Panic Button worked. Token is dead globally.', 'success');
+        addLog('💡 The Panic Button worked. The next governed request was denied.', 'success');
         
         setRevocationResult({ banned: true, tested: true });
         return;
@@ -658,7 +658,7 @@ export default function ProtectDemoPage() {
         addLog('🚫 403 Forbidden - TOKEN REVOKED!', 'error');
         addLog(`📝 Response: ${JSON.stringify(data)}`, 'info');
         addLog('', 'info');
-        addLog('💡 The Panic Button worked. Token is dead globally.', 'success');
+        addLog('💡 The Panic Button worked. The next governed request was denied.', 'success');
         setRevocationResult({ banned: true, tested: true });
       } else {
         addLog(`⚠️ Unexpected response: ${response.status}`, 'warn');
@@ -1436,7 +1436,7 @@ export default function ProtectDemoPage() {
                           <XCircle size={18} /> Token Rejected!
                         </div>
                         <p className="text-gray-400 text-sm mb-3">
-                          The banned token is rejected on the next governed request. The attacker is locked out.
+                          The banned token is rejected on the next governed request at the gateway policy check.
                         </p>
                         <pre className="text-xs bg-black rounded-lg p-3 text-red-400 overflow-x-auto">
 {`{
@@ -1481,8 +1481,8 @@ export default function ProtectDemoPage() {
                       <div className="text-gray-400 text-sm">Admin tickets required</div>
                     </div>
                     <div className="p-4 bg-black rounded-xl border border-orange-800/50">
-                      <div className="text-3xl font-bold text-orange-400 mb-1">Instant</div>
-                      <div className="text-gray-400 text-sm">Kill Switch revocation</div>
+                      <div className="text-3xl font-bold text-orange-400 mb-1">Next request</div>
+                      <div className="text-gray-400 text-sm">Kill Switch check</div>
                     </div>
                   </div>
 

--- a/satgate-landing/app/revocable-agent-credentials/page.tsx
+++ b/satgate-landing/app/revocable-agent-credentials/page.tsx
@@ -56,7 +56,7 @@ export default function Page() {
     mainEntity: [
       { '@type': 'Question', name: 'What is a revocable agent credential?', acceptedAnswer: { '@type': 'Answer', text: 'A revocable agent credential is a scoped, expiring capability issued to an autonomous agent for a specific task, workflow, route, tool, budget, or time window. It can be invalidated before the next request without rotating global API keys.' } },
       { '@type': 'Question', name: 'Why are static API keys risky for AI agents?', acceptedAnswer: { '@type': 'Answer', text: 'Static API keys are broad, long-lived, and hard to delegate safely. Autonomous agents need credentials with scoped authority, budget limits, expiry, revocation, and audit context.' } },
-      { '@type': 'Question', name: 'How does SatGate enforce agent credentials?', acceptedAnswer: { '@type': 'Answer', text: 'SatGate sits in the request path and checks identity, token scope, route, tool, budget, expiry, delegation rules, and revocation state before forwarding upstream access.' } },
+      { '@type': 'Question', name: 'How does SatGate enforce agent credentials?', acceptedAnswer: { '@type': 'Answer', text: 'SatGate sits in the request path and checks identity, token scope, route, tool, budget, expiry, delegation rules, and revocation state before forwarding upstream.' } },
     ],
   };
 
@@ -95,7 +95,7 @@ export default function Page() {
           <div className="space-y-5 text-lg leading-relaxed text-gray-300">
             <p>Human access systems assume stable users, managed devices, predictable sessions, and human-scale request rates. Agent systems are different: credentials can be copied into tools, delegated to sub-agents, retried in loops, and used faster than a billing alert can fire.</p>
             <p>The safe model is not a single permanent secret. It is a request-path capability that answers: what can this agent do, on which route, for how long, with what budget, and can it still be revoked right now?</p>
-            <p>SatGate turns those answers into enforceable policy before upstream API, model, or MCP tool access happens.</p>
+            <p>SatGate turns those answers into enforceable policy at the gateway before forwarding to an upstream API, model, or MCP tool happens.</p>
           </div>
         </div>
         <div className="rounded-2xl border border-yellow-900/50 bg-yellow-950/10 p-6">
@@ -157,7 +157,7 @@ audit:
             {[
               ['What is a revocable agent credential?', 'A revocable agent credential is a scoped, expiring capability issued to an autonomous agent for a specific task, workflow, route, tool, budget, or time window. It can be invalidated before the next request without rotating global API keys.'],
               ['Why are static API keys risky for AI agents?', 'Static API keys are broad, long-lived, and hard to delegate safely. Autonomous agents need credentials with scoped authority, budget limits, expiry, revocation, and audit context.'],
-              ['How does SatGate enforce agent credentials?', 'SatGate sits in the request path and checks identity, token scope, route, tool, budget, expiry, delegation rules, and revocation state before forwarding upstream access.'],
+              ['How does SatGate enforce agent credentials?', 'SatGate sits in the request path and checks identity, token scope, route, tool, budget, expiry, delegation rules, and revocation state before forwarding upstream.'],
             ].map(([question, answer]) => (
               <div key={question} className="rounded-xl border border-gray-800 bg-black p-5">
                 <h3 className="mb-2 font-bold text-white">{question}</h3>

--- a/satgate-landing/app/revocable-capability-token-policy-template/page.tsx
+++ b/satgate-landing/app/revocable-capability-token-policy-template/page.tsx
@@ -167,7 +167,7 @@ export default function RevocableCapabilityTokenPolicyTemplatePage() {
         name: 'How does SatGate enforce these token policies?',
         acceptedAnswer: {
           '@type': 'Answer',
-          text: 'SatGate sits in the request path as an economic firewall, checking token scope, budget, delegation, revocation state, and receipt policy before upstream model, API, MCP, or externally exposed agent access.',
+          text: 'SatGate sits in the request path as an economic firewall, checking token scope, budget, delegation, revocation state, and receipt policy at the gateway before forwarding to model, API, MCP, or externally exposed agent access.',
         },
       },
     ],
@@ -290,7 +290,7 @@ export default function RevocableCapabilityTokenPolicyTemplatePage() {
             </div>
             <div className="rounded-xl border border-gray-800 bg-gray-950 p-6">
               <h3 className="mb-2 text-xl font-bold text-white">How does SatGate enforce these token policies?</h3>
-              <p className="leading-relaxed text-gray-400">SatGate sits in the request path as an economic firewall, checking token scope, budget, delegation, revocation state, and receipt policy before upstream model, API, MCP, or externally exposed agent access.</p>
+              <p className="leading-relaxed text-gray-400">SatGate sits in the request path as an economic firewall, checking token scope, budget, delegation, revocation state, and receipt policy at the gateway before forwarding to model, API, MCP, or externally exposed agent access.</p>
             </div>
           </div>
         </div>

--- a/satgate-landing/app/roi-calculator/page.tsx
+++ b/satgate-landing/app/roi-calculator/page.tsx
@@ -140,7 +140,7 @@ export default function ROICalculatorPage() {
         name: 'How does SatGate reduce runaway AI agent spend?',
         acceptedAnswer: {
           '@type': 'Answer',
-          text: 'SatGate enforces per-agent, per-tool, per-route, and per-request budget policy before upstream API calls execute, blocking or routing requests that exceed economic policy.',
+          text: 'SatGate enforces per-agent, per-tool, per-route, and per-request budget policy at the gateway before forwarding to upstream APIs, blocking or routing requests that exceed economic policy.',
         },
       },
       {
@@ -487,7 +487,7 @@ export default function ROICalculatorPage() {
             </div>
             <div className="rounded-xl border border-gray-800 bg-black/40 p-5">
               <h3 className="mb-2 font-bold text-white">SatGate savings model</h3>
-              <p className="text-sm leading-relaxed text-gray-400">Request-path budget enforcement blocks most loop waste before upstream APIs or MCP tools execute.</p>
+              <p className="text-sm leading-relaxed text-gray-400">Request-path budget enforcement denies over-budget requests at the gateway before forwarding to upstream APIs or MCP tools.</p>
             </div>
           </div>
         </div>
@@ -585,7 +585,7 @@ export default function ROICalculatorPage() {
             <div>
               <h3 className="mb-2 text-xl font-bold text-white">How does SatGate reduce runaway AI agent spend?</h3>
               <p className="text-gray-400 leading-relaxed">
-                SatGate enforces per-agent, per-tool, per-route, and per-request budget policy before upstream API calls execute, blocking or routing requests that exceed economic policy.
+                SatGate enforces per-agent, per-tool, per-route, and per-request budget policy at the gateway before forwarding to upstream APIs, blocking or routing requests that exceed economic policy.
               </p>
             </div>
             <div>

--- a/satgate-landing/app/runaway-agent-cost-calculator/page.tsx
+++ b/satgate-landing/app/runaway-agent-cost-calculator/page.tsx
@@ -107,7 +107,7 @@ export default function RunawayAgentCostCalculatorPage() {
       {
         '@type': 'Question',
         name: 'How does SatGate reduce runaway agent costs?',
-        acceptedAnswer: { '@type': 'Answer', text: 'SatGate enforces request-path budgets, scoped authority, per-tool spend caps, revocation, and route policy before upstream API or MCP tool calls execute, then records the decision in the Evidence Pack.' },
+        acceptedAnswer: { '@type': 'Answer', text: 'SatGate enforces request-path budgets, scoped authority, per-tool spend caps, revocation, and route policy at the gateway before forwarding to upstream APIs or MCP tools, then records the decision in the Evidence Pack.' },
       },
       {
         '@type': 'Question',
@@ -227,7 +227,7 @@ export default function RunawayAgentCostCalculatorPage() {
               [Bot, 'Agent count', 'More autonomous workers means more simultaneous paid decisions.'],
               [Gauge, 'Call velocity', 'Retries and tool loops create cost at machine speed.'],
               [ReceiptText, 'Tool pricing', 'MCP tools can hide search, data, cloud, or premium API costs.'],
-              [ShieldCheck, 'Late detection', 'Dashboards report spend after the bill. Enforcement blocks before execution.'],
+              [ShieldCheck, 'Late detection', 'Dashboards report spend after the bill. Gateway policy checks deny over-budget requests before forwarding.'],
             ].map(([Icon, title, body]) => {
               const TypedIcon = Icon as typeof Bot;
               return (
@@ -262,7 +262,7 @@ export default function RunawayAgentCostCalculatorPage() {
             <div className="rounded-xl border border-gray-800 bg-gray-950 p-6">
               <h3 className="mb-2 text-xl font-bold text-white">How does SatGate reduce runaway agent costs?</h3>
               <p className="text-gray-400 leading-relaxed">
-                SatGate enforces request-path budgets, scoped authority, per-tool spend caps, revocation, and route policy before upstream API or MCP tool calls execute, then records the decision in the Evidence Pack.
+                SatGate enforces request-path budgets, scoped authority, per-tool spend caps, revocation, and route policy at the gateway before forwarding to upstream APIs or MCP tools, then records the decision in the Evidence Pack.
               </p>
             </div>
             <div className="rounded-xl border border-gray-800 bg-gray-950 p-6">

--- a/satgate-landing/app/satgate-for-claude-code/page.tsx
+++ b/satgate-landing/app/satgate-for-claude-code/page.tsx
@@ -77,7 +77,7 @@ export default function SatGateIntegrationPage() {
       {
         '@type': 'Question',
         name: 'Is SatGate just another observability dashboard?',
-        acceptedAnswer: { '@type': 'Answer', text: 'No. SatGate can observe traffic, but its core role is request-path enforcement: budgets, revocation, route policy, capabilities, audit, and L402 payment before upstream access.' },
+        acceptedAnswer: { '@type': 'Answer', text: 'No. SatGate can observe traffic, but its core role is request-path enforcement: budgets, revocation, route policy, capabilities, audit, and L402 payment at the gateway before forwarding.' },
       },
       {
         '@type': 'Question',
@@ -178,7 +178,7 @@ export default function SatGateIntegrationPage() {
           <div className="grid gap-5 md:grid-cols-3">
             {[
               ['Why use SatGate with Claude Code?', 'Claude Code is powerful because it can act autonomously. SatGate adds economic policy so autonomy has budgets, scoped access, revocation, and audit rather than broad keys and after-the-fact billing alerts.'],
-              ['Is SatGate just another observability dashboard?', 'No. SatGate can observe traffic, but its core role is request-path enforcement: budgets, revocation, route policy, capabilities, audit, and L402 payment before upstream access.'],
+              ['Is SatGate just another observability dashboard?', 'No. SatGate can observe traffic, but its core role is request-path enforcement: budgets, revocation, route policy, capabilities, audit, and L402 payment at the gateway before forwarding.'],
               ['Can SatGate start in observe-only mode?', 'Yes. Teams can start with Observe to map agent and tool spend, then graduate to Control policies once safe limits are clear.'],
             ].map(([question, answer]) => (
               <div key={question}>

--- a/satgate-landing/app/satgate-for-claude-desktop/page.tsx
+++ b/satgate-landing/app/satgate-for-claude-desktop/page.tsx
@@ -79,7 +79,7 @@ export default function SatGateIntegrationPage() {
       {
         '@type': 'Question',
         name: 'Is SatGate just another observability dashboard?',
-        acceptedAnswer: { '@type': 'Answer', text: 'No. SatGate can observe traffic, but its core role is request-path enforcement: budgets, revocation, route policy, capabilities, audit, and L402 payment before upstream access.' },
+        acceptedAnswer: { '@type': 'Answer', text: 'No. SatGate can observe traffic, but its core role is request-path enforcement: budgets, revocation, route policy, capabilities, audit, and L402 payment at the gateway before forwarding.' },
       },
       {
         '@type': 'Question',
@@ -185,7 +185,7 @@ export default function SatGateIntegrationPage() {
             </div>
             <div className="rounded-xl border border-gray-800 bg-gray-950 p-6">
               <h3 className="mb-2 text-xl font-bold text-white">Is SatGate just another observability dashboard?</h3>
-              <p className="leading-relaxed text-gray-400">No. SatGate can observe traffic, but its core role is request-path enforcement: budgets, revocation, route policy, capabilities, audit, and L402 payment before upstream access.</p>
+              <p className="leading-relaxed text-gray-400">No. SatGate can observe traffic, but its core role is request-path enforcement: budgets, revocation, route policy, capabilities, audit, and L402 payment at the gateway before forwarding.</p>
             </div>
             <div className="rounded-xl border border-gray-800 bg-gray-950 p-6">
               <h3 className="mb-2 text-xl font-bold text-white">Can SatGate start in observe-only mode?</h3>

--- a/satgate-landing/app/satgate-for-cursor/page.tsx
+++ b/satgate-landing/app/satgate-for-cursor/page.tsx
@@ -77,7 +77,7 @@ export default function SatGateIntegrationPage() {
       {
         '@type': 'Question',
         name: 'Is SatGate just another observability dashboard?',
-        acceptedAnswer: { '@type': 'Answer', text: 'No. SatGate can observe traffic, but its core role is request-path enforcement: budgets, revocation, route policy, capabilities, audit, and L402 payment before upstream access.' },
+        acceptedAnswer: { '@type': 'Answer', text: 'No. SatGate can observe traffic, but its core role is request-path enforcement: budgets, revocation, route policy, capabilities, audit, and L402 payment at the gateway before forwarding.' },
       },
       {
         '@type': 'Question',
@@ -178,7 +178,7 @@ export default function SatGateIntegrationPage() {
           <div className="grid gap-5 md:grid-cols-3">
             {[
               ['Can SatGate control Cursor MCP tools?', 'Yes. SatGate can sit in front of MCP servers or paid API tools used by Cursor and enforce budgets, allowed routes, tool scopes, expiry, and revocation before the tool call executes.'],
-              ['Is SatGate just another observability dashboard?', 'No. SatGate can observe traffic, but its core role is request-path enforcement: budgets, revocation, route policy, capabilities, audit, and L402 payment before upstream access.'],
+              ['Is SatGate just another observability dashboard?', 'No. SatGate can observe traffic, but its core role is request-path enforcement: budgets, revocation, route policy, capabilities, audit, and L402 payment at the gateway before forwarding.'],
               ['Can SatGate start in observe-only mode?', 'Yes. Teams can start with Observe to map agent and tool spend, then graduate to Control policies once safe limits are clear.'],
             ].map(([question, answer]) => (
               <div key={question}>

--- a/satgate-landing/app/satgate-for-hermes-agent/page.tsx
+++ b/satgate-landing/app/satgate-for-hermes-agent/page.tsx
@@ -114,7 +114,7 @@ export default function SatGateForHermesAgentPage() {
 
           <h1 className="mb-8 max-w-5xl text-5xl font-extrabold tracking-tight md:text-7xl">Give Hermes Agent workflows an economic firewall</h1>
           <p className="mb-10 max-w-4xl text-xl leading-relaxed text-gray-300 md:text-2xl">
-            Hermes Agent is built for persistent, skillful agent workflows. SatGate adds the missing economic firewall: per-agent budgets, MCP tool cost policy, scoped credentials, revocation, and audit before upstream APIs or tools execute.
+            Hermes Agent is built for persistent, skillful agent workflows. SatGate adds the missing economic firewall: per-agent budgets, MCP tool cost policy, scoped credentials, revocation, and audit at the gateway before forwarding to upstream APIs or tools.
           </p>
 
           <div className="flex flex-col gap-4 sm:flex-row">

--- a/satgate-landing/app/satgate-for-openclaw/page.tsx
+++ b/satgate-landing/app/satgate-for-openclaw/page.tsx
@@ -77,7 +77,7 @@ export default function SatGateIntegrationPage() {
       {
         '@type': 'Question',
         name: 'Is SatGate just another observability dashboard?',
-        acceptedAnswer: { '@type': 'Answer', text: 'No. SatGate can observe traffic, but its core role is request-path enforcement: budgets, revocation, route policy, capabilities, Evidence Pack receipts, and paid-rail context before upstream access.' },
+        acceptedAnswer: { '@type': 'Answer', text: 'No. SatGate can observe traffic, but its core role is request-path enforcement: budgets, revocation, route policy, capabilities, Evidence Pack receipts, and paid-rail context at the gateway before forwarding.' },
       },
       {
         '@type': 'Question',
@@ -111,7 +111,7 @@ export default function SatGateIntegrationPage() {
           </div>
 
           <h1 className="mb-8 max-w-5xl text-5xl font-extrabold tracking-tight md:text-7xl">Give OpenClaw agents authority before execution</h1>
-          <p className="mb-10 max-w-4xl text-xl leading-relaxed text-gray-300 md:text-2xl">OpenClaw agents can run tools, spawn sub-agents, call MCP servers, route through models, and act across workflows. SatGate adds the Agent Authority & Accountability Layer underneath: Observe, Control, and Prove agent/API activity before upstream access.</p>
+          <p className="mb-10 max-w-4xl text-xl leading-relaxed text-gray-300 md:text-2xl">OpenClaw agents can run tools, spawn sub-agents, call MCP servers, route through models, and act across workflows. SatGate adds the Agent Authority & Accountability Layer underneath: Observe, Control, and Prove agent/API activity at the gateway before forwarding.</p>
 
           <div className="flex flex-col gap-4 sm:flex-row">
             <Link href="/policy-to-proof" className="inline-flex items-center justify-center gap-2 rounded-lg bg-white px-6 py-3 font-bold text-black transition hover:bg-gray-200">
@@ -178,7 +178,7 @@ export default function SatGateIntegrationPage() {
           <div className="grid gap-5 md:grid-cols-3">
             {[
               ['How does SatGate fit with OpenClaw?', 'OpenClaw coordinates agents and tools. SatGate governs the economics of those requests: who can spend, on what, under which budget, and with which Evidence Pack.'],
-              ['Is SatGate just another observability dashboard?', 'No. SatGate can observe traffic, but its core role is request-path enforcement: budgets, revocation, route policy, capabilities, Evidence Pack receipts, and paid-rail context before upstream access.'],
+              ['Is SatGate just another observability dashboard?', 'No. SatGate can observe traffic, but its core role is request-path enforcement: budgets, revocation, route policy, capabilities, Evidence Pack receipts, and paid-rail context at the gateway before forwarding.'],
               ['Can SatGate start in observe-only mode?', 'Yes. Teams can start with Observe to map agent and tool spend, then graduate to Control policies once safe limits are clear.'],
             ].map(([question, answer]) => (
               <div key={question}>

--- a/satgate-landing/app/security/page.tsx
+++ b/satgate-landing/app/security/page.tsx
@@ -63,7 +63,7 @@ export default function SecurityPage() {
       {
         '@type': 'Question',
         name: 'How does SatGate secure AI agent API access?',
-        acceptedAnswer: { '@type': 'Answer', text: 'SatGate secures AI agent API access with request-path policy enforcement, capability tokens, macaroon caveats, scoped budgets, expiry, delegation limits, revocation, and audit evidence before upstream access.' },
+        acceptedAnswer: { '@type': 'Answer', text: 'SatGate secures AI agent API access with request-path policy enforcement, capability tokens, macaroon caveats, scoped budgets, expiry, delegation limits, revocation, and audit evidence at the gateway before forwarding.' },
       },
       {
         '@type': 'Question',
@@ -318,7 +318,7 @@ export default function SecurityPage() {
               <div className="bg-gray-900/50 border border-gray-800 rounded-lg p-4">
                 <h3 className="text-white text-sm font-bold mb-2">How does SatGate secure AI agent API access?</h3>
                 <p className="text-gray-500 text-xs mb-0">
-                  SatGate secures AI agent API access with request-path policy enforcement, capability tokens, macaroon caveats, scoped budgets, expiry, delegation limits, revocation, and audit evidence before upstream access.
+                  SatGate secures AI agent API access with request-path policy enforcement, capability tokens, macaroon caveats, scoped budgets, expiry, delegation limits, revocation, and audit evidence at the gateway before forwarding.
                 </p>
               </div>
               <div className="bg-gray-900/50 border border-gray-800 rounded-lg p-4">

--- a/satgate-landing/app/stripe-link-agents-vs-satgate/page.tsx
+++ b/satgate-landing/app/stripe-link-agents-vs-satgate/page.tsx
@@ -17,7 +17,7 @@ export const metadata = {
   ],
   openGraph: {
     title: 'Stripe Link for Agents vs SatGate',
-    description: 'Stripe Link can provide payment credentials and approval flows. SatGate controls what agents may access, spend, meter, delegate, and monetize before upstream API calls execute.',
+    description: 'Stripe Link can provide payment credentials and approval flows. SatGate controls what agents may access, spend, meter, delegate, and monetize at the gateway before forwarding to upstream APIs.',
     url: 'https://satgate.io/stripe-link-agents-vs-satgate',
     type: 'article',
   },
@@ -31,7 +31,7 @@ export const metadata = {
 const comparison = [
   ['Primary job', 'Provide payment credentials and approval flows', 'Govern agent/API economic activity in the request path'],
   ['Best fit', 'Purchases on merchant sites and payment-token flows', 'APIs, models, MCP tools, delegated agents, budgets, and monetization'],
-  ['Control point', 'Wallet / credential issuance', 'Before upstream API, model, or tool access'],
+  ['Control point', 'Wallet / credential issuance', 'Gateway policy check before forwarding to an upstream API, model, or tool'],
   ['Budget enforcement', 'User approval and future granular controls', 'Per-agent, route, tool, tenant, workflow, and time-window budgets'],
   ['API metering', 'Not the core product', 'Core Observe capability'],
   ['Payment rail', 'Cards and shared payment tokens', 'SatGate paid-rail governance uses paid-rail context for API monetization'],
@@ -103,7 +103,7 @@ export default function StripeLinkAgentsVsSatGatePage() {
             Stripe Link for Agents vs SatGate
           </h1>
           <p className="text-xl md:text-2xl text-gray-300 max-w-4xl leading-relaxed mb-8">
-            Stripe Link can provide payment credentials and approval flows. SatGate controls whether agents are allowed to access, spend, meter, delegate, and monetize before upstream API calls execute.
+            Stripe Link can provide payment credentials and approval flows. SatGate controls whether agents are allowed to access, spend, meter, delegate, and monetize at the gateway before forwarding to upstream APIs.
           </p>
           <p className="text-2xl md:text-3xl font-bold text-white max-w-4xl mb-10">
             Wallets authorize payment. Economic firewalls authorize behavior.

--- a/satgate-landing/public/data/ai-agent-runaway-spend-index-2026-04.json
+++ b/satgate-landing/public/data/ai-agent-runaway-spend-index-2026-04.json
@@ -24,6 +24,6 @@
     "delegation and sub-agent fanout caps",
     "revocable capability tokens",
     "budget exhaustion errors agents can reason about",
-    "request-path enforcement before upstream calls execute"
+    "request-path enforcement at the gateway before forwarding to upstream services"
   ]
 }

--- a/satgate-landing/public/distribution/satgate-seo-machine-launch-kit.md
+++ b/satgate-landing/public/distribution/satgate-seo-machine-launch-kit.md
@@ -1,7 +1,7 @@
 # SatGate SEO Machine Distribution Kit — 2026-04-29
 
 ## Positioning
-SatGate is the economic control plane for AI agents: it observes, controls, and charges agent/API activity before upstream access.
+SatGate is the economic control plane for AI agents: it observes, controls, and charges agent/API activity at the gateway before forwarding.
 
 ## Launch Posts
 
@@ -42,7 +42,7 @@ AI agents make API calls autonomously. That breaks traditional cost controls.
 
 SatGate now has a public toolset for modeling and enforcing agent spend: runaway cost calculators, LLM cost monitoring guides, MCP budget policy generators, revocable capability-token policy templates, governance dashboard demos, agent credential risk scoring, L402 API pricing, and a monthly runaway spend index.
 
-The thesis is simple: monitoring is not enough. Agent spend must be governed before upstream access.
+The thesis is simple: monitoring is not enough. Agent spend must be governed at the gateway before forwarding.
 
 Start here: https://satgate.io/tools
 

--- a/satgate-landing/public/llms.txt
+++ b/satgate-landing/public/llms.txt
@@ -1,6 +1,6 @@
 # SatGate™ — Agent Authority & Accountability Layer
 > SatGate is the Agent Authority & Accountability Layer for governed agent execution.
-> Observe, Control, and Prove agent/API activity before upstream access.
+> Observe, Control, and Prove agent/API activity at the gateway before forwarding.
 > Request-path budget enforcement, MCP governance, scoped capabilities, Evidence Packs, and paid-rail context.
 
 ## What is SatGate?
@@ -22,7 +22,7 @@ Enforce budgets, spend caps, route policy, revocation, expiry, per-request ceili
 Preserve Evidence Pack receipts for allowed, denied, delegated, revoked, and paid-rail decisions. x402, L402, AgentCore Payments, Pay.sh, and Fiat402 are paid rails; SatGate governs authority and proof above them.
 
 ## Category Definition
-An economic firewall is a request-path control layer that governs AI agent access, spend, budgets, routing, Evidence Pack receipts, and paid-rail context before upstream API calls execute.
+An economic firewall is a request-path control layer that governs AI agent access, spend, budgets, routing, Evidence Pack receipts, and paid-rail context at the gateway before forwarding to upstream APIs.
 
 Traditional API gateways route traffic. Dashboards report spend after the fact. Economic firewalls enforce economic policy before autonomous agents spend money.
 

--- a/satgate-landing/scripts/check_buyer_narrative.py
+++ b/satgate-landing/scripts/check_buyer_narrative.py
@@ -62,7 +62,7 @@ REQUIRED = {
         "Build Agents With Bounded Economic Authority",
         "Build agents with bounded economic authority",
         "Consume upstream with max budget",
-        "enforce max budgets before upstream access",
+        "enforce max budgets at the gateway before forwarding",
     ],
     "app/paid-agent-payments/page.tsx": [
         "Agents consume. Humans and platforms buy.",


### PR DESCRIPTION
## Summary
- narrows site-wide public copy away from instant revocation / before-upstream overclaims
- uses gateway policy check / next governed request / before forwarding language
- keeps dependency versions, proof mechanics, production posture, and SDK tooling unchanged

## Verification
- npm run build
- npm run test:demo-ia
- git diff --check

## Notes
- Existing guard failures remain pre-existing on main and are documented in the loop report: authority-followups, buyer-narrative, proof-spine, build-page.
- Not production-ready. Not production-promoted. No Wayne production authorization.