### PR TITLE
fix: align Fable proof and IA claims

### DIFF
--- a/satgate-landing/app/build/page.tsx
+++ b/satgate-landing/app/build/page.tsx
@@ -143,10 +143,13 @@ const voiceCards = [
   { title: "Machine voice", label: "schemas / signatures / receipts", body: "Anchor verifiers on canonical capability fields, receipt schema, JWKS discovery, RFC 8785 canonicalization, and Ed25519 signatures." },
 ];
 
+const trustMetadataNote = 'Trust metadata documents capability acceptance, receipt verification fields, and is canonical for rail adapter status.';
+
 const buildDocLinks = [
   { title: "Quickstart", href: `${docsBase}/getting-started/quickstart.md`, body: "Start with the issue/pay/verify primitive and local gateway compatibility path." },
   { title: "Capability schema", href: `${docsBase}/reference/capability-schema.md`, body: "The bounded authority contract: issuer, subject, allowlist, budget, expiry, caveats, and delegation depth." },
   { title: "Receipt schema", href: `${docsBase}/reference/receipt-schema.md`, body: "The signed decision artifact for allowed, denied, delegated, revoked, and paid outcomes." },
+  { title: "Trust metadata", href: `${docsBase}/reference/satgate-trust-metadata.md`, body: trustMetadataNote },
   { title: "Open verifier", href: "https://github.com/SatGate-io/evidence-pack-verifier", body: "Verify a live Evidence Pack from the issuer JWKS with RFC8785 canonicalization and Ed25519 signatures." },
   { title: "MCP integration", href: `${docsBase}/guides/mcp-gateway.md`, body: "Put SatGate in front of MCP tools and preserve a receipt per tool invocation." },
   { title: "Raw HTTP", href: `${docsBase}/guides/raw-http.md`, body: "Copy-paste curl for issue, pay, and verify without an SDK." },

--- a/satgate-landing/app/components/HomeClient.tsx
+++ b/satgate-landing/app/components/HomeClient.tsx
@@ -655,7 +655,7 @@ const LandingPage = () => {
                 step: "4",
                 title: "Prove What Happened",
                 description: "Receipts for allowed, denied, paid, delegated, and revoked decisions — ready to export as an Evidence Pack.",
-                code: `Allowed receipts: 1,203\nDenied receipts: 12,847\nPaid receipts:   $847 settled\nDelegations:     42\nRevocations:     9\n\n→ Export Evidence Pack`
+                code: `Illustrative sample — not live customer data\nAllowed receipts: 1,203\nDenied receipts: 12,847\nPaid receipts:   $847 settled\nDelegations:     42\nRevocations:     9\n\n→ Export Evidence Pack`
               }
             ].map((item, i) => (
               <div key={i} className="relative">

--- a/satgate-landing/app/page.tsx
+++ b/satgate-landing/app/page.tsx
@@ -11,7 +11,7 @@ export const metadata: Metadata = {
   openGraph: {
     title: "SatGate — Agent Authority & Accountability Layer",
     description:
-      "Policy-to-Proof governance for enterprise agents: bounded economic authority before execution and Evidence Packs after every decision.",
+      "Policy-to-Proof governance for enterprise agents: bounded economic authority before execution and Evidence Pack proof, decision receipts, and paid-call receipts after governed decisions.",
     url: "https://satgate.io",
     type: "website",
   },
@@ -19,7 +19,7 @@ export const metadata: Metadata = {
     card: "summary_large_image",
     title: "SatGate — Agent Authority & Accountability Layer",
     description:
-      "Policy-to-Proof governance for enterprise agents: bounded economic authority before execution and Evidence Packs after every decision.",
+      "Policy-to-Proof governance for enterprise agents: bounded economic authority before execution and Evidence Pack proof, decision receipts, and paid-call receipts after governed decisions.",
   },
 };
 
@@ -32,7 +32,7 @@ export default function HomePage() {
         name: 'SatGate',
         url: 'https://satgate.io',
         logo: 'https://satgate.io/logo_white_transparent.png',
-        description: 'SatGate is the Agent Authority & Accountability Layer for governed agent execution: authority before execution and Evidence Pack receipts after every decision.',
+        description: 'SatGate is the Agent Authority & Accountability Layer for governed agent execution: authority before execution and Evidence Pack proof through decision receipts and paid-call receipts after governed decisions.',
       },
       {
         '@type': 'WebSite',
@@ -68,7 +68,7 @@ export default function HomePage() {
         name: 'What is SatGate?',
         acceptedAnswer: {
           '@type': 'Answer',
-          text: 'SatGate is the Agent Authority & Accountability Layer for governed agent execution. It sits in the request path so humans and platforms can delegate bounded authority to agents, enforce policy and budgets, and preserve Evidence Packs across APIs, MCP tools, and paid rails.',
+          text: 'SatGate is the Agent Authority & Accountability Layer for governed agent execution. It sits in the request path so humans and platforms can delegate bounded authority to agents, enforce policy and budgets, and preserve Evidence Packs for governed API, MCP tool, and paid-rail decisions.',
         },
       },
       {
@@ -84,7 +84,7 @@ export default function HomePage() {
         name: 'How does SatGate give agents bounded economic authority?',
         acceptedAnswer: {
           '@type': 'Answer',
-          text: 'Humans and platforms define policy, budgets, scope, and delegation depth. Agents consume approved API and MCP primitives through SatGate, and every approval, denial, spend event, delegation, and revocation leaves receipt-backed proof.',
+          text: 'Humans and platforms define policy, budgets, scope, and delegation depth. Agents consume approved API and MCP primitives through SatGate, and allowed, denied, delegated, revoked, and paid-rail decisions leave receipt-backed proof.',
         },
       },
     ],

--- a/satgate-landing/app/policy-to-proof/page.tsx
+++ b/satgate-landing/app/policy-to-proof/page.tsx
@@ -33,7 +33,7 @@ export const metadata: Metadata = {
   openGraph: {
     title: "SatGate Policy-to-Proof",
     description:
-      "Every grant, denial, spend event, delegation, and revocation produces receipts and Evidence Pack proof your CISO, finance team, and auditor can trust.",
+      "Every grant, paid call, denial, delegation, and revocation produces receipts and Evidence Pack proof your CISO, finance team, and auditor can trust.",
     url: "https://satgate.io/policy-to-proof",
     type: "website",
   },

--- a/satgate-landing/app/pricing/page.tsx
+++ b/satgate-landing/app/pricing/page.tsx
@@ -338,7 +338,7 @@ const PricingPage = () => {
                 <tr>
                   <td className="py-3 px-4 text-gray-300">Authentication</td>
                   <td className="py-3 px-4">Basic / bearer tokens</td>
-                  <td className="py-3 px-4 text-white">L402 — cryptographic proof-of-budget</td>
+                  <td className="py-3 px-4 text-white">Paid-rail context — L402/x402-aware governance</td>
                 </tr>
               </tbody>
             </table>
@@ -363,7 +363,7 @@ const PricingPage = () => {
             <div className="text-center">
               <div className="text-3xl mb-3">💰</div>
               <h3 className="font-bold text-white mb-2">Revenue Enablement</h3>
-              <p className="text-gray-400 text-sm">Charge other companies&apos; agents micropayments via L402. Trust-as-a-Service for enterprise deals.</p>
+              <p className="text-gray-400 text-sm">Govern paid-rail context such as L402/x402 while SatGate proves agent authority, policy, and budget decisions.</p>
             </div>
           </div>
         </div>
@@ -436,7 +436,7 @@ const PricingPage = () => {
                 <Image src="/logo_white_transparent.png" alt="SatGate" width={24} height={24} className="w-6 h-6" />
                 <h4 className="font-bold text-white">SatGate</h4>
               </div>
-              <p className="text-gray-500 text-sm">The Economic Firewall for AI agent requests.</p>
+              <p className="text-gray-500 text-sm">The Agent Authority & Accountability Layer for governed agent requests.</p>
               <p className="text-gray-600 text-xs mt-3">Non-custodial. We never hold your keys.</p>
             </div>
             <div>

--- a/satgate-landing/package.json
+++ b/satgate-landing/package.json
@@ -20,7 +20,8 @@
     "test:reputation-substrate": "python3 scripts/check_reputation_substrate.py",
     "test:cache-protocol": "python3 scripts/check_cache_protocol.py",
     "test:buyer-narrative": "python3 scripts/check_buyer_narrative.py",
-    "test:authority-followups": "python3 scripts/check_authority_followups.py"
+    "test:authority-followups": "python3 scripts/check_authority_followups.py",
+    "test:fable-burn-down": "python3 scripts/check_fable_burn_down.py"
   },
   "dependencies": {
     "lucide-react": "^0.555.0",

--- a/satgate-landing/scripts/check_fable_burn_down.py
+++ b/satgate-landing/scripts/check_fable_burn_down.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+from pathlib import Path
+import re
+
+ROOT = Path(__file__).resolve().parents[1]
+
+failures: list[str] = []
+
+def read(rel: str) -> str:
+    return (ROOT / rel).read_text()
+
+home = read('app/page.tsx')
+pricing = read('app/pricing/page.tsx')
+robots = read('app/robots.ts')
+
+canonical_org_nodes = home.count("logo: 'https://satgate.io/logo_white_transparent.png'")
+if canonical_org_nodes != 1:
+    failures.append('homepage JSON-LD must contain exactly one canonical Organization node with logo in app/page.tsx')
+if "description: 'SatGate is the Agent Authority & Accountability Layer" not in home:
+    failures.append('homepage Organization JSON-LD must use the current Agent Authority description')
+for stale in ['Evidence Packs after every decision', 'Evidence Pack receipts after every decision']:
+    if stale in home:
+        failures.append(f'homepage contains overbroad proof claim: {stale}')
+
+for stale in ['robot customer', 'Trust-as-a-Service for enterprise deals', 'L402 — cryptographic proof-of-budget']:
+    if stale.lower() in pricing.lower():
+        failures.append(f'pricing still contains stale paid-rail/product-center phrase: {stale}')
+
+if robots.count("userAgent: '*'") != 1 or robots.count("sitemap: 'https://satgate.io/sitemap.xml'") != 1:
+    failures.append('robots.ts must define one canonical allow/disallow block and one sitemap')
+
+if failures:
+    print('FABLE_LANDING_GUARD_FAIL')
+    for failure in failures:
+        print(f'- {failure}')
+    raise SystemExit(1)
+
+print('FABLE_LANDING_GUARD_PASS')


### PR DESCRIPTION
## Summary

Fable burn-down copy/IA alignment for public landing proof claims. Production untouched; this PR does **not** claim production-ready or buyer-demo-ready.

Fixes:
- Adds `test:fable-burn-down` guard for stale proof/product framing.
- Softens broad “every decision” proof language to governed/proven decision classes.
- Keeps proof-spine language explicit: decision receipts, paid-call receipts, Evidence Pack proof.
- Moves L402 from product-center hype into paid-rail context.
- Adds `/build` trust metadata language for capability acceptance, receipt verification fields, and rail adapter status.

## Verification

- `npm run test:fable-burn-down` — PASS
- `npm run test:demo-ia` — PASS
- `npm run test:proof-spine` — PASS
- `npm run test:well-known` — PASS
- `npm run build` — PASS, 122/122 static pages
- `git diff --check` — PASS

## Boundary

No production deploy. Landing copy is source/build verified only until Vercel/production deployment is separately authorized and verified.
