### PR TITLE
feat: add MCP evidence recorder hook

### DIFF
--- a/pkg/mcpserver/evidence.go
+++ b/pkg/mcpserver/evidence.go
@@ -1,0 +1,55 @@
+package mcpserver
+
+import "context"
+
+// MCPDecision is the receipt-ready decision envelope emitted for governed MCP
+// tools/call budget decisions. Enterprise implementations can turn this into a
+// signed, issuer-anchored Evidence Pack without depending on proxy internals.
+type MCPDecision struct {
+	Decision               string `json:"decision"`
+	DecisionReason         string `json:"decision_reason"`
+	PolicyMode             string `json:"policy_mode"`
+	TenantID               string `json:"tenant_id,omitempty"`
+	TokenID                string `json:"token_id,omitempty"`
+	BudgetID               string `json:"budget_id,omitempty"`
+	BudgetSubjectID        string `json:"budget_subject_id,omitempty"`
+	BudgetLimitCredits     int64  `json:"budget_limit_credits,omitempty"`
+	DelegationDepth        int64  `json:"delegation_depth,omitempty"`
+	DelegationBudget       int64  `json:"delegation_budget,omitempty"`
+	ParentTokenID          string `json:"parent_token_id,omitempty"`
+	Scope                  string `json:"scope,omitempty"`
+	MCPMethod              string `json:"mcp_method"`
+	ToolName               string `json:"tool_name"`
+	RouteOrTool            string `json:"route_or_tool"`
+	RequestID              string `json:"request_id"`
+	JSONRPCID              string `json:"jsonrpc_id,omitempty"`
+	CostCredits            int64  `json:"cost_credits"`
+	RemainingCredits       int64  `json:"remaining_credits"`
+	RemainingBeforeCredits int64  `json:"remaining_before_credits"`
+}
+
+// MCPEvidence is the verifier-facing handle returned after recording an MCP
+// decision as a signed artifact.
+type MCPEvidence struct {
+	ReceiptID      string `json:"receipt_id,omitempty"`
+	ReceiptHash    string `json:"receipt_hash,omitempty"`
+	EvidencePackID string `json:"evidence_pack_id,omitempty"`
+	EvidenceURL    string `json:"evidence_url,omitempty"`
+	VerifyURL      string `json:"verify_url,omitempty"`
+	JWKSURL        string `json:"jwks_url,omitempty"`
+}
+
+// EvidenceRecorder records governed MCP decisions into a durable, independently
+// verifiable artifact. Enterprise implementations should fail closed from
+// Preflight/RecordMCPDecision when required signing/archive infrastructure is
+// unavailable.
+type EvidenceRecorder interface {
+	Preflight(ctx context.Context) error
+	RecordMCPDecision(ctx context.Context, decision MCPDecision) (*MCPEvidence, error)
+}
+
+// BudgetCompensator is optionally implemented by budget enforcers that can undo
+// a debit when proof generation fails before an upstream tool call is made.
+type BudgetCompensator interface {
+	Compensate(ctx context.Context, tokenID string, requestID string, cost int64) error
+}

--- a/pkg/mcpserver/evidence_test.go
+++ b/pkg/mcpserver/evidence_test.go
@@ -1,0 +1,191 @@
+package mcpserver
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+)
+
+type fakeMCPRouter struct{ called bool }
+
+func (r *fakeMCPRouter) AllToolsForTenant(context.Context, string) []json.RawMessage { return nil }
+func (r *fakeMCPRouter) ForwardToolCallForTenant(ctx context.Context, tenantID, toolName string, params json.RawMessage, timeout time.Duration) (*Response, error) {
+	r.called = true
+	result, _ := json.Marshal(map[string]interface{}{
+		"content": []map[string]interface{}{{"type": "text", "text": "ok"}},
+	})
+	return &Response{JSONRPC: "2.0", Result: result}, nil
+}
+
+type fakeEvidenceRecorder struct {
+	preflightCalls int
+	decisions      []MCPDecision
+	preflightErr   error
+	recordErr      error
+}
+
+func (r *fakeEvidenceRecorder) Preflight(context.Context) error {
+	r.preflightCalls++
+	return r.preflightErr
+}
+
+func (r *fakeEvidenceRecorder) RecordMCPDecision(_ context.Context, decision MCPDecision) (*MCPEvidence, error) {
+	r.decisions = append(r.decisions, decision)
+	if r.recordErr != nil {
+		return nil, r.recordErr
+	}
+	return &MCPEvidence{
+		ReceiptID:      "rcpt_test",
+		ReceiptHash:    "sha256:test",
+		EvidencePackID: "ep_test",
+		EvidenceURL:    "https://issuer.example/v1/evidence/evid_test",
+		VerifyURL:      "https://issuer.example/verify",
+		JWKSURL:        "https://issuer.example/.well-known/jwks.json",
+	}, nil
+}
+
+type compensatingBudget struct {
+	remaining   int64
+	spent       bool
+	compensated bool
+}
+
+func (b *compensatingBudget) Check(context.Context, string, int64) (*BudgetResult, error) {
+	return &BudgetResult{Allowed: true, Remaining: b.remaining}, nil
+}
+func (b *compensatingBudget) Spend(_ context.Context, tokenID string, toolName string, cost int64, requestID string) (*BudgetResult, error) {
+	b.spent = true
+	b.remaining -= cost
+	return &BudgetResult{Allowed: true, Remaining: b.remaining, TokenID: tokenID, Cost: cost}, nil
+}
+func (b *compensatingBudget) Remaining(context.Context, string) (int64, error) {
+	return b.remaining, nil
+}
+func (b *compensatingBudget) Initialize(context.Context, string, int64) error { return nil }
+func (b *compensatingBudget) Compensate(_ context.Context, tokenID string, requestID string, cost int64) error {
+	b.compensated = true
+	b.remaining += cost
+	return nil
+}
+
+func newEvidenceTestProxy(t *testing.T) *Proxy {
+	t.Helper()
+	cfg := &Config{
+		Server: ServerConfig{Transport: "stdio", Name: "test", Version: "1.0"},
+		Auth:   AuthConfig{Mode: "none"},
+		Upstreams: map[string]UpstreamConfig{
+			"mock": {Transport: "stdio", Command: []string{"python3", "-c", "import sys; sys.exit(0)"}},
+		},
+		Budget:      BudgetConfig{Backend: "memory", Limit: 0, FailMode: "closed"},
+		Tools:       ToolsConfig{DefaultCost: 10, Costs: map[string]int64{"search": 10}},
+		Enforcement: EnforcementConfig{Mode: "control"},
+		Logging:     LoggingConfig{Level: "error"},
+	}
+	cfg.applyDefaults()
+	proxy, err := New(cfg)
+	if err != nil {
+		t.Fatalf("create proxy: %v", err)
+	}
+	proxy.router = &fakeMCPRouter{}
+	return proxy
+}
+
+func TestMCPToolsCallRecordsEvidenceOnAllowedDecision(t *testing.T) {
+	ctx := context.Background()
+	proxy := newEvidenceTestProxy(t)
+	recorder := &fakeEvidenceRecorder{}
+	proxy.SetEvidenceRecorder(recorder)
+	if err := proxy.budget.Initialize(ctx, "budget-1", 20); err != nil {
+		t.Fatal(err)
+	}
+
+	req := &Request{JSONRPC: "2.0", ID: json.RawMessage(`1`), Method: MethodToolsCall, Params: json.RawMessage(`{"name":"search","arguments":{"q":"satgate"}}`)}
+	resp, err := proxy.handleToolsCall(ctx, req, &TokenInfo{TokenID: "token-1", BudgetID: "budget-1", BudgetLimit: 20, TenantID: "tenant-1", Scope: "mcp:*", DelegationDepth: 2, DelegationBudget: 7, ParentTokenID: "parent-1"})
+	if err != nil {
+		t.Fatalf("handleToolsCall: %v", err)
+	}
+	if resp.Error != nil {
+		t.Fatalf("unexpected error response: %+v", resp.Error)
+	}
+	if recorder.preflightCalls != 1 {
+		t.Fatalf("expected evidence preflight once, got %d", recorder.preflightCalls)
+	}
+	if len(recorder.decisions) != 1 {
+		t.Fatalf("expected one decision, got %d", len(recorder.decisions))
+	}
+	decision := recorder.decisions[0]
+	if decision.Decision != "allowed" || decision.DecisionReason != "budget_authorized" || decision.ToolName != "search" || decision.MCPMethod != MethodToolsCall {
+		t.Fatalf("unexpected decision: %+v", decision)
+	}
+	if decision.TenantID != "tenant-1" || decision.TokenID != "token-1" || decision.BudgetID != "budget-1" || decision.ParentTokenID != "parent-1" {
+		t.Fatalf("decision missing authority fields: %+v", decision)
+	}
+	if decision.CostCredits != 10 || decision.RemainingCredits != 10 || decision.RemainingBeforeCredits != 20 {
+		t.Fatalf("decision missing budget fields: %+v", decision)
+	}
+	var result map[string]interface{}
+	if err := json.Unmarshal(resp.Result, &result); err != nil {
+		t.Fatal(err)
+	}
+	meta, _ := result["_meta"].(map[string]interface{})
+	evidence, _ := meta["satgate_evidence"].(map[string]interface{})
+	if evidence["evidence_url"] == "" || evidence["receipt_hash"] == "" {
+		t.Fatalf("response missing evidence metadata: %#v", result)
+	}
+}
+
+func TestMCPToolsCallRecordsEvidenceOnBudgetDenial(t *testing.T) {
+	ctx := context.Background()
+	proxy := newEvidenceTestProxy(t)
+	recorder := &fakeEvidenceRecorder{}
+	proxy.SetEvidenceRecorder(recorder)
+	if err := proxy.budget.Initialize(ctx, "budget-1", 5); err != nil {
+		t.Fatal(err)
+	}
+
+	req := &Request{JSONRPC: "2.0", ID: json.RawMessage(`2`), Method: MethodToolsCall, Params: json.RawMessage(`{"name":"search"}`)}
+	resp, err := proxy.handleToolsCall(ctx, req, &TokenInfo{TokenID: "token-1", BudgetID: "budget-1", BudgetLimit: 5, TenantID: "tenant-1", Scope: "mcp:*"})
+	if err != nil {
+		t.Fatalf("handleToolsCall: %v", err)
+	}
+	if resp.Error == nil || resp.Error.Code != CodeBudgetExhausted {
+		t.Fatalf("expected budget exhausted response, got %+v", resp)
+	}
+	if len(recorder.decisions) != 1 || recorder.decisions[0].Decision != "denied" {
+		t.Fatalf("expected denied evidence decision, got %+v", recorder.decisions)
+	}
+	var data map[string]interface{}
+	if err := json.Unmarshal(resp.Error.Data, &data); err != nil {
+		t.Fatal(err)
+	}
+	if data["evidence_url"] == "" || data["receipt_hash"] == "" {
+		t.Fatalf("denial data missing evidence metadata: %#v", data)
+	}
+}
+
+func TestMCPToolsCallEvidenceFailureCompensatesDebitAndSkipsUpstream(t *testing.T) {
+	ctx := context.Background()
+	proxy := newEvidenceTestProxy(t)
+	budget := &compensatingBudget{remaining: 20}
+	proxy.budget = budget
+	router := &fakeMCPRouter{}
+	proxy.router = router
+	proxy.SetEvidenceRecorder(&fakeEvidenceRecorder{recordErr: errors.New("archive down")})
+
+	req := &Request{JSONRPC: "2.0", ID: json.RawMessage(`3`), Method: MethodToolsCall, Params: json.RawMessage(`{"name":"search"}`)}
+	resp, err := proxy.handleToolsCall(ctx, req, &TokenInfo{TokenID: "token-1", BudgetID: "budget-1", BudgetLimit: 20, TenantID: "tenant-1", Scope: "mcp:*"})
+	if err != nil {
+		t.Fatalf("handleToolsCall: %v", err)
+	}
+	if resp.Error == nil || resp.Error.Code != CodeInternalError {
+		t.Fatalf("expected proof_unavailable error, got %+v", resp)
+	}
+	if !budget.spent || !budget.compensated || budget.remaining != 20 {
+		t.Fatalf("expected compensated debit, got spent=%v compensated=%v remaining=%d", budget.spent, budget.compensated, budget.remaining)
+	}
+	if router.called {
+		t.Fatal("upstream should not be called when evidence generation fails")
+	}
+}

--- a/pkg/mcpserver/proxy.go
+++ b/pkg/mcpserver/proxy.go
@@ -54,6 +54,7 @@ type Proxy struct {
 	auth              Authenticator
 	delegator         *Delegator
 	events            EventPublisher
+	evidence          EvidenceRecorder
 	revocation        RevocationChecker // optional, checks if token is revoked
 	toolsListEnricher ToolsListEnricher // optional, enriches tools/list with cost metadata
 	taskTracker       *TaskTracker      // MCP task-level cost aggregation (SEP-1686)
@@ -228,6 +229,11 @@ func (p *Proxy) SetEventPublisher(ep EventPublisher) {
 	if p.delegator != nil {
 		p.delegator.SetEventPublisher(ep)
 	}
+}
+
+// SetEvidenceRecorder wires signed evidence recording for governed MCP decisions.
+func (p *Proxy) SetEvidenceRecorder(rec EvidenceRecorder) {
+	p.evidence = rec
 }
 
 // SetRevocationChecker sets the revocation checker for token validation.
@@ -572,11 +578,21 @@ func (p *Proxy) handleToolsCall(ctx context.Context, req *Request, tokenInfo *To
 	mode := p.config.Enforcement.Mode
 	isObserve := mode == "observe" || mode == "shadow" || mode == "chargeback"
 	isControl := mode == "control" || mode == "hard" || mode == "soft" || mode == "fiat402"
+	var allowedEvidence *MCPEvidence
 
 	if (isObserve || isControl) && budgetID != "" && cost > 0 {
 		// Auto-initialize budget from macaroon caveat if not yet initialized
 		if tokenInfo.BudgetLimit > 0 {
 			_ = p.budget.Initialize(ctx, budgetID, tokenInfo.BudgetLimit)
+		}
+		if p.evidence != nil && isControl {
+			if err := p.evidence.Preflight(ctx); err != nil {
+				log.Error().Err(err).Str("tool", tc.Name).Str("budgetId", budgetID).Msg("MCP evidence preflight failed")
+				return NewErrorResponseWithData(req.ID, CodeInternalError, "Evidence proof unavailable", map[string]interface{}{
+					"error": "proof_unavailable",
+					"tool":  tc.Name,
+				}), nil
+			}
 		}
 		result, err := p.budget.Spend(ctx, budgetID, tc.Name, cost, requestID)
 		if err != nil {
@@ -610,6 +626,10 @@ func (p *Proxy) handleToolsCall(ctx context.Context, req *Request, tokenInfo *To
 						"cost":         cost,
 						"remaining":    remaining,
 						"budget_limit": tokenInfo.BudgetLimit,
+						"request_id":   requestID,
+						"policy_mode":  normalizeEnforcementMode(mode),
+						"decision":     "denied",
+						"reason":       result.ErrorCode,
 					},
 				})
 
@@ -618,20 +638,37 @@ func (p *Proxy) handleToolsCall(ctx context.Context, req *Request, tokenInfo *To
 					log.Info().Str("tool", tc.Name).Int64("remaining", remaining).
 						Msg("observe mode: allowing overspend")
 				} else {
-					// Control: block the request
+					// Control: block the request, with issuer-anchored evidence when configured.
 					errMsg := "Budget exhausted"
 					errCode := result.ErrorCode
 					if errCode == "insufficient_budget" {
 						errMsg = fmt.Sprintf("Insufficient budget: tool '%s' costs %d credits, %d remaining", tc.Name, cost, remaining)
 					}
-					return NewErrorResponseWithData(req.ID, CodeBudgetExhausted, errMsg, map[string]interface{}{
+					evidence, evidenceErr := p.recordMCPDecision(ctx, req, tokenInfo, tc.Name, MCPDecision{
+						Decision:         "denied",
+						DecisionReason:   errCode,
+						PolicyMode:       normalizeEnforcementMode(mode),
+						CostCredits:      cost,
+						RemainingCredits: remaining,
+						RequestID:        requestID,
+					})
+					if evidenceErr != nil {
+						log.Error().Err(evidenceErr).Str("tool", tc.Name).Str("budgetId", budgetID).Msg("MCP denial evidence recording failed")
+						return NewErrorResponseWithData(req.ID, CodeInternalError, "Evidence proof unavailable", map[string]interface{}{
+							"error": "proof_unavailable",
+							"tool":  tc.Name,
+						}), nil
+					}
+					data := map[string]interface{}{
 						"error":             errCode,
 						"tool":              tc.Name,
 						"cost_credits":      cost,
 						"remaining_credits": remaining,
 						"token_id":          tokenInfo.TokenID,
 						"budget_id":         budgetID,
-					}), nil
+					}
+					mergeEvidenceData(data, evidence)
+					return NewErrorResponseWithData(req.ID, CodeBudgetExhausted, errMsg, data), nil
 				}
 			} else {
 				// Backend failure (Redis down, network error, etc.)
@@ -673,8 +710,30 @@ func (p *Proxy) handleToolsCall(ctx context.Context, req *Request, tokenInfo *To
 					"cost":         cost,
 					"remaining":    result.Remaining,
 					"budget_limit": tokenInfo.BudgetLimit,
+					"request_id":   requestID,
+					"policy_mode":  normalizeEnforcementMode(mode),
 				},
 			})
+
+			var evidenceErr error
+			allowedEvidence, evidenceErr = p.recordMCPDecision(ctx, req, tokenInfo, tc.Name, MCPDecision{
+				Decision:         "allowed",
+				DecisionReason:   "budget_authorized",
+				PolicyMode:       normalizeEnforcementMode(mode),
+				CostCredits:      cost,
+				RemainingCredits: result.Remaining,
+				RequestID:        requestID,
+			})
+			if evidenceErr != nil {
+				log.Error().Err(evidenceErr).Str("tool", tc.Name).Str("budgetId", budgetID).Msg("MCP allowed evidence recording failed")
+				if isControl {
+					p.compensateMCPSpend(ctx, budgetID, requestID, cost)
+					return NewErrorResponseWithData(req.ID, CodeInternalError, "Evidence proof unavailable", map[string]interface{}{
+						"error": "proof_unavailable",
+						"tool":  tc.Name,
+					}), nil
+				}
+			}
 		}
 	}
 
@@ -764,7 +823,95 @@ func (p *Proxy) handleToolsCall(ctx context.Context, req *Request, tokenInfo *To
 
 	// Rewrite the response ID to match the client's request ID
 	resp.ID = req.ID
+	attachMCPEvidenceToResponse(resp, allowedEvidence)
 	return resp, nil
+}
+
+func (p *Proxy) recordMCPDecision(ctx context.Context, req *Request, tokenInfo *TokenInfo, toolName string, decision MCPDecision) (*MCPEvidence, error) {
+	if p.evidence == nil {
+		return nil, nil
+	}
+	decision.TenantID = tokenInfo.TenantID
+	decision.TokenID = tokenInfo.TokenID
+	decision.BudgetID = tokenInfo.BudgetID
+	decision.BudgetSubjectID = tokenInfo.BudgetID
+	decision.BudgetLimitCredits = tokenInfo.BudgetLimit
+	decision.DelegationDepth = int64(tokenInfo.DelegationDepth)
+	decision.DelegationBudget = tokenInfo.DelegationBudget
+	decision.ParentTokenID = tokenInfo.ParentTokenID
+	decision.Scope = tokenInfo.Scope
+	decision.MCPMethod = MethodToolsCall
+	decision.ToolName = toolName
+	decision.RouteOrTool = "mcp:tools/call:" + toolName
+	decision.JSONRPCID = string(req.ID)
+	if decision.PolicyMode == "" {
+		decision.PolicyMode = normalizeEnforcementMode(p.config.Enforcement.Mode)
+	}
+	if decision.RemainingBeforeCredits == 0 && decision.Decision == "allowed" {
+		decision.RemainingBeforeCredits = decision.RemainingCredits + decision.CostCredits
+	}
+	if decision.RemainingBeforeCredits == 0 && decision.Decision != "allowed" {
+		decision.RemainingBeforeCredits = decision.RemainingCredits
+	}
+	return p.evidence.RecordMCPDecision(ctx, decision)
+}
+
+func (p *Proxy) compensateMCPSpend(ctx context.Context, budgetID, requestID string, cost int64) {
+	compensator, ok := p.budget.(BudgetCompensator)
+	if !ok || budgetID == "" || requestID == "" || cost <= 0 {
+		return
+	}
+	if err := compensator.Compensate(ctx, budgetID, requestID, cost); err != nil {
+		log.Error().Err(err).Str("budgetId", budgetID).Str("requestId", requestID).Msg("failed to compensate MCP debit after evidence failure")
+	}
+}
+
+func mergeEvidenceData(data map[string]interface{}, evidence *MCPEvidence) {
+	if data == nil || evidence == nil {
+		return
+	}
+	if evidence.ReceiptID != "" {
+		data["receipt_id"] = evidence.ReceiptID
+	}
+	if evidence.ReceiptHash != "" {
+		data["receipt_hash"] = evidence.ReceiptHash
+	}
+	if evidence.EvidencePackID != "" {
+		data["evidence_pack_id"] = evidence.EvidencePackID
+	}
+	if evidence.EvidenceURL != "" {
+		data["evidence_url"] = evidence.EvidenceURL
+	}
+	if evidence.VerifyURL != "" {
+		data["verify_url"] = evidence.VerifyURL
+	}
+	if evidence.JWKSURL != "" {
+		data["jwks_url"] = evidence.JWKSURL
+	}
+}
+
+func attachMCPEvidenceToResponse(resp *Response, evidence *MCPEvidence) {
+	if resp == nil || evidence == nil || len(resp.Result) == 0 {
+		return
+	}
+	var result map[string]interface{}
+	if err := json.Unmarshal(resp.Result, &result); err != nil {
+		return
+	}
+	meta, _ := result["_meta"].(map[string]interface{})
+	if meta == nil {
+		meta = map[string]interface{}{}
+	}
+	evidenceData := map[string]interface{}{}
+	mergeEvidenceData(evidenceData, evidence)
+	if len(evidenceData) == 0 {
+		return
+	}
+	meta["satgate_evidence"] = evidenceData
+	result["_meta"] = meta
+	if encoded, err := json.Marshal(result); err == nil {
+		resp.Result = encoded
+	}
 }
 
 // handleDelegate processes satgate/delegate requests.


### PR DESCRIPTION
## Summary
- Add an MCP `EvidenceRecorder` hook and receipt-ready `MCPDecision` / `MCPEvidence` types.
- Record evidence synchronously for governed `tools/call` allowed and denied budget decisions.
- Attach evidence metadata to MCP JSON-RPC denial data and allowed response `_meta.satgate_evidence`.
- Fail closed on proof preflight/recording failure in control mode; compensate budget debit and skip upstream if proof generation fails after spend.

## Why
This is the OSS half of SatGate MCP P0: enterprise can now turn governed MCP decisions into signed issuer-anchored Evidence Packs instead of relying on unsigned telemetry.

## Tests
- `go test ./pkg/mcpserver`

## Boundaries
- No enterprise receipt implementation here.
- No production deploy.
- MCP Evidence Pack parity is not closed until enterprise consumes this hook, emits a live pack, and verifier/tamper checks pass.