### PR TITLE
Thread SSE session identity into MCP request context

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/satgate-io/satgate
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/gorilla/websocket v1.5.3

--- a/pkg/mcpserver/sse.go
+++ b/pkg/mcpserver/sse.go
@@ -30,13 +30,14 @@ type SSEServer struct {
 
 // sseSession represents one connected MCP client over SSE.
 type sseSession struct {
-	id       string
-	messages chan json.RawMessage // outbound messages to client
-	ctx      context.Context
-	cancel   context.CancelFunc
-	tokenID  string // from auth at connect time (may be empty)
-	tenantID string // from auth at connect time (may be empty)
-	budgetID string // from auth at connect time (may be empty)
+	id                string
+	messages          chan json.RawMessage // outbound messages to client
+	ctx               context.Context
+	cancel            context.CancelFunc
+	tokenID           string     // from auth/session tracking (may be empty)
+	tenantID          string     // from auth/session tracking (may be empty)
+	budgetID          string     // from auth/session tracking (may be empty)
+	verifiedTokenInfo *TokenInfo // only set after authenticator verification succeeds
 }
 
 func (s *sseSession) contextWithIdentity() context.Context {
@@ -44,12 +45,8 @@ func (s *sseSession) contextWithIdentity() context.Context {
 	if s.tenantID != "" {
 		ctx = context.WithValue(ctx, CtxTenantID, s.tenantID)
 	}
-	if s.tokenID != "" || s.budgetID != "" || s.tenantID != "" {
-		ctx = context.WithValue(ctx, CtxTokenInfo, &TokenInfo{
-			TokenID:  s.tokenID,
-			BudgetID: s.budgetID,
-			TenantID: s.tenantID,
-		})
+	if s.verifiedTokenInfo != nil {
+		ctx = context.WithValue(ctx, CtxTokenInfo, s.verifiedTokenInfo)
 	}
 	return ctx
 }
@@ -222,6 +219,7 @@ func (s *SSEServer) handleSSE(w http.ResponseWriter, r *http.Request) {
 				session.tokenID = info.TokenID
 				session.tenantID = info.TenantID
 				session.budgetID = info.BudgetID
+				session.verifiedTokenInfo = info
 				resolved = true
 			}
 		}
@@ -323,6 +321,7 @@ func (s *SSEServer) handleMessage(w http.ResponseWriter, r *http.Request) {
 				session.tokenID = info.TokenID
 				session.tenantID = info.TenantID
 				session.budgetID = info.BudgetID
+				session.verifiedTokenInfo = info
 				resolved = true
 			}
 		}

--- a/pkg/mcpserver/sse.go
+++ b/pkg/mcpserver/sse.go
@@ -39,6 +39,21 @@ type sseSession struct {
 	budgetID string // from auth at connect time (may be empty)
 }
 
+func (s *sseSession) contextWithIdentity() context.Context {
+	ctx := s.ctx
+	if s.tenantID != "" {
+		ctx = context.WithValue(ctx, CtxTenantID, s.tenantID)
+	}
+	if s.tokenID != "" || s.budgetID != "" || s.tenantID != "" {
+		ctx = context.WithValue(ctx, CtxTokenInfo, &TokenInfo{
+			TokenID:  s.tokenID,
+			BudgetID: s.budgetID,
+			TenantID: s.tenantID,
+		})
+	}
+	return ctx
+}
+
 // SSEOption configures optional SSEServer settings.
 type SSEOption func(*SSEServer)
 
@@ -354,12 +369,10 @@ func (s *SSEServer) handleMessage(w http.ResponseWriter, r *http.Request) {
 
 	// Handle request asynchronously — don't block the HTTP response
 	go func() {
-		// Inject session's tenant ID into context so tools/list and other
-		// methods can access it (for multi-tenant upstream routing).
-		reqCtx := session.ctx
-		if session.tenantID != "" {
-			reqCtx = context.WithValue(reqCtx, CtxTenantID, session.tenantID)
-		}
+		// Inject session identity into context so unauthenticated-but-session-scoped
+		// methods such as tools/list can use the already-resolved tenant and budget
+		// subject without re-verifying or guessing from global session state.
+		reqCtx := session.contextWithIdentity()
 		resp, handleErr := s.proxy.handleRequest(reqCtx, req)
 		if handleErr != nil {
 			resp = NewErrorResponse(req.ID, CodeInternalError, handleErr.Error())

--- a/pkg/mcpserver/sse_test.go
+++ b/pkg/mcpserver/sse_test.go
@@ -93,13 +93,18 @@ func TestSSEServer_ConnectAndMessage(t *testing.T) {
 	}
 }
 
-func TestSSESessionContextWithIdentityIncludesTokenInfo(t *testing.T) {
+func TestSSESessionContextWithIdentityIncludesVerifiedTokenInfo(t *testing.T) {
 	base := context.Background()
 	session := &sseSession{
 		ctx:      base,
 		tokenID:  "tok-session",
 		tenantID: "tenant-session",
 		budgetID: "budget-session",
+		verifiedTokenInfo: &TokenInfo{
+			TokenID:  "tok-session",
+			BudgetID: "budget-session",
+			TenantID: "tenant-session",
+		},
 	}
 
 	ctx := session.contextWithIdentity()
@@ -112,6 +117,22 @@ func TestSSESessionContextWithIdentityIncludesTokenInfo(t *testing.T) {
 	}
 	if info.TokenID != "tok-session" || info.BudgetID != "budget-session" || info.TenantID != "tenant-session" {
 		t.Fatalf("token info = %#v", info)
+	}
+}
+
+func TestSSESessionContextWithIdentityDoesNotTrustFallbackCaveatIdentity(t *testing.T) {
+	session := &sseSession{
+		ctx:      context.Background(),
+		tenantID: "tenant-from-unverified-caveat",
+		budgetID: "budget-from-unverified-caveat",
+	}
+
+	ctx := session.contextWithIdentity()
+	if got := TenantFromContext(ctx); got != "tenant-from-unverified-caveat" {
+		t.Fatalf("tenant from context = %q, want fallback tenant for routing/session tracking", got)
+	}
+	if info := TokenInfoFromContext(ctx); info != nil {
+		t.Fatalf("unverified caveat identity must not become TokenInfo, got %#v", info)
 	}
 }
 

--- a/pkg/mcpserver/sse_test.go
+++ b/pkg/mcpserver/sse_test.go
@@ -93,6 +93,28 @@ func TestSSEServer_ConnectAndMessage(t *testing.T) {
 	}
 }
 
+func TestSSESessionContextWithIdentityIncludesTokenInfo(t *testing.T) {
+	base := context.Background()
+	session := &sseSession{
+		ctx:      base,
+		tokenID:  "tok-session",
+		tenantID: "tenant-session",
+		budgetID: "budget-session",
+	}
+
+	ctx := session.contextWithIdentity()
+	if got := TenantFromContext(ctx); got != "tenant-session" {
+		t.Fatalf("tenant from context = %q, want tenant-session", got)
+	}
+	info := TokenInfoFromContext(ctx)
+	if info == nil {
+		t.Fatal("expected token info in context")
+	}
+	if info.TokenID != "tok-session" || info.BudgetID != "budget-session" || info.TenantID != "tenant-session" {
+		t.Fatalf("token info = %#v", info)
+	}
+}
+
 func TestSSEServer_BudgetEnforcement(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()


### PR DESCRIPTION
## Summary

Tiny MCP SSE context-plumbing fix needed for session-scoped `tools/list` enrichers.

This PR:

- threads the already-resolved SSE session identity into request context;
- includes `TokenInfo{TokenID, TenantID, BudgetID}` when available;
- preserves the existing `ToolsListEnricher(ctx, tenantID, tools)` signature;
- adds a regression test for tenant/token/budget context propagation.

## Scope / caveats

- No spend/debit behavior change.
- No idempotency/evidence behavior change.
- No Enterprise gateway deploy authorized.
- No staging deploy/restart.
- This does not close Wave 2.

## Verification

```text
OSS_GOFMT_STATUS=0
OSS_MCP_TEST_STATUS=0
OSS_ALL_TEST_STATUS=0
OSS_DIFFCHECK_STATUS=0
```

Commands run:

```bash
gofmt -w pkg/mcpserver/sse.go pkg/mcpserver/sse_test.go
go test ./pkg/mcpserver
go test ./...
git diff --check
```
