### PR TITLE
feat(mcp): publish canonical budget request identity

### DIFF
--- a/pkg/mcpserver/budget.go
+++ b/pkg/mcpserver/budget.go
@@ -13,6 +13,7 @@ type BudgetResult struct {
 	Remaining int64  `json:"remaining"`
 	TokenID   string `json:"token_id"`
 	Cost      int64  `json:"cost"`
+	RequestID string `json:"request_id,omitempty"`
 	ErrorCode string `json:"error_code,omitempty"`
 }
 

--- a/pkg/mcpserver/proxy.go
+++ b/pkg/mcpserver/proxy.go
@@ -559,6 +559,7 @@ func (p *Proxy) handleToolsCall(ctx context.Context, req *Request, tokenInfo *To
 
 	// Generate request ID for idempotency
 	requestID := generateRequestID(budgetID, tc.Name, req.ID)
+	eventRequestID := requestID
 
 	log.Debug().
 		Str("tool", tc.Name).
@@ -595,6 +596,7 @@ func (p *Proxy) handleToolsCall(ctx context.Context, req *Request, tokenInfo *To
 			}
 		}
 		result, err := p.budget.Spend(ctx, budgetID, tc.Name, cost, requestID)
+		eventRequestID = budgetEventRequestID(requestID, result)
 		if err != nil {
 			isBudgetExhausted := result != nil && (result.ErrorCode == "budget_exhausted" || result.ErrorCode == "insufficient_budget")
 
@@ -626,7 +628,7 @@ func (p *Proxy) handleToolsCall(ctx context.Context, req *Request, tokenInfo *To
 						"cost":         cost,
 						"remaining":    remaining,
 						"budget_limit": tokenInfo.BudgetLimit,
-						"request_id":   requestID,
+						"request_id":   eventRequestID,
 						"policy_mode":  normalizeEnforcementMode(mode),
 						"decision":     "denied",
 						"reason":       result.ErrorCode,
@@ -650,7 +652,7 @@ func (p *Proxy) handleToolsCall(ctx context.Context, req *Request, tokenInfo *To
 						PolicyMode:       normalizeEnforcementMode(mode),
 						CostCredits:      cost,
 						RemainingCredits: remaining,
-						RequestID:        requestID,
+						RequestID:        eventRequestID,
 					})
 					if evidenceErr != nil {
 						log.Error().Err(evidenceErr).Str("tool", tc.Name).Str("budgetId", budgetID).Msg("MCP denial evidence recording failed")
@@ -710,7 +712,7 @@ func (p *Proxy) handleToolsCall(ctx context.Context, req *Request, tokenInfo *To
 					"cost":         cost,
 					"remaining":    result.Remaining,
 					"budget_limit": tokenInfo.BudgetLimit,
-					"request_id":   requestID,
+					"request_id":   eventRequestID,
 					"policy_mode":  normalizeEnforcementMode(mode),
 				},
 			})
@@ -722,12 +724,12 @@ func (p *Proxy) handleToolsCall(ctx context.Context, req *Request, tokenInfo *To
 				PolicyMode:       normalizeEnforcementMode(mode),
 				CostCredits:      cost,
 				RemainingCredits: result.Remaining,
-				RequestID:        requestID,
+				RequestID:        eventRequestID,
 			})
 			if evidenceErr != nil {
 				log.Error().Err(evidenceErr).Str("tool", tc.Name).Str("budgetId", budgetID).Msg("MCP allowed evidence recording failed")
 				if isControl {
-					p.compensateMCPSpend(ctx, budgetID, requestID, cost)
+					p.compensateMCPSpend(ctx, budgetID, eventRequestID, cost)
 					return NewErrorResponseWithData(req.ID, CodeInternalError, "Evidence proof unavailable", map[string]interface{}{
 						"error": "proof_unavailable",
 						"tool":  tc.Name,
@@ -748,6 +750,7 @@ func (p *Proxy) handleToolsCall(ctx context.Context, req *Request, tokenInfo *To
 			"tool":        tc.Name,
 			"cost":        cost,
 			"enforcement": p.config.Enforcement.Mode,
+			"request_id":  eventRequestID,
 		},
 	})
 
@@ -854,6 +857,13 @@ func (p *Proxy) recordMCPDecision(ctx context.Context, req *Request, tokenInfo *
 		decision.RemainingBeforeCredits = decision.RemainingCredits
 	}
 	return p.evidence.RecordMCPDecision(ctx, decision)
+}
+
+func budgetEventRequestID(callerRequestID string, result *BudgetResult) string {
+	if result != nil && result.RequestID != "" {
+		return result.RequestID
+	}
+	return callerRequestID
 }
 
 func (p *Proxy) compensateMCPSpend(ctx context.Context, budgetID, requestID string, cost int64) {

--- a/pkg/mcpserver/request_identity_test.go
+++ b/pkg/mcpserver/request_identity_test.go
@@ -1,0 +1,18 @@
+package mcpserver
+
+import "testing"
+
+func TestBudgetEventRequestIDPrefersCanonicalEnforcerIdentity(t *testing.T) {
+	got := budgetEventRequestID("caller-id", &BudgetResult{RequestID: "billreq:v1:canonical"})
+	if got != "billreq:v1:canonical" {
+		t.Fatalf("got %q", got)
+	}
+}
+
+func TestBudgetEventRequestIDFallsBackForLegacyEnforcer(t *testing.T) {
+	for _, result := range []*BudgetResult{nil, {}} {
+		if got := budgetEventRequestID("caller-id", result); got != "caller-id" {
+			t.Fatalf("got %q", got)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- expose the trusted enforcer canonical request identity on `BudgetResult`
- use that identity consistently for MCP spend/denial events, evidence, compensation, and tool-call events
- retain generated-ID fallback for legacy enforcers

## Verification
- `go test ./...`
- `go vet ./...`
- `git diff --check`
- independent exact-head Security PASS for `c7ded4a96b4d73cb4318e03a6c6cc690ba8408c3`, tree `73a92fea011cb43aaa28b88d83cf7f2315928a34`

No deployment or production mutation.