### PR TITLE
fix(mcp): preserve caller identity in spend events

### DIFF
--- a/pkg/mcpserver/proxy.go
+++ b/pkg/mcpserver/proxy.go
@@ -707,14 +707,7 @@ func (p *Proxy) handleToolsCall(ctx context.Context, req *Request, tokenInfo *To
 				TokenID:   tokenInfo.TokenID,
 				BudgetID:  budgetID,
 				TenantID:  tenantID,
-				Data: map[string]interface{}{
-					"tool":         tc.Name,
-					"cost":         cost,
-					"remaining":    result.Remaining,
-					"budget_limit": tokenInfo.BudgetLimit,
-					"request_id":   eventRequestID,
-					"policy_mode":  normalizeEnforcementMode(mode),
-				},
+				Data:      budgetSpendEventData(tc.Name, cost, result.Remaining, tokenInfo.BudgetLimit, eventRequestID, requestID, mode),
 			})
 
 			var evidenceErr error
@@ -857,6 +850,18 @@ func (p *Proxy) recordMCPDecision(ctx context.Context, req *Request, tokenInfo *
 		decision.RemainingBeforeCredits = decision.RemainingCredits
 	}
 	return p.evidence.RecordMCPDecision(ctx, decision)
+}
+
+func budgetSpendEventData(tool string, cost, remaining, budgetLimit int64, requestIdentity, callerRequestID, mode string) map[string]interface{} {
+	return map[string]interface{}{
+		"tool":              tool,
+		"cost":              cost,
+		"remaining":         remaining,
+		"budget_limit":      budgetLimit,
+		"request_id":        requestIdentity,
+		"caller_request_id": callerRequestID,
+		"policy_mode":       normalizeEnforcementMode(mode),
+	}
 }
 
 func budgetEventRequestID(callerRequestID string, result *BudgetResult) string {

--- a/pkg/mcpserver/request_identity_test.go
+++ b/pkg/mcpserver/request_identity_test.go
@@ -9,6 +9,13 @@ func TestBudgetEventRequestIDPrefersCanonicalEnforcerIdentity(t *testing.T) {
 	}
 }
 
+func TestBudgetSpendEventDataKeepsCanonicalAndCallerIdentity(t *testing.T) {
+	data := budgetSpendEventData("search", 3, 7, 10, "scoped:canonical", "caller-id", "control")
+	if data["request_id"] != "scoped:canonical" || data["caller_request_id"] != "caller-id" {
+		t.Fatalf("identity fields=%v", data)
+	}
+}
+
 func TestBudgetEventRequestIDFallsBackForLegacyEnforcer(t *testing.T) {
 	for _, result := range []*BudgetResult{nil, {}} {
 		if got := budgetEventRequestID("caller-id", result); got != "caller-id" {


### PR DESCRIPTION
## Summary
- preserve the pre-enforcement caller request identity alongside the canonical enforcer identity in successful MCP budget spend events
- keep `request_id` canonical and add `caller_request_id` as correlation metadata
- add regression coverage

## Verification
- `go test -count=1 ./...`
- `go vet ./...`
- `git diff --check`
- exact-head Security PASS

No deployment or production mutation.