### PR TITLE
feat(mcp): expose proof on pre-connect revocation

### DIFF
--- a/pkg/mcpserver/evidence.go
+++ b/pkg/mcpserver/evidence.go
@@ -26,6 +26,10 @@ type MCPDecision struct {
 	CostCredits            int64  `json:"cost_credits"`
 	RemainingCredits       int64  `json:"remaining_credits"`
 	RemainingBeforeCredits int64  `json:"remaining_before_credits"`
+	// NoVerifiedCapability marks terminal denials produced before credential
+	// verification succeeds. Recorders must not project token, capability, or
+	// evaluated-budget authority for this profile.
+	NoVerifiedCapability bool `json:"no_verified_capability,omitempty"`
 }
 
 // MCPEvidence is the verifier-facing handle returned after recording an MCP

--- a/pkg/mcpserver/sse.go
+++ b/pkg/mcpserver/sse.go
@@ -30,23 +30,73 @@ type SSEServer struct {
 
 // sseSession represents one connected MCP client over SSE.
 type sseSession struct {
-	id                string
-	messages          chan json.RawMessage // outbound messages to client
-	ctx               context.Context
-	cancel            context.CancelFunc
+	id       string
+	messages chan json.RawMessage // outbound messages to client
+	ctx      context.Context
+	cancel   context.CancelFunc
+
+	identityMu        sync.RWMutex
 	tokenID           string     // from auth/session tracking (may be empty)
 	tenantID          string     // from auth/session tracking (may be empty)
 	budgetID          string     // from auth/session tracking (may be empty)
 	verifiedTokenInfo *TokenInfo // only set after authenticator verification succeeds
 }
 
-func (s *sseSession) contextWithIdentity() context.Context {
-	ctx := s.ctx
-	if s.tenantID != "" {
-		ctx = context.WithValue(ctx, CtxTenantID, s.tenantID)
+type sseSessionIdentity struct {
+	tokenID           string
+	tenantID          string
+	budgetID          string
+	verifiedTokenInfo *TokenInfo
+}
+
+func (s *sseSession) identitySnapshot() sseSessionIdentity {
+	s.identityMu.RLock()
+	defer s.identityMu.RUnlock()
+	identity := sseSessionIdentity{
+		tokenID:  s.tokenID,
+		tenantID: s.tenantID,
+		budgetID: s.budgetID,
 	}
 	if s.verifiedTokenInfo != nil {
-		ctx = context.WithValue(ctx, CtxTokenInfo, s.verifiedTokenInfo)
+		info := *s.verifiedTokenInfo
+		identity.verifiedTokenInfo = &info
+	}
+	return identity
+}
+
+func (s *sseSession) setVerifiedIdentity(info *TokenInfo) {
+	if info == nil {
+		return
+	}
+	copyInfo := *info
+	s.identityMu.Lock()
+	s.tokenID = info.TokenID
+	s.tenantID = info.TenantID
+	s.budgetID = info.BudgetID
+	s.verifiedTokenInfo = &copyInfo
+	s.identityMu.Unlock()
+}
+
+func (s *sseSession) setTrackingIdentity(tenantID, budgetID string) {
+	if tenantID == "" {
+		return
+	}
+	s.identityMu.Lock()
+	if s.tenantID == "" {
+		s.tenantID = tenantID
+		s.budgetID = budgetID
+	}
+	s.identityMu.Unlock()
+}
+
+func (s *sseSession) contextWithIdentity() context.Context {
+	ctx := s.ctx
+	identity := s.identitySnapshot()
+	if identity.tenantID != "" {
+		ctx = context.WithValue(ctx, CtxTenantID, identity.tenantID)
+	}
+	if identity.verifiedTokenInfo != nil {
+		ctx = context.WithValue(ctx, CtxTokenInfo, identity.verifiedTokenInfo)
 	}
 	return ctx
 }
@@ -168,8 +218,8 @@ func (s *SSEServer) handleSSE(w http.ResponseWriter, r *http.Request) {
 			// Only reject on definitive errors (enterprise misrouting, revocation)
 			// NOT on key-mismatch (multi-tenant SaaS where key lookup is deferred)
 			if strings.Contains(errMsg, "enterprise deployment") || strings.Contains(errMsg, "token revoked") {
-				log.Warn().Str("error", errMsg).Msg("SSE connection rejected at pre-connect")
-				http.Error(w, errMsg, http.StatusForbidden)
+				log.Warn().Msg("SSE connection rejected at pre-connect")
+				s.writePreConnectDenial(w, r, errMsg)
 				cancel()
 				return
 			}
@@ -186,13 +236,14 @@ func (s *SSEServer) handleSSE(w http.ResponseWriter, r *http.Request) {
 		s.mu.Unlock()
 		cancel()
 		log.Info().Str("session", sessionID).Msg("SSE session closed")
+		identity := session.identitySnapshot()
 		s.proxy.events.Publish(Event{
 			Type:      EventSessionClose,
 			Timestamp: time.Now(),
 			SessionID: sessionID,
-			TokenID:   session.tokenID,
-			TenantID:  session.tenantID,
-			BudgetID:  session.budgetID,
+			TokenID:   identity.tokenID,
+			TenantID:  identity.tenantID,
+			BudgetID:  identity.budgetID,
 		})
 	}()
 
@@ -216,10 +267,7 @@ func (s *SSEServer) handleSSE(w http.ResponseWriter, r *http.Request) {
 		var resolved bool
 		if s.proxy.auth != nil {
 			if info, err := s.proxy.auth.Verify(ctx, authToken); err == nil {
-				session.tokenID = info.TokenID
-				session.tenantID = info.TenantID
-				session.budgetID = info.BudgetID
-				session.verifiedTokenInfo = info
+				session.setVerifiedIdentity(info)
 				resolved = true
 			}
 		}
@@ -227,20 +275,20 @@ func (s *SSEServer) handleSSE(w http.ResponseWriter, r *http.Request) {
 			// Best-effort: decode macaroon and read caveats for dashboard tracking.
 			// This is NOT security enforcement — tool calls are verified on /message.
 			if tid, bid := extractTokenCaveats(authToken); tid != "" {
-				session.tenantID = tid
-				session.budgetID = bid
+				session.setTrackingIdentity(tid, bid)
 			}
 		}
 	}
 
-	log.Info().Str("session", sessionID).Str("tenant", session.tenantID).Msg("SSE session established")
+	identity := session.identitySnapshot()
+	log.Info().Str("session", sessionID).Str("tenant", identity.tenantID).Msg("SSE session established")
 	s.proxy.events.Publish(Event{
 		Type:      EventSessionConnect,
 		Timestamp: time.Now(),
 		SessionID: sessionID,
-		TokenID:   session.tokenID,
-		TenantID:  session.tenantID,
-		BudgetID:  session.budgetID,
+		TokenID:   identity.tokenID,
+		TenantID:  identity.tenantID,
+		BudgetID:  identity.budgetID,
 	})
 
 	// Stream outbound messages with keepalive
@@ -258,13 +306,14 @@ func (s *SSEServer) handleSSE(w http.ResponseWriter, r *http.Request) {
 			fmt.Fprintf(w, ": keepalive\n\n")
 			flusher.Flush()
 			// Publish keepalive event so enterprise Redis TTLs stay fresh
+			identity := session.identitySnapshot()
 			s.proxy.events.Publish(Event{
 				Type:      EventSessionKeepalive,
 				Timestamp: time.Now(),
 				SessionID: sessionID,
-				TokenID:   session.tokenID,
-				TenantID:  session.tenantID,
-				BudgetID:  session.budgetID,
+				TokenID:   identity.tokenID,
+				TenantID:  identity.tenantID,
+				BudgetID:  identity.budgetID,
 			})
 
 		case <-ctx.Done():
@@ -314,33 +363,30 @@ func (s *SSEServer) handleMessage(w http.ResponseWriter, r *http.Request) {
 	// Authorization header on the initial SSE GET — only on POST /message.
 	// When we see a token here for the first time, extract tenant/budget info
 	// and re-publish a session_connect event so the dashboard picks it up.
-	if authToken != "" && session.tenantID == "" {
+	if authToken != "" && session.identitySnapshot().tenantID == "" {
 		var resolved bool
 		if s.proxy.auth != nil {
 			if info, err := s.proxy.auth.Verify(session.ctx, authToken); err == nil {
-				session.tokenID = info.TokenID
-				session.tenantID = info.TenantID
-				session.budgetID = info.BudgetID
-				session.verifiedTokenInfo = info
+				session.setVerifiedIdentity(info)
 				resolved = true
 			}
 		}
 		if !resolved {
 			if tid, bid := extractTokenCaveats(authToken); tid != "" {
-				session.tenantID = tid
-				session.budgetID = bid
+				session.setTrackingIdentity(tid, bid)
 			}
 		}
-		// Re-publish session_connect with correct identity
-		if session.tenantID != "" {
-			log.Info().Str("session", sessionID).Str("tenant", session.tenantID).Msg("session identity resolved from message auth")
+		// Re-publish session_connect with correct identity.
+		identity := session.identitySnapshot()
+		if identity.tenantID != "" {
+			log.Info().Str("session", sessionID).Str("tenant", identity.tenantID).Msg("session identity resolved from message auth")
 			s.proxy.events.Publish(Event{
 				Type:      EventSessionConnect,
 				Timestamp: time.Now(),
 				SessionID: sessionID,
-				TokenID:   session.tokenID,
-				TenantID:  session.tenantID,
-				BudgetID:  session.budgetID,
+				TokenID:   identity.tokenID,
+				TenantID:  identity.tenantID,
+				BudgetID:  identity.budgetID,
 			})
 		}
 	}
@@ -393,6 +439,64 @@ func (s *SSEServer) handleMessage(w http.ResponseWriter, r *http.Request) {
 	}()
 
 	w.WriteHeader(http.StatusAccepted)
+}
+
+func (s *SSEServer) writePreConnectDenial(w http.ResponseWriter, r *http.Request, verifierError string) {
+	code := "WRONG_LANE"
+	errorName := "wrong_lane"
+	message := "Credential is not valid for this MCP endpoint."
+	isRevoked := strings.Contains(verifierError, "token revoked")
+	if isRevoked {
+		code = "TOKEN_REVOKED"
+		errorName = "token_revoked"
+		message = "This credential has been revoked."
+	}
+
+	response := map[string]interface{}{
+		"error":   errorName,
+		"code":    code,
+		"message": message,
+	}
+
+	// TenantFromContext is populated only by trusted in-process routing
+	// middleware. Never derive signed tenant authority from caller headers or
+	// unverified token caveats at this pre-connect boundary.
+	tenantID := TenantFromContext(r.Context())
+	if isRevoked && tenantID != "" && s.proxy.evidence != nil {
+		requestID := "mcp-sse-" + generateSessionID()
+		if err := s.proxy.evidence.Preflight(r.Context()); err == nil {
+			proof, recordErr := s.proxy.evidence.RecordMCPDecision(r.Context(), MCPDecision{
+				Decision:             "denied",
+				DecisionReason:       "token_revoked",
+				PolicyMode:           "auth",
+				TenantID:             tenantID,
+				MCPMethod:            "sse/connect",
+				RouteOrTool:          "mcp:sse:connect",
+				RequestID:            requestID,
+				NoVerifiedCapability: true,
+			})
+			if recordErr == nil && proof != nil && proof.EvidenceURL != "" {
+				response["proof"] = map[string]string{
+					"receipt_id":       proof.ReceiptID,
+					"receipt_hash":     proof.ReceiptHash,
+					"evidence_pack_id": proof.EvidencePackID,
+					"evidence_url":     proof.EvidenceURL,
+					"verify_url":       proof.VerifyURL,
+					"jwks_url":         proof.JWKSURL,
+					"request_id":       requestID,
+				}
+				w.Header().Set("X-SatGate-Request-ID", requestID)
+				w.Header().Set("X-SatGate-Receipt-ID", proof.ReceiptID)
+				w.Header().Set("X-SatGate-Receipt-Hash", proof.ReceiptHash)
+				w.Header().Set("X-SatGate-Evidence-Pack-ID", proof.EvidencePackID)
+				w.Header().Set("Link", fmt.Sprintf("<%s>; rel=\"satgate-evidence-pack\"; type=\"application/json\"", proof.EvidenceURL))
+			}
+		}
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusForbidden)
+	_ = json.NewEncoder(w).Encode(response)
 }
 
 func (s *SSEServer) handleHealth(w http.ResponseWriter, _ *http.Request) {

--- a/pkg/mcpserver/sse_preconnect_evidence_test.go
+++ b/pkg/mcpserver/sse_preconnect_evidence_test.go
@@ -1,0 +1,190 @@
+package mcpserver
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+type rejectingAuthenticator struct{ err error }
+
+func (a rejectingAuthenticator) Verify(context.Context, string) (*TokenInfo, error) {
+	return nil, a.err
+}
+
+type resolvingAuthenticator struct{}
+
+func (resolvingAuthenticator) Verify(context.Context, string) (*TokenInfo, error) {
+	time.Sleep(time.Millisecond)
+	return &TokenInfo{
+		TokenID:  "token-late",
+		TenantID: "tenant-late",
+		BudgetID: "budget-late",
+	}, nil
+}
+
+func preConnectRequest(t *testing.T, proxy *Proxy, trustedTenant string) *httptest.ResponseRecorder {
+	t.Helper()
+	sse := NewSSEServer(proxy, ":0")
+	req := httptest.NewRequest(http.MethodGet, "/sse", nil)
+	req.Header.Set("Authorization", "Bearer redacted-test-token")
+	if trustedTenant != "" {
+		req = req.WithContext(context.WithValue(req.Context(), CtxTenantID, trustedTenant))
+	}
+	rec := httptest.NewRecorder()
+	sse.Handler().ServeHTTP(rec, req)
+	return rec
+}
+
+func decodePreConnectBody(t *testing.T, rec *httptest.ResponseRecorder) map[string]interface{} {
+	t.Helper()
+	var body map[string]interface{}
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode response: %v body=%q", err, rec.Body.String())
+	}
+	return body
+}
+
+func TestSSEPreConnectRevocationReturnsTrustedDenialProof(t *testing.T) {
+	proxy := newEvidenceTestProxy(t)
+	recorder := &fakeEvidenceRecorder{}
+	proxy.SetEvidenceRecorder(recorder)
+	proxy.SetAuthenticator(rejectingAuthenticator{err: errors.New("token revoked")})
+
+	rec := preConnectRequest(t, proxy, "tenant-trusted")
+	body := decodePreConnectBody(t, rec)
+	if rec.Code != http.StatusForbidden || body["error"] != "token_revoked" || body["code"] != "TOKEN_REVOKED" {
+		t.Fatalf("unexpected denial: status=%d body=%#v", rec.Code, body)
+	}
+	proof, _ := body["proof"].(map[string]interface{})
+	if proof["evidence_url"] == "" || rec.Header().Get("X-SatGate-Evidence-Pack-ID") == "" || !strings.Contains(rec.Header().Get("Link"), "satgate-evidence-pack") {
+		t.Fatalf("missing proof metadata: headers=%v body=%#v", rec.Header(), body)
+	}
+	if len(recorder.decisions) != 1 {
+		t.Fatalf("decisions=%d", len(recorder.decisions))
+	}
+	decision := recorder.decisions[0]
+	if decision.TenantID != "tenant-trusted" || decision.Decision != "denied" || decision.DecisionReason != "token_revoked" || !decision.NoVerifiedCapability || decision.TokenID != "" || decision.BudgetID != "" {
+		t.Fatalf("unsafe denial decision: %#v", decision)
+	}
+}
+
+func TestSSEPreConnectRevocationWithoutTrustedTenantReturnsNoProof(t *testing.T) {
+	proxy := newEvidenceTestProxy(t)
+	recorder := &fakeEvidenceRecorder{}
+	proxy.SetEvidenceRecorder(recorder)
+	proxy.SetAuthenticator(rejectingAuthenticator{err: errors.New("token revoked")})
+
+	rec := preConnectRequest(t, proxy, "")
+	body := decodePreConnectBody(t, rec)
+	if rec.Code != http.StatusForbidden || body["error"] != "token_revoked" || body["proof"] != nil {
+		t.Fatalf("unexpected denial: status=%d body=%#v", rec.Code, body)
+	}
+	if len(recorder.decisions) != 0 || rec.Header().Get("X-SatGate-Evidence-Pack-ID") != "" {
+		t.Fatal("untrusted request produced proof")
+	}
+}
+
+func TestSSEPreConnectRevocationRecorderFailureStillDeniesWithoutProof(t *testing.T) {
+	proxy := newEvidenceTestProxy(t)
+	recorder := &fakeEvidenceRecorder{recordErr: errors.New("archive unavailable")}
+	proxy.SetEvidenceRecorder(recorder)
+	proxy.SetAuthenticator(rejectingAuthenticator{err: errors.New("token revoked")})
+
+	rec := preConnectRequest(t, proxy, "tenant-trusted")
+	body := decodePreConnectBody(t, rec)
+	if rec.Code != http.StatusForbidden || body["error"] != "token_revoked" || body["proof"] != nil {
+		t.Fatalf("enforcement changed on recorder failure: status=%d body=%#v", rec.Code, body)
+	}
+}
+
+func TestSSEPreConnectRevocationPreflightFailureStillDeniesWithoutProof(t *testing.T) {
+	proxy := newEvidenceTestProxy(t)
+	recorder := &fakeEvidenceRecorder{preflightErr: errors.New("signer unavailable")}
+	proxy.SetEvidenceRecorder(recorder)
+	proxy.SetAuthenticator(rejectingAuthenticator{err: errors.New("token revoked")})
+
+	rec := preConnectRequest(t, proxy, "tenant-trusted")
+	body := decodePreConnectBody(t, rec)
+	if rec.Code != http.StatusForbidden || body["error"] != "token_revoked" || body["proof"] != nil {
+		t.Fatalf("enforcement changed on preflight failure: status=%d body=%#v", rec.Code, body)
+	}
+	if len(recorder.decisions) != 0 {
+		t.Fatal("preflight failure still attempted evidence recording")
+	}
+}
+
+func TestSSEPreConnectWrongLaneNeverProducesRevocationProof(t *testing.T) {
+	proxy := newEvidenceTestProxy(t)
+	recorder := &fakeEvidenceRecorder{}
+	proxy.SetEvidenceRecorder(recorder)
+	proxy.SetAuthenticator(rejectingAuthenticator{err: errors.New("enterprise deployment token rejected")})
+
+	rec := preConnectRequest(t, proxy, "tenant-trusted")
+	body := decodePreConnectBody(t, rec)
+	if rec.Code != http.StatusForbidden || body["error"] != "wrong_lane" || body["code"] != "WRONG_LANE" || body["proof"] != nil {
+		t.Fatalf("unexpected wrong-lane denial: status=%d body=%#v", rec.Code, body)
+	}
+	if len(recorder.decisions) != 0 {
+		t.Fatal("wrong-lane rejection was mislabeled as revocation proof")
+	}
+}
+
+func TestSSEConcurrentLateIdentityResolutionAndClose(t *testing.T) {
+	proxy := newEvidenceTestProxy(t)
+	proxy.SetAuthenticator(resolvingAuthenticator{})
+	sse := NewSSEServer(proxy, ":0")
+	server := httptest.NewServer(sse.Handler())
+	defer server.Close()
+
+	sseResp, err := http.Get(server.URL + "/sse")
+	if err != nil {
+		t.Fatal(err)
+	}
+	sessionID := readEndpointEvent(t, sseResp.Body)
+	if sessionID == "" {
+		t.Fatal("missing session ID")
+	}
+
+	const requestCount = 32
+	errs := make(chan error, requestCount)
+	var wg sync.WaitGroup
+	for i := 0; i < requestCount; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			req, err := http.NewRequest(http.MethodPost, server.URL+"/message?sessionId="+sessionID, strings.NewReader(`{"jsonrpc":"2.0","id":1,"method":"ping"}`))
+			if err != nil {
+				errs <- err
+				return
+			}
+			req.Header.Set("Authorization", "Bearer late-token")
+			req.Header.Set("Content-Type", "application/json")
+			resp, err := http.DefaultClient.Do(req)
+			if err != nil {
+				errs <- err
+				return
+			}
+			_, _ = io.ReadAll(resp.Body)
+			_ = resp.Body.Close()
+			if resp.StatusCode != http.StatusAccepted && resp.StatusCode != http.StatusNotFound {
+				errs <- errors.New("unexpected message status: " + resp.Status)
+			}
+		}()
+	}
+
+	time.Sleep(time.Millisecond)
+	_ = sseResp.Body.Close()
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		t.Error(err)
+	}
+}


### PR DESCRIPTION
## Summary
- return normalized JSON 403 for revoked and wrong-lane SSE pre-connect denials
- record proof-bearing token_revoked denials only with trusted in-process tenant context
- preserve denial when evidence preflight/recording fails
- synchronize mutable SSE session identity and add a race regression

## Security invariants
- no caller header or unverified caveat is used as signed tenant authority
- no raw token or verifier error is returned or logged
- wrong-lane failures never receive revocation proof
- no verified capability or evaluated budget is projected before auth succeeds

## Verification
- `go test ./...`
- `go test -race ./pkg/mcpserver`
- focused pre-connect tests repeated and race-tested
- independent exact-head security review: PASS, high confidence

Reviewed exact head: `9aaf86f36c0f9a71e242d218bc43a96384cbd37c`
Reviewed tree: `4438a8b1bb8bf36e9ab94528c26d23c20b37f0d7`

No deployment or environment mutation.