### PR TITLE
Sharpen homepage hero around overspend and proof

### DIFF
--- a/satgate-landing/app/components/HomeClient.tsx
+++ b/satgate-landing/app/components/HomeClient.tsx
@@ -174,13 +174,13 @@ const LandingPage = () => {
               <Zap size={12} /> Agent Authority & Accountability Layer
             </div>
             <h1 className="text-5xl md:text-6xl font-extrabold tracking-tight mb-6">
-              Govern agent authority<br/>
+              Stop agent overspend.<br/>
               <span className="sr-only"> </span><span className="text-transparent bg-clip-text bg-gradient-to-r from-purple-400 via-pink-400 to-cyan-400">
-                before execution.
+                Prove what they did.
               </span>
             </h1>
             <p className="text-xl text-gray-400 mb-4 max-w-lg leading-relaxed">
-              SatGate gives agents bounded economic authority so humans, platforms, and upstream APIs can trust what they consume, spend, and prove.
+              One gateway in front of the APIs, models, and tools your agents touch: budgets and scope enforced before execution, and signed evidence your auditor can verify independently.
             </p>
             <p className="text-lg text-gray-500 mb-8 max-w-lg leading-relaxed">
               Humans and platforms set policy. Agents consume approved primitives. Upstreams get receipt-backed proof.


### PR DESCRIPTION
## Summary

- lead the homepage with the buyer outcome: **Stop agent overspend.**
- pair it with the proof differentiator: **Prove what they did.**
- explain the mechanism with pre-execution budgets/scope and independently verifiable signed evidence
- preserve the existing category eyebrow and policy/primitives/proof line

## Scope

One file only: `satgate-landing/app/components/HomeClient.tsx`.

## Verification

- `npm ci` — PASS; zero vulnerabilities
- focused ESLint — PASS with zero errors (14 existing warnings)
- `npm run build` — PASS; 124 static pages
- `npm run test:proof-spine` — PASS
- rendered homepage exact-copy and old-H1-absence probe — PASS
- `git diff --check` — PASS
- independent exact-head `satgate-copy-editor` review — PASS

## Existing guard debt

`test:buyer-narrative` and `test:authority-followups` fail on current `origin/main` for unrelated missing legacy thesis/partner strings. The one-file hero change does not introduce those failures.

## Boundaries

This PR changes homepage hero copy only. It does not change product behavior, production configuration, billing, or security enforcement.
