### PR TITLE
Align homepage metadata and foundation copy

### DIFF
--- a/satgate-landing/app/components/HomeClient.tsx
+++ b/satgate-landing/app/components/HomeClient.tsx
@@ -330,7 +330,7 @@ const LandingPage = () => {
             </div>
             <p className="text-gray-400 leading-relaxed mb-4">
               Every protected route requires valid credentials (Macaroons). Capabilities, caveats,
-              delegation, and revocation-built into the protocol, not bolted on.
+              delegation, and revocation are built into the protocol, not bolted on.
             </p>
             <div className="flex flex-wrap gap-4 text-sm text-gray-500">
               <span>✓ Capabilities + Caveats</span>

--- a/satgate-landing/app/page.tsx
+++ b/satgate-landing/app/page.tsx
@@ -4,7 +4,7 @@ import HomeClient from "./components/HomeClient";
 export const metadata: Metadata = {
   title: "SatGate — Agent Authority & Accountability Layer",
   description:
-    "SatGate governs agent authority before execution so humans, platforms, and upstream APIs can trust what agents access, spend, and prove.",
+    "SatGate stops agents from overspending and produces signed evidence your auditor can verify independently. Agent authority is governed before execution.",
   alternates: {
     canonical: "https://satgate.io",
   },


### PR DESCRIPTION
## Summary

- align the homepage meta description with the live overspend/proof hero
- fix the Default Protection sentence so capabilities, caveats, delegation, and revocation are correctly described as built into the protocol

## Verification

- metadata description length: 152 characters
- focused ESLint: PASS with zero errors (existing HomeClient warnings only)
- `npm run build`: PASS; 124 static pages
- `npm run test:proof-spine`: PASS
- `git diff --check`: PASS
- independent exact-head `satgate-copy-editor` review: PASS

## Scope

Two copy lines only across:

- `satgate-landing/app/page.tsx`
- `satgate-landing/app/components/HomeClient.tsx`
