### PR TITLE
fix(landing): retire deprecated Hybrid deployment copy

### DIFF
--- a/satgate-landing/app/compare/_components/comparisons.ts
+++ b/satgate-landing/app/compare/_components/comparisons.ts
@@ -17,7 +17,7 @@ export const brutalComparisons: Record<string, BrutalComparison> = {
     eyebrow: 'Managed agent payments vs Policy-to-Proof governance',
     title: 'SatGate vs AWS AgentCore Payments: Governance Above Paid Rails',
     description: 'AWS AgentCore Payments helps agents transact inside AWS. SatGate governs authority, Evidence Pack proof, MCP tools, and paid rails before execution across the multi-provider enterprise environment.',
-    verdict: 'If your world is AWS AgentCore, AWS gives you managed payments. If your environment spans OpenAI, Anthropic, local agents, MCP tools, internal APIs, hybrid gateways, and multiple payment rails, SatGate is the control layer.',
+    verdict: 'If your world is AWS AgentCore, AWS gives you managed payments. If your environment spans OpenAI, Anthropic, local agents, MCP tools, internal APIs, customer-controlled gateways, and multiple payment rails, SatGate is the control layer.',
     competitorGoodAt: [
       'Managed payment enablement for agents built around AWS AgentCore patterns.',
       'Tight fit for teams standardizing agent runtime, identity, tools, and observability inside AWS.',
@@ -36,14 +36,14 @@ export const brutalComparisons: Record<string, BrutalComparison> = {
       { axis: 'Pre-execution control', satgate: standardAxes.preExecution, competitor: 'Can help with managed agent access/payment flows, but the center is not provider-neutral policy before every external spend event.', winner: 'SatGate' },
       { axis: 'Delegation', satgate: standardAxes.delegation, competitor: 'AWS identity and agent controls help inside AWS; portability across heterogeneous agents and sub-agents requires additional governance.', winner: 'SatGate' },
       { axis: 'Evidence Packs', satgate: standardAxes.evidence, competitor: 'AWS observability gives logs/traces. SatGate packages the policy decision and economic proof itself.', winner: 'SatGate' },
-      { axis: 'Hybrid deployment', satgate: standardAxes.hybrid, competitor: 'AWS-managed by default; excellent cloud integration, weaker story when enforcement must live beside private non-AWS systems.', winner: 'SatGate' },
+      { axis: 'Deployment flexibility', satgate: standardAxes.hybrid, competitor: 'AWS-managed by default; excellent cloud integration, weaker story when enforcement must live beside private non-AWS systems.', winner: 'SatGate' },
       { axis: 'MCP-native proxying', satgate: standardAxes.mcp, competitor: 'AgentCore has gateway/tool surfaces; SatGate frames MCP as the enforcement boundary for spend and authority.', winner: 'SatGate' },
     ],
     bullets: [
       { title: 'AWS is strongest inside AWS-native architectures', body: 'That is valuable. It is also the limitation. Most enterprises will not put every agent, model, API, MCP server, and paid rail inside one AWS-native box.' },
       { title: 'Payments are not permission', body: 'A payment session does not answer whether this agent, task, tenant, budget, route, or delegated child should be allowed to act right now.' },
       { title: 'Receipts need policy context', body: 'Finance and security need more than “a payment happened.” They need who delegated authority, what policy applied, why it was allowed, and what evidence remains.' },
-      { title: 'Hybrid matters', body: 'Regulated APIs, private MCP tools, and customer-controlled gateways need enforcement near the trust boundary, not only in a managed cloud console.' },
+      { title: 'Deployment flexibility matters', body: 'Regulated APIs, private MCP tools, and customer-controlled gateways need enforcement near the trust boundary, not only in a managed cloud console.' },
     ],
     faqs: [
       { question: 'Does SatGate replace AWS AgentCore Payments?', answer: 'Not necessarily. AWS AgentCore Payments is useful for AWS-native agent payments. SatGate is the cross-provider control layer for agent authority, budgets, MCP tools, APIs, and paid rails.' },
@@ -73,7 +73,7 @@ export const brutalComparisons: Record<string, BrutalComparison> = {
       { axis: 'Pre-execution control', satgate: standardAxes.preExecution, competitor: 'Rate limits and gateway controls are useful, but they are not delegated economic authority.', winner: 'SatGate' },
       { axis: 'Delegation', satgate: standardAxes.delegation, competitor: 'No native SatGate-style attenuated agent capability and delegation-depth model.', winner: 'SatGate' },
       { axis: 'Evidence Packs', satgate: standardAxes.evidence, competitor: 'Logs and analytics explain traffic; they do not package authority, budget, and proof as the core artifact.', winner: 'SatGate' },
-      { axis: 'Hybrid deployment', satgate: standardAxes.hybrid, competitor: 'Cloudflare-managed edge platform.', winner: 'SatGate' },
+      { axis: 'Deployment flexibility', satgate: standardAxes.hybrid, competitor: 'Cloudflare-managed edge platform.', winner: 'SatGate' },
       { axis: 'MCP-native proxying', satgate: standardAxes.mcp, competitor: 'AI Gateway is not primarily an MCP authority policy proxy.', winner: 'SatGate' },
     ],
     bullets: [
@@ -110,7 +110,7 @@ export const brutalComparisons: Record<string, BrutalComparison> = {
       { axis: 'Pre-execution control', satgate: standardAxes.preExecution, competitor: 'Primarily after/during execution visibility; some gateway controls exist, but enforcement is not the core category.', winner: 'SatGate' },
       { axis: 'Delegation', satgate: standardAxes.delegation, competitor: 'Users, sessions, traces, and properties are not portable delegated spend authority.', winner: 'SatGate' },
       { axis: 'Evidence Packs', satgate: standardAxes.evidence, competitor: 'Logs and traces are raw material; SatGate packages policy proof as the artifact.', winner: 'SatGate' },
-      { axis: 'Hybrid deployment', satgate: standardAxes.hybrid, competitor: 'Varies by product and enterprise tier; often SaaS/agent-centric observability.', winner: 'SatGate' },
+      { axis: 'Deployment flexibility', satgate: standardAxes.hybrid, competitor: 'Varies by product and enterprise tier; often SaaS/agent-centric observability.', winner: 'SatGate' },
       { axis: 'MCP-native proxying', satgate: standardAxes.mcp, competitor: 'Not primarily MCP economic enforcement proxies.', winner: 'SatGate' },
     ],
     bullets: [
@@ -147,7 +147,7 @@ export const brutalComparisons: Record<string, BrutalComparison> = {
       { axis: 'Pre-execution control', satgate: 'Semantic policy before spend: who, what, why, budget, route, tool, rail, evidence.', competitor: 'Pre-request count/quota checks. Useful, but blunt.', winner: 'SatGate' },
       { axis: 'Delegation', satgate: standardAxes.delegation, competitor: 'API keys, JWTs, IAM, or usage plans rarely encode agent delegation depth and bounded spend.', winner: 'SatGate' },
       { axis: 'Evidence Packs', satgate: standardAxes.evidence, competitor: 'Access logs exist, but they do not usually explain delegated economic authority.', winner: 'SatGate' },
-      { axis: 'Hybrid deployment', satgate: standardAxes.hybrid, competitor: 'Many gateway stacks can be hybrid; the primary comparison is whether policy follows delegated agent authority across tools, rails, and providers.', winner: 'Tie' },
+      { axis: 'Deployment flexibility', satgate: standardAxes.hybrid, competitor: 'Many gateway stacks can be hybrid; the primary comparison is whether policy follows delegated agent authority across tools, rails, and providers.', winner: 'Tie' },
       { axis: 'MCP-native proxying', satgate: standardAxes.mcp, competitor: 'Generic API gateways are HTTP-aware, not MCP authority-aware by default.', winner: 'SatGate' },
     ],
     bullets: [
@@ -169,8 +169,8 @@ export const brutalComparisons: Record<string, BrutalComparison> = {
     competitor: 'native OpenAI and Anthropic budget controls',
     eyebrow: 'Provider caps vs cross-provider control',
     title: 'SatGate vs OpenAI and Anthropic Budgets: Cross-Provider Authority',
-    description: 'OpenAI and Anthropic budget controls are useful provider-specific guardrails. SatGate is the cross-provider Agent Authority & Accountability Layer above them: delegated budgets, MCP tool governance, paid API access, hybrid enforcement, and Evidence Packs.',
-    verdict: 'Native budgets are necessary last-mile guardrails. They are not a portable agent authorization layer across providers, tools, APIs, rails, and hybrid systems.',
+    description: 'OpenAI and Anthropic budget controls are useful provider-specific guardrails. SatGate is the cross-provider Agent Authority & Accountability Layer above them: delegated budgets, MCP tool governance, paid API access, flexible deployment, and Evidence Packs.',
+    verdict: 'Native budgets are necessary last-mile guardrails. They are not a portable agent authorization layer across providers, tools, APIs, rails, and customer-controlled systems.',
     competitorGoodAt: [
       'Capping or tracking spend inside a single model provider account, project, workspace, or organization.',
       'Provider-native usage dashboards, API keys, rate limits, and admin controls.',
@@ -184,7 +184,7 @@ export const brutalComparisons: Record<string, BrutalComparison> = {
       { axis: 'Pre-execution control', satgate: standardAxes.preExecution, competitor: 'Can stop calls when provider limits are reached, but lacks rich business policy across external tools and rails.', winner: 'SatGate' },
       { axis: 'Delegation', satgate: standardAxes.delegation, competitor: 'Projects, keys, and workspaces are not portable delegated capabilities for autonomous subagents.', winner: 'SatGate' },
       { axis: 'Evidence Packs', satgate: standardAxes.evidence, competitor: 'Usage exports and dashboards help accounting; they do not explain policy and delegation across the full workflow.', winner: 'SatGate' },
-      { axis: 'Hybrid deployment', satgate: standardAxes.hybrid, competitor: 'Provider-side SaaS controls.', winner: 'SatGate' },
+      { axis: 'Deployment flexibility', satgate: standardAxes.hybrid, competitor: 'Provider-side SaaS controls.', winner: 'SatGate' },
       { axis: 'MCP-native proxying', satgate: standardAxes.mcp, competitor: 'Native provider budgets do not govern arbitrary MCP tool calls.', winner: 'SatGate' },
     ],
     bullets: [
@@ -195,7 +195,7 @@ export const brutalComparisons: Record<string, BrutalComparison> = {
     ],
     faqs: [
       { question: 'Should teams still use OpenAI and Anthropic budgets?', answer: 'Yes. Native budgets are useful provider-side backstops. SatGate adds cross-provider agent authority before traffic reaches those providers.' },
-      { question: 'What does SatGate add above native budgets?', answer: 'Delegated capabilities, per-agent and per-tool budgets, MCP-native enforcement, paid-rail policy, hybrid deployment, and Evidence Packs.' },
+      { question: 'What does SatGate add above native budgets?', answer: 'Delegated capabilities, per-agent and per-tool budgets, MCP-native enforcement, paid-rail policy, flexible deployment, and Evidence Packs.' },
       { question: 'Why not just set lower provider limits?', answer: 'Lower limits reduce blast radius inside one vendor. They do not govern the agent’s full workflow across other models, APIs, tools, and payment rails.' },
     ],
     ctaPrimary: { href: '/openai-budget-policy-generator', label: 'Generate an OpenAI policy' },

--- a/satgate-landing/app/compare/api-gateway-rate-limits/page.tsx
+++ b/satgate-landing/app/compare/api-gateway-rate-limits/page.tsx
@@ -5,10 +5,10 @@ const config = brutalComparisons['api-gateway-rate-limits'];
 
 export const metadata = {
   title: 'SatGate vs API Gateway Rate Limits: Authority Beats Quotas',
-  description: 'Compare API Gateway rate limits with SatGate agent authority: delegated budgets, MCP tool policy, paid rails, hybrid enforcement, and Evidence Packs.',
+  description: 'Compare API Gateway rate limits with SatGate agent authority: delegated budgets, MCP tool policy, paid rails, flexible deployment, and Evidence Packs.',
   alternates: { canonical: 'https://satgate.io/compare/api-gateway-rate-limits' },
   keywords: ['SatGate vs API Gateway rate limits', 'agent API rate limits', 'API gateway budget enforcement', 'MCP rate limits', 'agent spend policy'],
-  openGraph: { title: config.title, description: 'Compare API Gateway rate limits with SatGate agent authority: delegated budgets, MCP tool policy, paid rails, hybrid enforcement, and Evidence Packs.', url: 'https://satgate.io/compare/api-gateway-rate-limits', type: 'article' },
+  openGraph: { title: config.title, description: 'Compare API Gateway rate limits with SatGate agent authority: delegated budgets, MCP tool policy, paid rails, flexible deployment, and Evidence Packs.', url: 'https://satgate.io/compare/api-gateway-rate-limits', type: 'article' },
   twitter: { card: 'summary_large_image', title: config.title, description: config.verdict },
 };
 

--- a/satgate-landing/app/compare/aws-agentcore-payments/page.tsx
+++ b/satgate-landing/app/compare/aws-agentcore-payments/page.tsx
@@ -5,10 +5,10 @@ const config = brutalComparisons['aws-agentcore-payments'];
 
 export const metadata = {
   title: 'SatGate vs AWS AgentCore Payments: Governance Above Paid Rails',
-  description: 'Compare SatGate and AWS AgentCore Payments across cross-provider control, paid rails, MCP proxying, delegated budgets, hybrid deployment, and Evidence Packs.',
+  description: 'Compare SatGate and AWS AgentCore Payments across cross-provider control, paid rails, MCP proxying, delegated budgets, flexible deployment, and Evidence Packs.',
   alternates: { canonical: 'https://satgate.io/compare/aws-agentcore-payments' },
   keywords: ['SatGate vs AWS AgentCore Payments', 'AWS AgentCore Payments alternative', 'agent payments governance', 'x402 agent payments', 'MCP agent policy', 'agent authority governance'],
-  openGraph: { title: config.title, description: 'Compare SatGate and AWS AgentCore Payments across cross-provider control, paid rails, MCP proxying, delegated budgets, hybrid deployment, and Evidence Packs.', url: 'https://satgate.io/compare/aws-agentcore-payments', type: 'article' },
+  openGraph: { title: config.title, description: 'Compare SatGate and AWS AgentCore Payments across cross-provider control, paid rails, MCP proxying, delegated budgets, flexible deployment, and Evidence Packs.', url: 'https://satgate.io/compare/aws-agentcore-payments', type: 'article' },
   twitter: { card: 'summary_large_image', title: config.title, description: config.verdict },
 };
 

--- a/satgate-landing/app/compare/langsmith-helicone-datadog/page.tsx
+++ b/satgate-landing/app/compare/langsmith-helicone-datadog/page.tsx
@@ -5,10 +5,10 @@ const config = brutalComparisons['langsmith-helicone-datadog'];
 
 export const metadata = {
   title: 'SatGate vs LangSmith, Helicone, Datadog: Proof Before Postmortems',
-  description: 'Compare LLM observability tools with SatGate pre-execution control: delegated budgets, MCP tool policy, paid rails, hybrid enforcement, and Evidence Packs.',
+  description: 'Compare LLM observability tools with SatGate pre-execution control: delegated budgets, MCP tool policy, paid rails, flexible deployment, and Evidence Packs.',
   alternates: { canonical: 'https://satgate.io/compare/langsmith-helicone-datadog' },
   keywords: ['SatGate vs LangSmith', 'SatGate vs Helicone', 'SatGate vs Datadog LLM Observability', 'LLM observability vs control', 'agent Evidence Packs'],
-  openGraph: { title: config.title, description: 'Compare LLM observability tools with SatGate pre-execution control: delegated budgets, MCP tool policy, paid rails, hybrid enforcement, and Evidence Packs.', url: 'https://satgate.io/compare/langsmith-helicone-datadog', type: 'article' },
+  openGraph: { title: config.title, description: 'Compare LLM observability tools with SatGate pre-execution control: delegated budgets, MCP tool policy, paid rails, flexible deployment, and Evidence Packs.', url: 'https://satgate.io/compare/langsmith-helicone-datadog', type: 'article' },
   twitter: { card: 'summary_large_image', title: config.title, description: config.verdict },
 };
 

--- a/satgate-landing/app/compare/openai-anthropic-budget-controls/page.tsx
+++ b/satgate-landing/app/compare/openai-anthropic-budget-controls/page.tsx
@@ -5,10 +5,10 @@ const config = brutalComparisons['openai-anthropic-budget-controls'];
 
 export const metadata = {
   title: 'SatGate vs OpenAI and Anthropic Budgets: Cross-Provider Authority',
-  description: 'Compare native OpenAI and Anthropic budget controls with SatGate cross-provider agent budgets, MCP policy, paid rails, hybrid control, and Evidence Packs.',
+  description: 'Compare native OpenAI and Anthropic budget controls with SatGate cross-provider agent budgets, MCP policy, paid rails, flexible deployment, and Evidence Packs.',
   alternates: { canonical: 'https://satgate.io/compare/openai-anthropic-budget-controls' },
   keywords: ['OpenAI budget controls alternative', 'Anthropic budget controls alternative', 'cross-provider AI budgets', 'agent budget enforcement', 'SatGate vs OpenAI budgets'],
-  openGraph: { title: config.title, description: 'Compare native OpenAI and Anthropic budget controls with SatGate cross-provider agent budgets, MCP policy, paid rails, hybrid control, and Evidence Packs.', url: 'https://satgate.io/compare/openai-anthropic-budget-controls', type: 'article' },
+  openGraph: { title: config.title, description: 'Compare native OpenAI and Anthropic budget controls with SatGate cross-provider agent budgets, MCP policy, paid rails, flexible deployment, and Evidence Packs.', url: 'https://satgate.io/compare/openai-anthropic-budget-controls', type: 'article' },
   twitter: { card: 'summary_large_image', title: config.title, description: config.verdict },
 };
 

--- a/satgate-landing/app/components/GovernClient.tsx
+++ b/satgate-landing/app/components/GovernClient.tsx
@@ -624,11 +624,12 @@ export default function GovernPage() {
           <div className="bg-gradient-to-r from-cyan-900/20 to-purple-900/20 border border-cyan-800/30 rounded-xl p-6 text-center">
             <div className="flex items-center justify-center gap-2 mb-2">
               <Network size={18} className="text-cyan-400" />
-              <h4 className="font-semibold text-white">Hybrid Mode</h4>
+              <h4 className="font-semibold text-white">SaaS or Dedicated</h4>
             </div>
             <p className="text-gray-400 text-sm max-w-lg mx-auto">
-              Gateway runs in your VPC. Dashboard in our cloud (or yours). Gateway traffic stays inside your infrastructure.
-              The best of both worlds: self-hosted security, managed convenience.
+              Start on the managed platform at cloud.satgate.io. When requirements call for isolation, the same
+              platform deploys as a single-customer Dedicated environment — deployment and custody boundaries
+              agreed by contract during onboarding, up to fully client-operated.
             </p>
           </div>
         </div>

--- a/satgate-landing/app/design-partners/page.tsx
+++ b/satgate-landing/app/design-partners/page.tsx
@@ -70,7 +70,7 @@ export default function DesignPartnersPage() {
     { q: 'How long is the program?', a: '90 days. After that, you keep everything you built and get priority access to GA pricing.' },
     { q: 'Is it really free?', a: 'Yes. The design-partner path starts with an agreed staging lane and no credit card. You get visibility into agent traffic and help shape the authority, budget, revocation, and Evidence Pack workflows that matter in your environment.' },
     { q: 'Do I need to change my code?', a: 'Usually no. Most pilots start with a DNS, proxy, or MCP configuration change around one staging endpoint or tool. We verify the path together before expanding.' },
-    { q: 'Where does my data go?', a: 'Your infrastructure in hybrid mode. The SatGate gateway runs in your VPC. We never see your API payloads or sensitive data.' },
+    { q: 'Where does my data go?', a: 'Your infrastructure. In a Dedicated deployment the SatGate gateway runs in your environment, with custody boundaries agreed during onboarding. We never see your API payloads or sensitive data.' },
     { q: 'Is this for production traffic?', a: 'Design partners usually start in staging or a bounded pilot lane. The goal is to verify request-path policy, revocation, budgets, and Evidence Pack proof before expanding scope.' },
   ];
 

--- a/satgate-landing/app/privacy/page.tsx
+++ b/satgate-landing/app/privacy/page.tsx
@@ -85,9 +85,9 @@ export default function PrivacyPage() {
           <section>
             <h2 className="text-2xl font-bold text-white mb-4">Dedicated &amp; Self-Hosted Deployments</h2>
             <p className="text-gray-400 leading-relaxed">
-              In a Dedicated deployment, custody boundaries are agreed by contract during onboarding. When the 
-              gateway runs in your environment, all proxied traffic stays in your infrastructure. We have no access 
-              to your server logs, API traffic, or Lightning node data. Where a SatGate-operated dashboard is part 
+              In a Dedicated deployment, custody boundaries are agreed by contract during onboarding. When the
+              gateway runs in your environment, all proxied traffic stays in your infrastructure. We have no access
+              to your server logs, API traffic, or Lightning node data. Where a SatGate-operated dashboard is part
               of the agreed deployment, it receives only aggregated telemetry (request counts, budget status) — never request contents.
             </p>
           </section>

--- a/satgate-landing/app/privacy/page.tsx
+++ b/satgate-landing/app/privacy/page.tsx
@@ -3,18 +3,18 @@ import { ArrowLeft } from 'lucide-react';
 
 export const metadata = {
   title: 'Privacy Policy - SatGate',
-  description: 'SatGate privacy policy for cloud, self-hosted, and hybrid deployments, including request metadata, telemetry, cookies, retention, and third-party services.',
+  description: 'SatGate privacy policy for SaaS and Dedicated deployments, including request metadata, telemetry, cookies, retention, and third-party services.',
   alternates: { canonical: 'https://satgate.io/privacy' },
   openGraph: {
     title: 'Privacy Policy - SatGate',
-    description: 'How SatGate handles privacy across cloud, self-hosted, and hybrid economic-control-plane deployments.',
+    description: 'How SatGate handles privacy across SaaS and Dedicated economic-control-plane deployments.',
     url: 'https://satgate.io/privacy',
     type: 'website',
   },
   twitter: {
     card: 'summary_large_image',
     title: 'Privacy Policy - SatGate',
-    description: 'How SatGate handles privacy across cloud, self-hosted, and hybrid economic-control-plane deployments.',
+    description: 'How SatGate handles privacy across SaaS and Dedicated economic-control-plane deployments.',
   },
 };
 
@@ -31,7 +31,7 @@ export default function PrivacyPage() {
       { '@type': 'Thing', name: 'SatGate Cloud privacy' },
       { '@type': 'Thing', name: 'self-hosted Economic Firewall privacy' },
       { '@type': 'Thing', name: 'API request metadata privacy' },
-      { '@type': 'Thing', name: 'hybrid gateway telemetry' },
+      { '@type': 'Thing', name: 'dedicated gateway telemetry' },
     ],
   };
 
@@ -83,12 +83,12 @@ export default function PrivacyPage() {
           </section>
 
           <section>
-            <h2 className="text-2xl font-bold text-white mb-4">Self-Hosted &amp; Hybrid Deployments</h2>
+            <h2 className="text-2xl font-bold text-white mb-4">Dedicated &amp; Self-Hosted Deployments</h2>
             <p className="text-gray-400 leading-relaxed">
-              When you self-host SatGate or deploy the gateway in hybrid mode (gateway in your VPC, 
-              dashboard in our cloud), all proxied traffic stays in your infrastructure. We have no access 
-              to your server logs, API traffic, or Lightning node data. In hybrid mode, the cloud dashboard 
-              receives only aggregated telemetry (request counts, budget status) — never request contents.
+              In a Dedicated deployment, custody boundaries are agreed by contract during onboarding. When the 
+              gateway runs in your environment, all proxied traffic stays in your infrastructure. We have no access 
+              to your server logs, API traffic, or Lightning node data. Where a SatGate-operated dashboard is part 
+              of the agreed deployment, it receives only aggregated telemetry (request counts, budget status) — never request contents.
             </p>
           </section>
 

--- a/satgate-landing/app/terms/page.tsx
+++ b/satgate-landing/app/terms/page.tsx
@@ -3,18 +3,18 @@ import { ArrowLeft } from 'lucide-react';
 
 export const metadata = {
   title: 'Terms of Service - SatGate',
-  description: 'SatGate terms of service for cloud, self-hosted, and hybrid deployments, including economic access control, paid-rail context, licensing, and prohibited uses.',
+  description: 'SatGate terms of service for SaaS and Dedicated deployments, including economic access control, paid-rail context, licensing, and prohibited uses.',
   alternates: { canonical: 'https://satgate.io/terms' },
   openGraph: {
     title: 'Terms of Service - SatGate',
-    description: 'SatGate terms for cloud, self-hosted, and hybrid economic-control-plane deployments, paid-rail context, and licensing.',
+    description: 'SatGate terms for SaaS and Dedicated economic-control-plane deployments, paid-rail context, and licensing.',
     url: 'https://satgate.io/terms',
     type: 'website',
   },
   twitter: {
     card: 'summary_large_image',
     title: 'Terms of Service - SatGate',
-    description: 'SatGate terms for cloud, self-hosted, and hybrid economic-control-plane deployments, paid-rail context, and licensing.',
+    description: 'SatGate terms for SaaS and Dedicated economic-control-plane deployments, paid-rail context, and licensing.',
   },
 };
 

--- a/satgate-landing/app/verify-evidence-pack/page.tsx
+++ b/satgate-landing/app/verify-evidence-pack/page.tsx
@@ -100,7 +100,7 @@ python tools/verify_evidence_pack.py pack.json \
             </div>
             <div className="rounded-2xl border border-amber-400/20 bg-amber-400/10 p-5 text-amber-50">
               <h3 className="font-bold">Does not prove by itself</h3>
-              <p className="mt-2 text-sm leading-6">Billing settlement, upstream counter reconciliation, Hybrid/MCP parity, instant revocation propagation, or broad production readiness unless those claims are separately evidenced.</p>
+              <p className="mt-2 text-sm leading-6">Billing settlement, upstream counter reconciliation, MCP or deployment parity, instant revocation propagation, or broad production readiness unless those claims are separately evidenced.</p>
             </div>
           </div>
         </div>

--- a/satgate-landing/scripts/check_policy_to_proof_page.py
+++ b/satgate-landing/scripts/check_policy_to_proof_page.py
@@ -658,7 +658,7 @@ mcp_authority_required_phrases = {
         "MCP Evidence Pack receipt",
         "Evidence Pack",
         "SaaS MCP is Fly-hosted",
-        "Hybrid MCP is Hetzner-hosted",
+        "Dedicated MCP is contract-triggered",
         "Observe, Control, Charge MCP tool use",
         "/mcp-governance",
         "Govern MCP tool access",
@@ -710,6 +710,7 @@ mcp_authority_forbidden_phrases = {
         "/blog/http-402-payment-required-use-cases",
         "Check, Govern, Prove MCP tool use",
         "Run SaaS or Hybrid MCP",
+        "Hybrid MCP is Hetzner-hosted",
     ],
     "agent-api-governance": [
         "research-bot",


### PR DESCRIPTION
## Summary
- Replace the `/govern` “Hybrid Mode” card (gateway in your VPC, dashboard in our cloud) with the current SaaS / Dedicated model: managed platform at cloud.satgate.io, with the same platform deploying as a single-customer Dedicated environment, custody agreed by contract during onboarding. Matches the pricing FAQ and MCP Gateway “not a shared hybrid tier” positioning.
- Rewrite the privacy policy “Self-Hosted & Hybrid Deployments” section to Dedicated framing (custody boundaries by contract; telemetry description preserved), and update privacy/terms meta descriptions from “cloud, self-hosted, and hybrid” to “SaaS and Dedicated.”
- Update the design-partners “Where does my data go?” FAQ from “hybrid mode” to Dedicated deployment language.
- Rename the compare-page axis “Hybrid deployment” to “Deployment flexibility” and replace SatGate-specific “hybrid enforcement/control/deployment” framing. Competitor self-descriptions and generic industry references to hybrid environments remain unchanged.
- Replace the last SatGate product-surface reference on `/verify-evidence-pack`: “Hybrid/MCP parity” is now the bounded non-claim “MCP or deployment parity.”
- Update the Policy-to-Proof copy guard to require the current Dedicated MCP heading and reject the retired “Hybrid MCP is Hetzner-hosted” phrase.

## Exact candidate

- Base: `fd047884ae01001bfa9e70f5a65cf2ad1c7d3127`
- Head: `46f2257f9e607d70e2bbedb231b62b97bceffc23`

## Test plan
- [x] `npm run build` passes (124/124 static pages)
- [x] `npm run test:proof-spine`
- [x] focused ESLint on `/verify-evidence-pack`
- [x] Python guard syntax check
- [x] focused Hybrid-retirement assertion
- [x] `git diff --check`
- [ ] Visual review of `/govern`, `/privacy`, `/design-partners`, `/verify-evidence-pack`, and one comparison page

The broader `check_policy_to_proof_page.py` currently stops on two required phrases already absent on exact base (`Every agent action leaves a receipt`; `90-second Evidence Pack cut`). This PR does not touch those source areas; the focused Hybrid-retirement guard passes.

## Boundaries

Public copy/guard changes only. No runtime, deployment, custody, billing, customer, or production-authorization change.
