### PR TITLE
fix(landing): bridge Admit lane to charge policy on /agents

### DIFF
--- a/satgate-landing/app/agents/page.tsx
+++ b/satgate-landing/app/agents/page.tsx
@@ -245,7 +245,7 @@ export default function AgentsLandingPage() {
               <p className="text-gray-400 text-sm leading-relaxed">
                 Monetize your APIs. Approved external agents are admitted under a charge policy
                 (<code className="text-xs">policy: charge</code>): scoped, paid access per request
-                via paid rails (L402). No API keys, no subscriptions — just pay and go.
+                via paid rails (L402), without sharing long-lived API keys or requiring a subscription.
               </p>
               <ul className="mt-4 space-y-2 text-sm text-gray-500">
                 <li className="flex items-center gap-2"><CheckCircle size={14} className="text-yellow-400 shrink-0" /> paid-rail context</li>

--- a/satgate-landing/app/agents/page.tsx
+++ b/satgate-landing/app/agents/page.tsx
@@ -243,8 +243,9 @@ export default function AgentsLandingPage() {
               <Zap className="text-yellow-400 mb-4" size={32} />
               <h3 className="text-xl font-semibold text-white mb-2">Admit</h3>
               <p className="text-gray-400 text-sm leading-relaxed">
-                Monetize your APIs. Approved external agents consume scoped access per request
-                via paid-rail context (L402). No API keys, no subscriptions — just pay and go.
+                Monetize your APIs. Approved external agents are admitted under a charge policy
+                (<code className="text-xs">policy: charge</code>): scoped, paid access per request
+                via paid rails (L402). No API keys, no subscriptions — just pay and go.
               </p>
               <ul className="mt-4 space-y-2 text-sm text-gray-500">
                 <li className="flex items-center gap-2"><CheckCircle size={14} className="text-yellow-400 shrink-0" /> paid-rail context</li>


### PR DESCRIPTION
## Summary
- One-card public-copy bridge using the canonical rule: **Admit is the access outcome; Charge is the paid-access policy (`policy: charge`)**. Neither term renames the other away.
- The `/agents` external-agent card now says approved external agents are “admitted under a charge policy (`policy: charge`)”, consistent with `/protect` and `/security`.
- Replaces the unsafe absolute “No API keys, no subscriptions — just pay and go” with “without sharing long-lived API keys or requiring a subscription.”
- The companion Cloud copy handoff is an internal note outside this repository, slotted as SMB exposure X0.5 / pre-X1 product coherence. This PR stands alone as public-copy hygiene.

## Exact candidate

- Base: `496c5297a5a88ded9e4e433d838172214c8f4d72`
- Head: `60908285861a14190d43f103d50d5902b89b7f2d`

## Verification

- [x] Rebased after PR #158 onto exact current main
- [x] `npm ci` — zero vulnerabilities
- [x] focused ESLint — zero errors; four unchanged unused-import warnings
- [x] `npm run build` — 124/124 static pages
- [x] `git diff --check`
- [x] Prior exact-copy review: PASS; refresh required for this rebased SHA

## Boundaries

Copy only. No config, API, billing, runtime, deployment, customer, or production-authorization change. This does not restructure the pre-existing three-card page section; it prevents vocabulary regression within the Admit card.
