### PR TITLE
fix: align public claims with pilot readiness

### DIFF
--- a/satgate-landing/app/components/HomeClient.tsx
+++ b/satgate-landing/app/components/HomeClient.tsx
@@ -35,7 +35,7 @@ const LandingPage = () => {
             <Link href="/sandbox" className="hover:text-white transition">Demo</Link>
             <Link href="/pricing" className="hover:text-white transition">Pricing</Link>
             <a href="https://cloud.satgate.io/docs" target="_blank" rel="noopener noreferrer" className="hover:text-white transition">Docs</a>
-            <a href="https://cloud.satgate.io/cloud/login" target="_blank" rel="noopener noreferrer" className="rounded-full border border-purple-500/40 px-3 py-1.5 text-purple-300 hover:border-purple-400 hover:text-purple-200 transition">Cloud →</a>
+            <a href="https://cloud.satgate.io/cloud/login" target="_blank" rel="noopener noreferrer" className="rounded-full border border-purple-500/40 px-3 py-1.5 text-purple-300 hover:border-purple-400 hover:text-purple-200 transition">Cloud login</a>
           </div>
 
           {/* Mobile menu button */}
@@ -158,7 +158,7 @@ const LandingPage = () => {
               onClick={() => setMobileMenuOpen(false)}
               className="block text-gray-400 hover:text-white hover:bg-gray-800/50 transition py-3 px-4 rounded-lg"
             >
-              Cloud
+              Cloud login
             </a>
           </div>
         </div>
@@ -205,7 +205,7 @@ const LandingPage = () => {
               <div className="flex flex-wrap items-center gap-x-5 gap-y-2">
                 <span className="flex items-center gap-1.5"><CheckCircle size={12} className="text-green-500" /> REST · GraphQL · MCP</span>
                 <span className="flex items-center gap-1.5"><CheckCircle size={12} className="text-green-500" /> Gateway · Sidecar · MCP Proxy</span>
-                <span className="flex items-center gap-1.5"><CheckCircle size={12} className="text-green-500" /> Sub-ms verification</span>
+                <span className="flex items-center gap-1.5"><CheckCircle size={12} className="text-green-500" /> Request-path verification</span>
               </div>
               <div className="flex flex-wrap items-center gap-x-5 gap-y-2">
                 <span className="flex items-center gap-1.5"><CheckCircle size={12} className="text-green-500" /> MCP · API keys · x402-aware governance</span>
@@ -358,7 +358,7 @@ const LandingPage = () => {
                 verify → allow → meter/log
               </p>
               <p className="text-xs text-cyan-400/80 mb-3 italic">
-                Start here. No workflow changes. Map authority, tools, and spend before enforcing policy.
+                Start here. Keep agent behavior unchanged while you map authority, tools, and spend before enforcing policy.
               </p>
               <ul className="text-xs text-gray-500 space-y-1">
                 <li>✓ Observe mode - no enforcement changes to existing agent workflows</li>
@@ -586,7 +586,7 @@ const LandingPage = () => {
       <section className="py-16 px-6 border-b border-gray-800">
         <div className="max-w-5xl mx-auto">
           <h2 className="text-2xl font-bold text-center mb-3">Where It Fits</h2>
-          <p className="text-gray-500 text-center mb-10">Three deployment modes. Drop-in. No rip-and-replace.</p>
+          <p className="text-gray-500 text-center mb-10">Three integration patterns. Start with one bounded route or tool.</p>
 
           <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
             {/* Standard */}
@@ -653,7 +653,7 @@ const LandingPage = () => {
           <div className="text-center mb-16">
             <h2 className="text-3xl font-bold mb-3">How It Works</h2>
             <p className="text-gray-400 max-w-xl mx-auto">
-              Four steps to govern agent traffic. No code changes required.
+              Most pilots start with a proxy, DNS, or MCP configuration change around one bounded endpoint or tool.
             </p>
           </div>
 
@@ -732,9 +732,9 @@ const LandingPage = () => {
               <a href="mailto:contact@satgate.io" className="inline-block bg-gradient-to-r from-purple-600 to-cyan-600 text-white px-10 py-4 rounded-full font-bold text-lg hover:opacity-90 transition shadow-lg shadow-purple-500/20">
                 Get in Touch
               </a>
-              <a href="https://cloud.satgate.io/cloud/login" target="_blank" rel="noopener noreferrer" className="inline-block bg-white text-black px-10 py-4 rounded-full font-bold text-lg hover:bg-gray-200 transition">
-                Start Free →
-              </a>
+              <Link href="/design-partners" className="inline-block bg-white text-black px-10 py-4 rounded-full font-bold text-lg hover:bg-gray-200 transition">
+                Apply for a Pilot →
+              </Link>
             </div>
             <p className="text-gray-500 text-sm">
               Or <Link href="/policy-to-proof" className="text-purple-400 hover:text-purple-300 transition underline underline-offset-4">see the Policy-to-Proof evidence story →</Link>
@@ -759,7 +759,7 @@ const LandingPage = () => {
                 <li><Link href="/agent-authority-layer" className="hover:text-white transition">Authority & Accountability</Link></li>
                 <li><Link href="/partners/rails" className="hover:text-white transition">Rail Partners</Link></li>
                 <li><Link href="/pricing" className="hover:text-white transition">Pricing</Link></li>
-                <li><a href="https://cloud.satgate.io/cloud/login" target="_blank" rel="noopener noreferrer" className="hover:text-white transition">Cloud Dashboard</a></li>
+                <li><a href="https://cloud.satgate.io/cloud/login" target="_blank" rel="noopener noreferrer" className="hover:text-white transition">Cloud login</a></li>
               </ul>
             </div>
             <div>

--- a/satgate-landing/app/design-partners/page.tsx
+++ b/satgate-landing/app/design-partners/page.tsx
@@ -67,10 +67,10 @@ export default function DesignPartnersPage() {
   };
 
   const faqs = [
-    { q: 'How long is the program?', a: '90 days. After that, you keep everything you built and get priority access to GA pricing.' },
+    { q: 'How long is the program?', a: '90 days. At the end, both sides review the governed workload, policy outcomes, Evidence Pack use, support burden, and operating evidence before deciding whether to expand, contract, or stop.' },
     { q: 'Is it really free?', a: 'Yes. The design-partner path starts with an agreed staging lane and no credit card. You get visibility into agent traffic and help shape the authority, budget, revocation, and Evidence Pack workflows that matter in your environment.' },
     { q: 'Do I need to change my code?', a: 'Usually no. Most pilots start with a DNS, proxy, or MCP configuration change around one staging endpoint or tool. We verify the path together before expanding.' },
-    { q: 'Where does my data go?', a: 'Your infrastructure. In a Dedicated deployment the SatGate gateway runs in your environment, with custody boundaries agreed during onboarding. We never see your API payloads or sensitive data.' },
+    { q: 'Where does my data go?', a: 'The data path, environment, and custody boundaries are documented before activation. Most pilots start in staging or another bounded lane. Dedicated deployment is evaluated separately during enterprise scoping.' },
     { q: 'Is this for production traffic?', a: 'Design partners usually start in staging or a bounded pilot lane. The goal is to verify request-path policy, revocation, budgets, and Evidence Pack proof before expanding scope.' },
   ];
 
@@ -81,7 +81,7 @@ export default function DesignPartnersPage() {
     url: 'https://satgate.io/design-partners',
     description: 'Early access for teams shaping SatGate Policy-to-Proof capabilities for AI agent budget enforcement, MCP governance, API controls, paid-rail context, and Evidence Pack proof.',
     datePublished: '2026-04-27',
-    dateModified: '2026-05-02',
+    dateModified: '2026-08-15',
     isPartOf: { '@type': 'WebSite', name: 'SatGate', url: 'https://satgate.io' },
     about: [
       { '@type': 'Thing', name: 'AI agent economic governance' },
@@ -183,16 +183,16 @@ export default function DesignPartnersPage() {
       <header className="pt-32 pb-20 px-6">
         <div className="max-w-4xl mx-auto text-center">
           <div className="inline-flex items-center gap-2 px-3 py-1 rounded-full bg-cyan-900/30 border border-cyan-500/30 text-cyan-300 text-xs font-mono mb-6">
-            <Users size={12} /> Limited to 10 Companies
+            <Users size={12} /> Small cohort, one workload each
           </div>
           <h1 className="text-5xl md:text-6xl font-extrabold tracking-tight mb-6">
-            Shape the Future of{' '}
+            Test Bounded Authority on{' '}
             <span className="text-transparent bg-clip-text bg-gradient-to-r from-cyan-400 via-purple-400 to-pink-400">
-              AI Agent Governance
+              One Governed Workload
             </span>
           </h1>
           <p className="text-xl text-gray-400 mb-10 max-w-2xl mx-auto leading-relaxed">
-            We're working with <strong className="text-white">10 enterprises</strong> to shape SatGate's Policy-to-Proof layer for AI agent requests. Gate one MCP tool, REST API, or LLM endpoint in a bounded lane — see which agent had authority, what it spent, what was denied, and what Evidence Pack proof was preserved. Get direct engineering support and a product shaped by your needs.
+            SatGate is accepting a small design-partner cohort. Gate one MCP tool, REST API, or LLM endpoint in an agreed staging or bounded pilot lane. Measure which agent had authority, what it spent, what was denied, and what Evidence Pack proof was preserved before either side expands the scope.
           </p>
           <a href="#apply" className="inline-flex items-center gap-2 bg-white text-black px-8 py-3 rounded-lg font-bold hover:bg-gray-200 transition">
             Apply Now <ArrowRight size={18} />
@@ -273,7 +273,7 @@ export default function DesignPartnersPage() {
                 <h3 className="font-bold text-lg">15 Minutes / Week</h3>
               </div>
               <p className="text-gray-400 text-sm leading-relaxed">
-                A quick sync call or async feedback. Tell us what works, what doesn't, and what you need next.
+                A quick sync call or async feedback. Tell us what works, what does not, and what you need next.
               </p>
             </div>
 
@@ -285,7 +285,7 @@ export default function DesignPartnersPage() {
                 <h3 className="font-bold text-lg">Honest Feedback</h3>
               </div>
               <p className="text-gray-400 text-sm leading-relaxed">
-                We want the truth. If something's broken, tell us. If a feature is missing, we need to know. Your candor makes the product better.
+                We want the truth. If something is broken, tell us. If a feature is missing, we need to know. Your candor makes the product better.
               </p>
             </div>
           </div>
@@ -296,15 +296,15 @@ export default function DesignPartnersPage() {
       <section className="py-20 px-6 border-t border-gray-800">
         <div className="max-w-4xl mx-auto">
           <h2 className="text-3xl font-bold text-center mb-4">How It Works</h2>
-          <p className="text-gray-500 text-center mb-12">From application to insights in under 3 weeks.</p>
+          <p className="text-gray-500 text-center mb-12">A staged path from application to one bounded, instrumented workload.</p>
 
           <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
             {[
               {
                 step: '1',
                 title: 'Sign Up',
-                time: '5 minutes',
-                desc: 'Fill out the form below. We review and respond within 24 hours.',
+                time: 'About 2 minutes',
+                desc: 'Fill out the form below. We review it and reply with fit questions or a proposed pilot scope.',
                 color: 'purple',
                 icon: <Send size={20} />,
               },
@@ -350,7 +350,7 @@ export default function DesignPartnersPage() {
       <section id="apply" className="py-20 px-6 border-t border-gray-800 bg-gradient-to-b from-purple-950/10 to-black">
         <div className="max-w-2xl mx-auto">
           <h2 className="text-3xl font-bold text-center mb-4">Apply to the Design Partner Program</h2>
-          <p className="text-gray-500 text-center mb-10">Takes about 2 minutes. We'll respond within 24 hours.</p>
+          <p className="text-gray-500 text-center mb-10">Takes about 2 minutes. We review each application and reply with fit questions or a proposed pilot scope.</p>
 
           <form onSubmit={handleSubmit} className="space-y-6">
             {/* Name */}
@@ -443,7 +443,7 @@ export default function DesignPartnersPage() {
             {/* Challenge */}
             <div>
               <label className="block text-sm font-medium text-gray-300 mb-2">
-                What's your biggest challenge with AI agent management?
+                What is your biggest challenge with AI agent management?
               </label>
               <textarea
                 value={formData.challenge}
@@ -457,7 +457,7 @@ export default function DesignPartnersPage() {
             {/* Submit */}
             {submitStatus === 'sent' ? (
               <div className="w-full py-4 bg-green-900/30 border border-green-700/50 text-green-400 rounded-xl font-bold text-lg flex items-center justify-center gap-2">
-                ✓ Application received! We&apos;ll be in touch within 24 hours.
+                ✓ Application received. We will review it and follow up by email.
               </div>
             ) : (
               <button
@@ -515,7 +515,7 @@ export default function DesignPartnersPage() {
         <div className="max-w-3xl mx-auto text-center">
           <h2 className="text-3xl font-bold mb-4">Still have questions?</h2>
           <p className="text-gray-400 mb-8">
-            Reach out directly. We'd love to chat about your use case.
+            Reach out directly. We would be glad to discuss your use case.
           </p>
           <div className="flex flex-col sm:flex-row gap-4 justify-center">
             <a href="mailto:contact@satgate.io" className="border border-gray-700 px-8 py-3 rounded-lg font-bold hover:border-gray-500 transition flex items-center justify-center gap-2">

--- a/satgate-landing/app/pricing/page.tsx
+++ b/satgate-landing/app/pricing/page.tsx
@@ -7,32 +7,28 @@ import Image from 'next/image';
 
 const faqs = [
   {
-    q: 'What counts as a request?',
-    a: 'Every API call proxied through the gateway in Control or paid-rail admission mode counts as a metered request. Observe-mode requests are always free and unlimited — no catches.',
+    q: 'What access is available today?',
+    a: 'SatGate is accepting design partners for one bounded staging endpoint, API route, or MCP tool. The public demos and Evidence Pack examples remain available without an account.',
   },
   {
-    q: 'How does the Free → Pro upgrade work?',
-    a: 'Start with Free to see what your agents are spending. When you\'re ready to enforce budgets and set hard stops, upgrade to Pro in one click. No data migration — your dashboards carry over.',
+    q: 'Does a pilot require code changes?',
+    a: 'Most pilots start with a DNS, proxy, or MCP configuration change around one bounded endpoint or tool. We verify that path before expanding it.',
   },
   {
-    q: 'Can I switch plans?',
-    a: 'Yes, upgrade or downgrade anytime. Changes take effect immediately. No lock-in.',
+    q: 'Is the hosted production service generally available?',
+    a: 'No. General self-serve production access is not the current offer. Design partners start in an agreed staging or bounded pilot lane while SatGate verifies the buyer journey and operating controls.',
   },
   {
-    q: 'Do you offer annual billing?',
-    a: 'Yes, save 20% with annual billing. Contact us for details.',
+    q: 'What does the design-partner pilot cost?',
+    a: 'The initial 90-day design-partner pilot has no charge or credit-card requirement. Any later commercial contract depends on the accepted scope, measured usage, and operating requirements.',
   },
   {
-    q: 'What happens if I exceed my request limit?',
-    a: 'Overage is billed at $0.10 per 1,000 requests. No surprise charges — you\'ll get alerts at 80% and 90% so you can adjust budgets before you hit the limit.',
+    q: 'What happens after the pilot?',
+    a: 'We review the governed workload, policy outcomes, Evidence Pack use, support burden, and operating evidence together. Both sides then decide whether to expand, contract, or stop.',
   },
   {
-    q: 'Is there a free trial of Pro?',
-    a: 'Every account starts with a 14-day Pro trial. No credit card required. After the trial, you drop to Free (Observe) — you keep Observe-mode visibility.',
-  },
-  {
-    q: 'Do you support Dedicated deployment?',
-    a: 'Yes, by contract on the Enterprise plan. Deployment and custody boundaries are agreed during onboarding for each Dedicated environment.',
+    q: 'Is Dedicated deployment available?',
+    a: 'Dedicated deployment is evaluated during enterprise scoping. It is not currently advertised as a generally available tier or SLA-backed service.',
   },
 ];
 
@@ -45,9 +41,9 @@ const PricingPage = () => {
     '@type': 'WebPage',
     name: 'SatGate Pricing',
     url: 'https://satgate.io/pricing',
-    description: 'Pricing for bounded agent authority: Observe audits, request-path budget enforcement, MCP tool controls, receipts, and Evidence Pack proof.',
+    description: 'Current SatGate access: public proof demos, bounded design-partner pilots, and post-pilot enterprise scoping.',
     datePublished: '2026-04-27',
-    dateModified: '2026-05-03',
+    dateModified: '2026-08-15',
     isPartOf: { '@type': 'WebSite', name: 'SatGate', url: 'https://satgate.io' },
     about: [
       { '@type': 'Thing', name: 'Agent Authority & Accountability Layer' },
@@ -82,34 +78,17 @@ const PricingPage = () => {
     '@type': 'OfferCatalog',
     name: 'SatGate Pricing',
     url: 'https://satgate.io/pricing',
-    description: 'Pricing for bounded agent authority: Observe audits, request-path budget enforcement, MCP tool controls, receipts, and Evidence Pack proof.',
-    dateModified: '2026-05-03',
+    description: 'Current SatGate access: public proof demos, bounded design-partner pilots, and post-pilot enterprise scoping.',
+    dateModified: '2026-08-15',
     itemListElement: [
       {
         '@type': 'Offer',
-        name: 'Builder / Observe',
+        name: 'SatGate Design Partner Pilot',
         price: '0',
         priceCurrency: 'USD',
-        description: 'Free Observe-mode receipt capture for AI agent API traffic, cost attribution, and Evidence Pack-ready decision proof.',
-        availability: 'https://schema.org/InStock',
-        itemOffered: { '@type': 'SoftwareApplication', name: 'SatGate Observe', applicationCategory: 'DeveloperApplication' },
-      },
-      {
-        '@type': 'Offer',
-        name: 'Pro / Control',
-        price: '99',
-        priceCurrency: 'USD',
-        description: 'Request-path budget enforcement, per-agent caps, MCP tool controls, alerts, revocation, and signed decision receipts for AI agent spend.',
-        availability: 'https://schema.org/InStock',
-        itemOffered: { '@type': 'SoftwareApplication', name: 'SatGate Control', applicationCategory: 'DeveloperApplication' },
-      },
-      {
-        '@type': 'Offer',
-        name: 'Enterprise',
-        priceCurrency: 'USD',
-        description: 'Enterprise governance, contract-triggered Dedicated deployment, advanced controls, and paid-rail admission where supported paid calls return receipts and feed Evidence Packs.',
-        availability: 'https://schema.org/InStock',
-        itemOffered: { '@type': 'SoftwareApplication', name: 'SatGate Enterprise', applicationCategory: 'DeveloperApplication' },
+        description: 'No-charge 90-day pilot for one agreed staging endpoint, API route, or MCP tool, with instrumentation and Evidence Pack review.',
+        availability: 'https://schema.org/LimitedAvailability',
+        itemOffered: { '@type': 'Service', name: 'SatGate Design Partner Pilot', serviceType: 'AI agent governance pilot' },
       },
     ],
   };
@@ -134,7 +113,7 @@ const PricingPage = () => {
             <Link href="/pricing" className="text-white transition">Pricing</Link>
             <Link href="/roi-calculator" className="hover:text-white transition">ROI Calculator</Link>
             <a href="https://cloud.satgate.io/docs" target="_blank" rel="noopener noreferrer" className="hover:text-white transition">Docs</a>
-            <a href="https://cloud.satgate.io/cloud/login" target="_blank" rel="noopener noreferrer" className="hover:text-white transition">Cloud</a>
+            <a href="https://cloud.satgate.io/cloud/login" target="_blank" rel="noopener noreferrer" className="hover:text-white transition">Cloud login</a>
           </div>
 
           {/* Mobile menu button */}
@@ -159,7 +138,7 @@ const PricingPage = () => {
             <Link href="/pricing" onClick={() => setMobileMenuOpen(false)} className="block text-white hover:bg-gray-800/50 transition py-3 px-4 rounded-lg">Pricing</Link>
             <Link href="/roi-calculator" onClick={() => setMobileMenuOpen(false)} className="block text-gray-400 hover:text-white hover:bg-gray-800/50 transition py-3 px-4 rounded-lg">ROI Calculator</Link>
             <a href="https://cloud.satgate.io/docs" target="_blank" rel="noopener noreferrer" onClick={() => setMobileMenuOpen(false)} className="block text-gray-400 hover:text-white hover:bg-gray-800/50 transition py-3 px-4 rounded-lg">Docs</a>
-            <a href="https://cloud.satgate.io/cloud/login" target="_blank" rel="noopener noreferrer" onClick={() => setMobileMenuOpen(false)} className="block text-gray-400 hover:text-white hover:bg-gray-800/50 transition py-3 px-4 rounded-lg">Cloud</a>
+            <a href="https://cloud.satgate.io/cloud/login" target="_blank" rel="noopener noreferrer" onClick={() => setMobileMenuOpen(false)} className="block text-gray-400 hover:text-white hover:bg-gray-800/50 transition py-3 px-4 rounded-lg">Cloud login</a>
           </div>
         </div>
       </nav>
@@ -168,129 +147,118 @@ const PricingPage = () => {
       <header className="pt-32 pb-10 px-6 text-center">
         <div className="max-w-4xl mx-auto">
           <h1 className="text-5xl md:text-6xl font-extrabold tracking-tight mb-6">
-            Give Agents{' '}
+            Start with a{' '}
             <span className="text-transparent bg-clip-text bg-gradient-to-r from-purple-400 via-pink-400 to-cyan-400">
-              Bounded Authority.
+              Bounded Pilot.
             </span>
           </h1>
-          <p className="text-xl text-gray-400 max-w-2xl mx-auto leading-relaxed">
-            SatGate prices the controls humans and platforms need before agents reach protected APIs: visibility, hard budget stops, receipts, and Evidence Pack proof.
+          <p className="text-xl text-gray-400 max-w-3xl mx-auto leading-relaxed">
+            Public demos show the proof model. Current hosted access is a 90-day design-partner pilot for one agreed staging endpoint, API route, or MCP tool. General self-serve production access is not the current offer.
           </p>
         </div>
       </header>
 
-      {/* Observe → Control → Prove Journey */}
+      {/* Observe, Control, Admit, Prove */}
       <section className="pb-10 px-6">
-        <div className="max-w-3xl mx-auto">
-          <div className="flex flex-col md:flex-row items-center justify-center gap-3 md:gap-4">
-            <div className="flex items-center gap-2 px-4 py-2 rounded-lg bg-cyan-900/20 border border-cyan-800/30">
-              <span className="text-cyan-400 font-bold text-sm">👁 Observe</span>
-              <span className="text-gray-500 text-xs">See the spend</span>
+        <div className="max-w-5xl mx-auto">
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-3">
+            <div className="flex items-center gap-2 px-4 py-3 rounded-lg bg-cyan-900/20 border border-cyan-800/30">
+              <span className="text-cyan-400 font-bold text-sm">Observe</span>
+              <span className="text-gray-500 text-xs">Project impact</span>
             </div>
-            <span className="text-gray-600 text-xl hidden md:block">→</span>
-            <span className="text-gray-600 md:hidden">↓</span>
-            <div className="flex items-center gap-2 px-4 py-2 rounded-lg bg-purple-900/20 border border-purple-800/30">
-              <span className="text-purple-400 font-bold text-sm">🛡 Control</span>
-              <span className="text-gray-500 text-xs">Stop the bleed</span>
+            <div className="flex items-center gap-2 px-4 py-3 rounded-lg bg-purple-900/20 border border-purple-800/30">
+              <span className="text-purple-400 font-bold text-sm">Control</span>
+              <span className="text-gray-500 text-xs">Enforce owned-agent authority</span>
             </div>
-            <span className="text-gray-600 text-xl hidden md:block">→</span>
-            <span className="text-gray-600 md:hidden">↓</span>
-            <div className="flex items-center gap-2 px-4 py-2 rounded-lg bg-yellow-900/20 border border-yellow-800/30">
-              <span className="text-yellow-400 font-bold text-sm">⚡ Prove</span>
-              <span className="text-gray-500 text-xs">Export receipts</span>
+            <div className="flex items-center gap-2 px-4 py-3 rounded-lg bg-yellow-900/20 border border-yellow-800/30">
+              <span className="text-yellow-400 font-bold text-sm">Admit</span>
+              <span className="text-gray-500 text-xs">Govern external-agent access</span>
+            </div>
+            <div className="flex items-center gap-2 px-4 py-3 rounded-lg bg-green-900/20 border border-green-800/30">
+              <span className="text-green-400 font-bold text-sm">Prove</span>
+              <span className="text-gray-500 text-xs">Verify the evidence</span>
             </div>
           </div>
         </div>
       </section>
 
-      {/* Pricing Cards */}
+      {/* Current access paths */}
       <section className="pb-20 px-6">
         <div className="max-w-5xl mx-auto grid grid-cols-1 md:grid-cols-3 gap-6 items-stretch">
-          {/* Free (Observe) */}
+          {/* Public proof */}
           <div className="p-6 rounded-xl bg-gray-900 border border-gray-800 hover:border-gray-600 transition flex flex-col">
             <div className="mb-6">
-              <h3 className="text-lg font-bold text-cyan-400 mb-1">Builder</h3>
-              <p className="text-gray-500 text-sm">Get out of the dark. See every cent in real-time.</p>
+              <h3 className="text-lg font-bold text-cyan-400 mb-1">Public proof</h3>
+              <p className="text-gray-500 text-sm">Inspect the model before you discuss a pilot.</p>
             </div>
             <div className="mb-6">
               <span className="text-4xl font-extrabold text-white">$0</span>
-              <span className="text-gray-500 text-sm">/month forever</span>
+              <span className="text-gray-500 text-sm"> / no account</span>
             </div>
             <ul className="space-y-3 text-sm text-gray-400 mb-8 flex-1">
-              <li className="flex items-start gap-2"><Check size={16} className="text-cyan-400 mt-0.5 shrink-0" /><span><b className="text-gray-200">Unlimited</b> observe-mode requests</span></li>
-              <li className="flex items-start gap-2"><Check size={16} className="text-cyan-400 mt-0.5 shrink-0" />Real-time receipt dashboard</li>
-              <li className="flex items-start gap-2"><Check size={16} className="text-cyan-400 mt-0.5 shrink-0" />Cost attribution by agent &amp; team</li>
-              <li className="flex items-start gap-2"><Check size={16} className="text-cyan-400 mt-0.5 shrink-0" />Up to 3 routes</li>
-              <li className="flex items-start gap-2"><Check size={16} className="text-cyan-400 mt-0.5 shrink-0" />Community support</li>
+              <li className="flex items-start gap-2"><Check size={16} className="text-cyan-400 mt-0.5 shrink-0" />Deterministic allow and deny example</li>
+              <li className="flex items-start gap-2"><Check size={16} className="text-cyan-400 mt-0.5 shrink-0" />Evidence Pack example and verifier</li>
+              <li className="flex items-start gap-2"><Check size={16} className="text-cyan-400 mt-0.5 shrink-0" />Public calculators and policy templates</li>
+              <li className="flex items-start gap-2"><Check size={16} className="text-cyan-400 mt-0.5 shrink-0" />Proves the demo path only, not hosted production readiness</li>
             </ul>
-            <a
-              href="https://cloud.satgate.io/cloud/login"
-              target="_blank"
-              rel="noopener noreferrer"
+            <Link
+              href="/sandbox#golden-path"
               className="block text-center py-3 rounded-lg border border-gray-700 font-bold hover:border-gray-500 hover:bg-gray-800 transition"
             >
-              Start Observing — Free →
-            </a>
+              Run the Public Proof →
+            </Link>
           </div>
 
-          {/* Pro (Control + paid-rail admission) — highlighted */}
+          {/* Design partner */}
           <div className="p-6 rounded-xl bg-gray-900 border-2 border-purple-500/60 hover:border-purple-400 transition flex flex-col relative">
             <div className="absolute -top-3 left-1/2 -translate-x-1/2 px-3 py-0.5 rounded-full bg-purple-600 text-white text-xs font-bold">
-              MOST POPULAR
+              CURRENT ACCESS
             </div>
             <div className="mb-6">
-              <h3 className="text-lg font-bold text-purple-400 mb-1">Professional</h3>
-              <p className="text-gray-500 text-sm">The only security tool that pays for itself.</p>
+              <h3 className="text-lg font-bold text-purple-400 mb-1">Design partner</h3>
+              <p className="text-gray-500 text-sm">One governed workload, measured together.</p>
             </div>
             <div className="mb-6">
-              <span className="text-4xl font-extrabold text-white">$99</span>
-              <span className="text-gray-500 text-sm">/month</span>
+              <span className="text-4xl font-extrabold text-white">90 days</span>
+              <span className="text-gray-500 text-sm"> / no charge</span>
             </div>
-            <p className="text-xs text-gray-500 mb-4 -mt-4">Everything in Free, plus:</p>
             <ul className="space-y-3 text-sm text-gray-400 mb-8 flex-1">
-              <li className="flex items-start gap-2"><Check size={16} className="text-purple-400 mt-0.5 shrink-0" /><span><b className="text-gray-200">Budget enforcement</b> — hard stops per agent, team, or API</span></li>
-              <li className="flex items-start gap-2"><Check size={16} className="text-purple-400 mt-0.5 shrink-0" />Real-time alerts at 80%, 90%, and limit</li>
-              <li className="flex items-start gap-2"><Check size={16} className="text-purple-400 mt-0.5 shrink-0" />1M controlled or paid-rail requests included</li>
-              <li className="flex items-start gap-2"><Check size={16} className="text-purple-400 mt-0.5 shrink-0" />Then $0.10 per 1K overage</li>
-              <li className="flex items-start gap-2"><Check size={16} className="text-purple-400 mt-0.5 shrink-0" />Unlimited routes</li>
-              <li className="flex items-start gap-2"><Check size={16} className="text-purple-400 mt-0.5 shrink-0" />CFO-ready receipt and chargeback exports</li>
-              <li className="flex items-start gap-2"><Check size={16} className="text-purple-400 mt-0.5 shrink-0" />Evidence Pack compliance exports</li>
-              <li className="flex items-start gap-2"><Check size={16} className="text-purple-400 mt-0.5 shrink-0" />Email support</li>
+              <li className="flex items-start gap-2"><Check size={16} className="text-purple-400 mt-0.5 shrink-0" />One agreed staging endpoint, API route, or MCP tool</li>
+              <li className="flex items-start gap-2"><Check size={16} className="text-purple-400 mt-0.5 shrink-0" />A declared HTTP or MCP primary lane</li>
+              <li className="flex items-start gap-2"><Check size={16} className="text-purple-400 mt-0.5 shrink-0" />Observe, Control, and Admit only where the pilot scope supports them</li>
+              <li className="flex items-start gap-2"><Check size={16} className="text-purple-400 mt-0.5 shrink-0" />Instrumentation, weekly review, and Evidence Pack use</li>
+              <li className="flex items-start gap-2"><Check size={16} className="text-purple-400 mt-0.5 shrink-0" />Expansion only after both sides review the evidence</li>
             </ul>
-            <a
-              href="https://cloud.satgate.io/cloud/login"
-              target="_blank"
-              rel="noopener noreferrer"
+            <Link
+              href="/design-partners"
               className="block text-center py-3 rounded-lg bg-gradient-to-r from-purple-600 to-cyan-600 text-white font-bold hover:opacity-90 transition shadow-lg shadow-purple-500/20"
             >
-              Start Pro — 14 Days Free →
-            </a>
+              Apply for a Pilot →
+            </Link>
           </div>
 
-          {/* Enterprise */}
+          {/* Post-pilot enterprise */}
           <div className="p-6 rounded-xl bg-gray-900 border border-gray-800 hover:border-gray-600 transition flex flex-col">
             <div className="mb-6">
               <h3 className="text-lg font-bold text-green-400 mb-1">Enterprise</h3>
-              <p className="text-gray-500 text-sm">Turn your infrastructure into a marketplace.</p>
+              <p className="text-gray-500 text-sm">Commercial scope follows accepted pilot evidence.</p>
             </div>
             <div className="mb-6">
               <span className="text-4xl font-extrabold text-white">Custom</span>
+              <span className="text-gray-500 text-sm"> / after pilot</span>
             </div>
-            <p className="text-xs text-gray-500 mb-4 -mt-4">Everything in Pro, plus:</p>
             <ul className="space-y-3 text-sm text-gray-400 mb-8 flex-1">
-              <li className="flex items-start gap-2"><Check size={16} className="text-green-400 mt-0.5 shrink-0" /><span><b className="text-gray-200">Unlimited</b> requests — no metering caps</span></li>
-              <li className="flex items-start gap-2"><Check size={16} className="text-green-400 mt-0.5 shrink-0" />Contract-triggered Dedicated deployment</li>
-              <li className="flex items-start gap-2"><Check size={16} className="text-green-400 mt-0.5 shrink-0" />SSO/SCIM + RBAC</li>
-              <li className="flex items-start gap-2"><Check size={16} className="text-green-400 mt-0.5 shrink-0" />Full Evidence Pack &amp; retention policies</li>
-              <li className="flex items-start gap-2"><Check size={16} className="text-green-400 mt-0.5 shrink-0" />SOC 2 compliance package</li>
-              <li className="flex items-start gap-2"><Check size={16} className="text-green-400 mt-0.5 shrink-0" />Dedicated CSM + SLA</li>
-              <li className="flex items-start gap-2"><Check size={16} className="text-green-400 mt-0.5 shrink-0" />Custom integrations &amp; onboarding</li>
+              <li className="flex items-start gap-2"><Check size={16} className="text-green-400 mt-0.5 shrink-0" />Production scope requires a separate readiness decision</li>
+              <li className="flex items-start gap-2"><Check size={16} className="text-green-400 mt-0.5 shrink-0" />Environment and custody boundaries are agreed in writing</li>
+              <li className="flex items-start gap-2"><Check size={16} className="text-green-400 mt-0.5 shrink-0" />Usage, support, and retention are measured before pricing</li>
+              <li className="flex items-start gap-2"><Check size={16} className="text-green-400 mt-0.5 shrink-0" />Dedicated, SLA, and compliance support remain subject to readiness and contract scope</li>
+              <li className="flex items-start gap-2"><Check size={16} className="text-green-400 mt-0.5 shrink-0" />No automatic expansion from pilot to production</li>
             </ul>
             <a
               href="mailto:contact@satgate.io"
               className="block text-center py-3 rounded-lg border border-gray-700 font-bold hover:border-gray-500 hover:bg-gray-800 transition"
             >
-              Talk to Us →
+              Discuss Enterprise Scope →
             </a>
           </div>
         </div>
@@ -405,19 +373,17 @@ const PricingPage = () => {
       {/* Bottom CTA */}
       <section className="py-20 px-6 border-t border-gray-800">
         <div className="max-w-4xl mx-auto text-center">
-          <h2 className="text-2xl font-bold mb-3">If your agents aren&apos;t governed, they&apos;re a liability.</h2>
+          <h2 className="text-2xl font-bold mb-3">Start with one governed workload.</h2>
           <p className="text-lg text-gray-400 mb-8 max-w-xl mx-auto">
-            With SatGate, they&apos;re an asset. <Link href="/roi-calculator" className="text-purple-400 hover:text-purple-300 underline underline-offset-2">Calculate your savings →</Link>
+            Pick one staging endpoint or MCP tool, define the authority boundary, and measure the result before expanding.
           </p>
           <div className="flex flex-col sm:flex-row items-center justify-center gap-4">
-            <a
-              href="https://cloud.satgate.io/cloud/login"
-              target="_blank"
-              rel="noopener noreferrer"
+            <Link
+              href="/design-partners"
               className="inline-block bg-white text-black px-10 py-4 rounded-full font-bold text-lg hover:bg-gray-200 transition"
             >
-              Start Free →
-            </a>
+              Apply for a Pilot →
+            </Link>
             <a
               href="mailto:contact@satgate.io"
               className="inline-block border border-gray-700 text-gray-300 px-10 py-4 rounded-full font-bold text-lg hover:border-gray-500 hover:bg-gray-800 transition"
@@ -448,7 +414,7 @@ const PricingPage = () => {
                 <li><Link href="/govern" className="hover:text-white transition">Enterprise</Link></li>
                 <li><Link href="/design-partners" className="hover:text-white transition">Design Partners</Link></li>
                 <li><Link href="/pricing" className="hover:text-white transition">Pricing</Link></li>
-                <li><a href="https://cloud.satgate.io/cloud/login" target="_blank" rel="noopener noreferrer" className="hover:text-white transition">Cloud Dashboard</a></li>
+                <li><a href="https://cloud.satgate.io/cloud/login" target="_blank" rel="noopener noreferrer" className="hover:text-white transition">Cloud login</a></li>
               </ul>
             </div>
             <div>

--- a/satgate-landing/scripts/check_proof_spine.py
+++ b/satgate-landing/scripts/check_proof_spine.py
@@ -28,9 +28,8 @@ REQUIRED_PHRASES = {
         "Export Evidence Pack",
     ],
     "app/pricing/page.tsx": [
-        "receipt capture",
-        "Real-time receipt dashboard",
-        "Evidence Pack compliance exports",
+        "Evidence Pack example and verifier",
+        "Instrumentation, weekly review, and Evidence Pack use",
         "Signed receipts + Evidence Pack export",
     ],
     "app/pay/page.tsx": [
@@ -89,7 +88,17 @@ REQUIRED_PHRASES = {
 
 FORBIDDEN_PUBLIC_PHRASES = {
     "app/components/HomeClient.tsx": ["Metered:    $847 usage", "Audit: who, when, diff"],
-    "app/pricing/page.tsx": ["Real-time usage dashboard", "Live economic telemetry"],
+    "app/pricing/page.tsx": [
+        "Real-time usage dashboard",
+        "Live economic telemetry",
+        "Start Free",
+        "Start Pro",
+        "Unlimited observe-mode requests",
+        "$0.10 per 1K overage",
+        "SOC 2 compliance package",
+        "Dedicated CSM + SLA",
+        "14 Days Free",
+    ],
     "app/pay/page.tsx": ["Zero Invoices. Zero Contracts. Zero Wait."],
     "app/dashboard/page.tsx": ["Dashboard telemetry explains decisions", "live governance telemetry"],
     "app/policy-to-proof/page.tsx": ["revocation event", "spend event", "matching receipts preserve the event log"],


### PR DESCRIPTION
## Why

Public satgate.io still reads like general self-serve production (Start Free / Start Pro, unlimited observe, SOC 2 package, dedicated CSM, sub-ms verification, no-code drop-in). That is ahead of current readiness. Isolated public-site copy only. Dean's Enterprise / parity lane is untouched.

## What changed

- Homepage: drop "no code changes required" and unqualified sub-ms claim. Route the primary CTA to the design-partner / pilot path. Relabel Cloud as login, not a free-start funnel.
- Pricing: remove self-serve Start Free / Start Pro, overage, SOC 2 package, dedicated CSM + SLA, and 14-day-free copy. Keep Evidence Pack / signed-receipt language that matches what we can actually show.
- Design partners: one bounded workload, 90-day review, documented data path. Dedicated is scoped later, not implied as the default.
- `check_proof_spine.py`: require the new pricing phrases and forbid the old self-serve claims.

## Out of scope

- No merge.
- No production deploy.
- No Dean Enterprise repo, worktree, mission, or deploy-path changes.

## Test

- `python3 satgate-landing/scripts/check_proof_spine.py` → `proof-spine guard ok`
- Head SHA: `9fd3e3d0de6e87c75a3408a590371f3ac56ed1d3` on `d28bb085a7f15972c73bdddba3b0bd4091744d93`
