### PR TITLE
Rewrite OpenAI budget post title for per-team CTR

### DIFF
--- a/satgate-landing/app/blog/how-to-add-budget-limits-to-openai-api-calls/page.tsx
+++ b/satgate-landing/app/blog/how-to-add-budget-limits-to-openai-api-calls/page.tsx
@@ -3,22 +3,22 @@ import RoiCta from '../../components/RoiCta';
 import { ArrowLeft, Calendar, Clock } from 'lucide-react';
 
 export const metadata = {
-  title: "OpenAI API Budget Limits: Stop Runaway Spend Before Calls",
-  description: "Set OpenAI API budget limits by agent, team, or workflow. Stop runaway GPT spend before the call runs and keep Evidence Pack proof.",
+  title: "How to Set OpenAI API Budget Limits Per Team",
+  description: "Set OpenAI API budget limits per team or project before GPT calls run. Stop overspend at the request path and keep Evidence Pack proof.",
   alternates: { canonical: 'https://satgate.io/blog/how-to-add-budget-limits-to-openai-api-calls' },
   keywords: ['OpenAI API budget limits', 'OpenAI cost control', 'API gateway OpenAI', 'GPT-4 spending limits', 'OpenAI API costs', 'prevent OpenAI overspending', 'hard cap OpenAI spend', 'per-agent OpenAI budget'],
   openGraph: {
-    title: 'OpenAI API Budget Limits: Stop Runaway Spend Before Calls',
-    description: 'Set OpenAI API budget limits by agent, team, or workflow. Stop runaway GPT spend before the call runs and keep Evidence Pack proof.',
+    title: 'How to Set OpenAI API Budget Limits Per Team',
+    description: 'Set OpenAI API budget limits per team or project before GPT calls run. Stop overspend at the request path and keep Evidence Pack proof.',
     url: 'https://satgate.io/blog/how-to-add-budget-limits-to-openai-api-calls',
     type: 'article',
     publishedTime: '2026-04-07T00:00:00Z',
-    modifiedTime: '2026-08-12T00:00:00Z',
+    modifiedTime: '2026-08-31T00:00:00Z',
   },
   twitter: {
     card: 'summary_large_image',
-    title: 'OpenAI API Budget Limits: Stop Runaway Spend Before Calls',
-    description: 'Set per-agent, team, and workflow budgets before GPT calls execute, then prove each allow, deny, or downgrade decision.',
+    title: 'How to Set OpenAI API Budget Limits Per Team',
+    description: 'Set per-team and per-project OpenAI API budgets before GPT calls execute, then prove each allow, deny, or downgrade decision.',
   },
 };
 
@@ -26,12 +26,12 @@ export default function HowToAddBudgetLimitsToOpenAIAPICallsPage() {
   const articleJsonLd = {
     '@context': 'https://schema.org',
     '@type': 'TechArticle',
-    headline: 'OpenAI API Budget Limits: Stop Runaway Spend Before Calls',
+    headline: 'How to Set OpenAI API Budget Limits Per Team',
     description: metadata.description,
     author: { '@type': 'Organization', name: 'SatGate' },
     publisher: { '@type': 'Organization', name: 'SatGate', url: 'https://satgate.io' },
     datePublished: '2026-04-07',
-    dateModified: '2026-08-12',
+    dateModified: '2026-08-31',
     mainEntityOfPage: 'https://satgate.io/blog/how-to-add-budget-limits-to-openai-api-calls',
     about: [
       { '@type': 'Thing', name: 'OpenAI API budget limits' },
@@ -114,7 +114,7 @@ export default function HowToAddBudgetLimitsToOpenAIAPICallsPage() {
             <span className="px-2 py-1 rounded-full bg-purple-900/30 border border-purple-500/30 text-purple-300 text-xs font-mono">API Gateway</span>
           </div>
           
-          <h1 className="text-4xl font-bold mb-4">How to Add OpenAI API Budget Limits Before Calls Run</h1>
+          <h1 className="text-4xl font-bold mb-4">How to Set OpenAI API Budget Limits Per Team</h1>
           <div className="mb-6 rounded-2xl border border-green-900/60 bg-green-950/20 p-5">
             <p className="mb-2 text-sm font-semibold uppercase tracking-[0.2em] text-green-300">Direct answer</p>
             <p className="text-gray-300">OpenAI usage limits are account-level. Request-path controls enforce per-agent, per-team, and per-workflow budgets before a GPT call reaches OpenAI, then Prove each allow, deny, or downgrade with an Evidence Pack receipt.</p>

--- a/satgate-landing/app/blog/page.tsx
+++ b/satgate-landing/app/blog/page.tsx
@@ -68,8 +68,8 @@ const posts = [
   },
   {
     slug: 'how-to-add-budget-limits-to-openai-api-calls',
-    title: 'OpenAI API Budget Limits: Stop Runaway Spend Before Calls',
-    description: 'Learn how to enforce OpenAI API budget limits before each request, then use the ROI calculator to quantify avoided agent-loop spend.',
+    title: 'How to Set OpenAI API Budget Limits Per Team',
+    description: 'Set OpenAI API budget limits per team or project before GPT calls run. Stop overspend at the request path and keep Evidence Pack proof.',
     date: '2026-04-07',
     readTime: '8 min read',
     author: 'Matt Dean',

--- a/satgate-landing/app/sitemap.ts
+++ b/satgate-landing/app/sitemap.ts
@@ -123,7 +123,7 @@ const blogRoutes: SitemapEntry[] = [
   { path: '/blog/l402-protocol-explained', lastModified: '2026-05-04', changeFrequency: 'monthly', priority: 0.8 },
   { path: '/blog/zero-trust-for-ai-agents', lastModified: '2026-05-04', changeFrequency: 'monthly', priority: 0.8 },
   { path: '/blog/start-at-1-credit-economic-policy', lastModified: '2026-05-04', changeFrequency: 'monthly', priority: 0.8 },
-  { path: '/blog/how-to-add-budget-limits-to-openai-api-calls', lastModified: '2026-08-12', changeFrequency: 'monthly', priority: 0.8 },
+  { path: '/blog/how-to-add-budget-limits-to-openai-api-calls', lastModified: '2026-08-31', changeFrequency: 'monthly', priority: 0.8 },
   { path: '/blog/cursor-mcp-proxy-setup-guide', lastModified: '2026-05-04', changeFrequency: 'monthly', priority: 0.8 },
 ];
 

--- a/satgate-landing/scripts/seo_machine.py
+++ b/satgate-landing/scripts/seo_machine.py
@@ -28,8 +28,8 @@ SITEMAP_PATH_RE = re.compile(r"path:\s*'([^']*)'")
 
 RECOMMENDED_META = {
  '/blog/how-to-add-budget-limits-to-openai-api-calls': {
-   'title': 'OpenAI API Budget Limits: Stop Runaway Spend Before Calls',
-   'description': 'Set OpenAI API budget limits by agent, team, or workflow. Stop runaway GPT spend before the call runs and keep Evidence Pack proof.'},
+   'title': 'How to Set OpenAI API Budget Limits Per Team',
+   'description': 'Set OpenAI API budget limits per team or project before GPT calls run. Stop overspend at the request path and keep Evidence Pack proof.'},
  '/blog/llm-cost-management': {
    'title': 'LLM Cost Management: Control AI Spend Before It Happens',
    'description': 'A practical guide to LLM cost management using authority before execution, budget controls, and Evidence Pack receipts for AI agents.'},


### PR DESCRIPTION
## Summary

Isolated SEO slice only. Does not touch Dean, robots, login, pricing, or compare.

- Rewrite title/meta/H1 on `/blog/how-to-add-budget-limits-to-openai-api-calls` for the GSC CTR leak (2,519 impressions / 4 clicks / 0.16% CTR in the finalized 28-day window ending 2026-08-28).
- Bump sitemap `lastmod` for that URL to `2026-08-31`.
- Align the blog index card and `seo_machine.py` recommended meta with the live title.

Does **not** revive stale PR #139. That PR also changes `/govern` and `robots.txt`.

Prior merged slice #164 (`Stop Runaway Spend Before Calls`) is live; Google last crawled 2026-08-16 and CTR is still 0.16%. Visible query intent is per-team / per-project spending limits.

## Title

Before: `OpenAI API Budget Limits: Stop Runaway Spend Before Calls`
After: `How to Set OpenAI API Budget Limits Per Team`

## Verification

- `python3 scripts/seo_machine.py --check` (0 audit issue groups)
- Title 44 chars, description 135 chars (both in the 35-70 / 90-160 gates)
- Reports under `satgate-landing/seo/reports/` not committed

## Deploy note

Search Console sitemap was resubmitted separately (PUT 204). The new title is not on satgate.io until this PR is merged and Vercel deploys. Do not merge unless Wayne names this PR.