### PR TITLE
seo: clarify HTTP 402 meaning and API search snippet

### DIFF
--- a/satgate-landing/app/blog/http-402-payment-required-use-cases/page.tsx
+++ b/satgate-landing/app/blog/http-402-payment-required-use-cases/page.tsx
@@ -2,21 +2,21 @@ import Link from 'next/link';
 import { ArrowLeft, Calendar, Clock } from 'lucide-react';
 
 export const metadata = {
-  title: "HTTP 402 Payment Required: API and Agent Use Cases",
-  description: "HTTP 402 and L402 are paid-rail context. SatGate governs authority before execution and preserves Evidence Packs.",
+  title: "HTTP 402 Payment Required: Meaning and API Examples",
+  description: "Learn what HTTP 402 Payment Required means, why it is reserved in the HTTP standard, and how paid APIs and AI agents use it with L402.",
   alternates: { canonical: 'https://satgate.io/blog/http-402-payment-required-use-cases' },
   keywords: ['HTTP 402 Payment Required', 'HTTP 402 use cases', 'API payments', 'machine-to-machine payments', 'L402 protocol', 'AI agent payments', 'API monetization', 'pay-per-call API'],
   openGraph: {
-    title: 'HTTP 402 Payment Required: Meaning, Use Cases, and AI Agents',
-    description: 'HTTP 402 explained: reserved status code history, L402 paid API access, agent budget authority, and Evidence Pack proof.',
+    title: 'HTTP 402 Payment Required: Meaning and API Examples',
+    description: 'Learn what HTTP 402 Payment Required means, why it is reserved in the HTTP standard, and how paid APIs and AI agents use it with L402.',
     url: 'https://satgate.io/blog/http-402-payment-required-use-cases',
     type: 'article',
     publishedTime: '2026-04-02T00:00:00Z',
   },
   twitter: {
     card: 'summary_large_image',
-    title: 'HTTP 402 Payment Required: Meaning, Use Cases, and AI Agents',
-    description: 'HTTP 402 explained for reserved use, L402 paid APIs, agent budget authority, paid-rail governance, and Evidence Packs.',
+    title: 'HTTP 402 Payment Required: Meaning and API Examples',
+    description: 'Learn what HTTP 402 Payment Required means, why it is reserved in the HTTP standard, and how paid APIs and AI agents use it with L402.',
   },
 };
 

--- a/satgate-landing/app/sitemap.ts
+++ b/satgate-landing/app/sitemap.ts
@@ -119,7 +119,7 @@ const blogRoutes: SitemapEntry[] = [
   { path: '/blog/api-monetization-ai', lastModified: '2026-05-04', changeFrequency: 'monthly', priority: 0.8 },
   { path: '/blog/why-process-wont-scale-for-ai-agent-costs', lastModified: '2026-05-02', changeFrequency: 'monthly', priority: 0.8 },
   { path: '/blog/macaroon-tokens-vs-api-keys', lastModified: '2026-05-04', changeFrequency: 'monthly', priority: 0.8 },
-  { path: '/blog/http-402-payment-required-use-cases', lastModified: '2026-06-01', changeFrequency: 'monthly', priority: 0.8 },
+  { path: '/blog/http-402-payment-required-use-cases', lastModified: '2026-09-07', changeFrequency: 'monthly', priority: 0.8 },
   { path: '/blog/l402-protocol-explained', lastModified: '2026-05-04', changeFrequency: 'monthly', priority: 0.8 },
   { path: '/blog/zero-trust-for-ai-agents', lastModified: '2026-05-04', changeFrequency: 'monthly', priority: 0.8 },
   { path: '/blog/start-at-1-credit-economic-policy', lastModified: '2026-05-04', changeFrequency: 'monthly', priority: 0.8 },

--- a/satgate-landing/scripts/seo_machine.py
+++ b/satgate-landing/scripts/seo_machine.py
@@ -34,8 +34,8 @@ RECOMMENDED_META = {
    'title': 'LLM Cost Management: Control AI Spend Before It Happens',
    'description': 'A practical guide to LLM cost management using authority before execution, budget controls, and Evidence Pack receipts for AI agents.'},
  '/blog/http-402-payment-required-use-cases': {
-   'title': 'HTTP 402 Payment Required: API and Agent Use Cases',
-   'description': 'HTTP 402 and L402 are paid-rail context. SatGate governs authority before execution and preserves Evidence Packs.'},
+   'title': 'HTTP 402 Payment Required: Meaning and API Examples',
+   'description': 'Learn what HTTP 402 Payment Required means, why it is reserved in the HTTP standard, and how paid APIs and AI agents use it with L402.'},
  '/blog/macaroon-tokens-vs-api-keys': {
    'title': 'Macaroon Tokens vs API Keys for Agent Access',
    'description': 'Compare macaroon tokens and API keys for scoped authorization, delegated access, and safer AI agent permissions.'},


### PR DESCRIPTION
## Scope
Owner-approved HTTP 402 metadata only: title and description, matching social metadata and SEO recommendation, plus this URL sitemap lastmod. No body, robots, login, pricing, compare, or other page changes.

## Evidence
GSC finalized Aug 8–Sep 4: 904 page impressions, 4 clicks. Visible queries include HTTP 402, 402 payment required, and RFC reserved-for-future-use. Inspection confirms indexed; last crawl Aug 19. This is a snippet experiment, not a claim of improved CTR.

## Validation
python3 scripts/seo_machine.py --check: zero audit issue groups. git diff --check passed. Generated reports excluded. Await CI and preview build before owner-authorized merge; verify production metadata and sitemap afterward.