### PR TITLE
fix: require Go 1.26.6 security patch

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/satgate-io/satgate
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/gorilla/websocket v1.5.3


### PR DESCRIPTION
Owner-authorized isolated prerequisite for #167. Raise the Go minimum from 1.26.5 to 1.26.6 to resolve five reachable standard-library vulnerabilities reported by CI run 34131916955. CI and release already derive Go from go.mod. No Go source, dependency, security-check, or deployment configuration changes; no release tags or gateway deployment. Existing Docker builder follows the 1.26 patch line and go.mod enforces the minimum. Validation: diff check passed; full CI including race tests, integration, build, and govulncheck must pass before merge.